### PR TITLE
fix: Bind to 0.0.0.0 for Heroku

### DIFF
--- a/packages/vincent-service-dca/src/lib/server.ts
+++ b/packages/vincent-service-dca/src/lib/server.ts
@@ -75,7 +75,7 @@ export class Server {
 
     // Start server
     try {
-      await this.fastify.listen({ port: this.port });
+      await this.fastify.listen({ host: '0.0.0.0', port: this.port });
       this.fastify.log.info(`Server is running on port ${this.port}`);
     } catch (err) {
       this.fastify.log.error(err);


### PR DESCRIPTION
Had to bind to 0.0.0.0 explicitly in order for Heroku to bind correctly (it has multiple interfaces in the environment, so we can't use 127.0.0.1 there as it's too specific)