### PR TITLE
fix(sdk): package.json exports

### DIFF
--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,25 +1,12 @@
 {
   "name": "@lit-protocol/vincent-sdk",
-  "version": "0.1.0-8",
+  "version": "0.1.0-14",
   "description": "Vincent SDK for browser and backend",
   "author": "Lit Protocol",
   "license": "ISC",
   "type": "commonjs",
-  "main": "./dist/index.cjs",
-  "module": "./dist/index.mjs",
-  "types": "./dist/index.d.ts",
-  "browser": "./dist/vincent-sdk.umd.js",
-  "exports": {
-    ".": {
-      "types": "./dist/index.d.ts",
-      "import": "./dist/index.mjs",
-      "require": "./dist/index.cjs",
-      "default": "./dist/index.mjs"
-    }
-  },
-  "files": [
-    "dist"
-  ],
+  "main": "./dist/src/index.js",
+  "typings": "./dist/src/index.d.ts",
   "keywords": [
     "jwt",
     "authentication",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lit-protocol/vincent-sdk",
-  "version": "0.1.0-14",
+  "version": "0.1.1-1",
   "description": "Vincent SDK for browser and backend",
   "author": "Lit Protocol",
   "license": "ISC",
@@ -16,5 +16,8 @@
     "@noble/secp256k1": "^2.2.3",
     "did-jwt": "^8.0.8"
   },
-  "sideEffects": false
+  "sideEffects": false,
+  "files": [
+    "dist"
+  ]
 }


### PR DESCRIPTION
# WHAT

Another missing piece to remove from rollup to nx default settings from https://github.com/LIT-Protocol/Vincent/pull/20