### PR TITLE
[Example Only] Using Context Provider for contract APIs

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -676,61 +676,61 @@
 
     "@nrwl/workspace": ["@nrwl/workspace@19.8.4", "", { "dependencies": { "@nx/workspace": "19.8.4" } }, "sha512-ZdzVMuVDkD5nYRXkvBIZe6yUTcbllYanoIh38a7l3MfPqw+2cFY2Cr9uPNfH3LXpzZYgKcr4vffYWwLXeIwbjw=="],
 
-    "@nx/devkit": ["@nx/devkit@20.6.2", "", { "dependencies": { "ejs": "^3.1.7", "enquirer": "~2.3.6", "ignore": "^5.0.4", "minimatch": "9.0.3", "semver": "^7.5.3", "tmp": "~0.2.1", "tslib": "^2.3.0", "yargs-parser": "21.1.1" }, "peerDependencies": { "nx": ">= 19 <= 21" } }, "sha512-n36iECrNrrRugh7Jfpe9A3PS6vjil57iLyJ9fE8plylWSHPJmsXRp5K6HH7q3hBu6UG3my1HgdproJwvF34a5A=="],
+    "@nx/devkit": ["@nx/devkit@20.6.4", "", { "dependencies": { "ejs": "^3.1.7", "enquirer": "~2.3.6", "ignore": "^5.0.4", "minimatch": "9.0.3", "semver": "^7.5.3", "tmp": "~0.2.1", "tslib": "^2.3.0", "yargs-parser": "21.1.1" }, "peerDependencies": { "nx": ">= 19 <= 21" } }, "sha512-lyEidfyPhTuHt1X6EsskugBREazS5VOKSPIcreQ8Qt0MaULxn0bQ9o0N6C+BQaw5Zu6RTaMRMWKGW0I0Qni0UA=="],
 
     "@nx/eslint": ["@nx/eslint@19.8.4", "", { "dependencies": { "@nx/devkit": "19.8.4", "@nx/js": "19.8.4", "@nx/linter": "19.8.4", "semver": "^7.5.3", "tslib": "^2.3.0", "typescript": "~5.4.2" }, "peerDependencies": { "@zkochan/js-yaml": "0.0.7", "eslint": "^8.0.0 || ^9.0.0" }, "optionalPeers": ["@zkochan/js-yaml"] }, "sha512-gJGtYd9ThKSM1pbV/iG/PGwtVKg1PwjAly2AjgebYmAey+hgxzwgjQy84Lf+FdkKNUQZjB0sYaKCw26oKXXYaA=="],
 
-    "@nx/jest": ["@nx/jest@20.6.2", "", { "dependencies": { "@jest/reporters": "^29.4.1", "@jest/test-result": "^29.4.1", "@nx/devkit": "20.6.2", "@nx/js": "20.6.2", "@phenomnomnominal/tsquery": "~5.0.1", "identity-obj-proxy": "3.0.0", "jest-config": "^29.4.1", "jest-resolve": "^29.4.1", "jest-util": "^29.4.1", "minimatch": "9.0.3", "picocolors": "^1.1.0", "resolve.exports": "2.0.3", "semver": "^7.5.3", "tslib": "^2.3.0", "yargs-parser": "21.1.1" } }, "sha512-F+z6zY27KfBXSq2FaERwCw/yUpvXzXnsuDJ//Pn+jfdswEoMHRPOfYCzDxH2aoEv5S5S/WBXEfXfGXFiCbYPIA=="],
+    "@nx/jest": ["@nx/jest@20.6.4", "", { "dependencies": { "@jest/reporters": "^29.4.1", "@jest/test-result": "^29.4.1", "@nx/devkit": "20.6.4", "@nx/js": "20.6.4", "@phenomnomnominal/tsquery": "~5.0.1", "identity-obj-proxy": "3.0.0", "jest-config": "^29.4.1", "jest-resolve": "^29.4.1", "jest-util": "^29.4.1", "minimatch": "9.0.3", "picocolors": "^1.1.0", "resolve.exports": "2.0.3", "semver": "^7.5.3", "tslib": "^2.3.0", "yargs-parser": "21.1.1" } }, "sha512-/GRvhs4DMDUd347jM55Ft1k8VnO7bvjHjQ6MakQalVk60l2GbF172c1EaAWZPgQhpMY2NlYHVr0FnjpfUjQ7jw=="],
 
     "@nx/js": ["@nx/js@20.4.6", "", { "dependencies": { "@babel/core": "^7.23.2", "@babel/plugin-proposal-decorators": "^7.22.7", "@babel/plugin-transform-class-properties": "^7.22.5", "@babel/plugin-transform-runtime": "^7.23.2", "@babel/preset-env": "^7.23.2", "@babel/preset-typescript": "^7.22.5", "@babel/runtime": "^7.22.6", "@nx/devkit": "20.4.6", "@nx/workspace": "20.4.6", "@zkochan/js-yaml": "0.0.7", "babel-plugin-const-enum": "^1.0.1", "babel-plugin-macros": "^3.1.0", "babel-plugin-transform-typescript-metadata": "^0.3.1", "chalk": "^4.1.0", "columnify": "^1.6.0", "detect-port": "^1.5.1", "enquirer": "~2.3.6", "ignore": "^5.0.4", "js-tokens": "^4.0.0", "jsonc-parser": "3.2.0", "minimatch": "9.0.3", "npm-package-arg": "11.0.1", "npm-run-path": "^4.0.1", "ora": "5.3.0", "semver": "^7.5.3", "source-map-support": "0.5.19", "tinyglobby": "^0.2.10", "ts-node": "10.9.1", "tsconfig-paths": "^4.1.2", "tslib": "^2.3.0" }, "peerDependencies": { "verdaccio": "^5.0.4" }, "optionalPeers": ["verdaccio"] }, "sha512-wHO6tXJNVIW0Z9zKLL/g6qee7K92XJNS4D8irpJB9sOg25fqAzKjwgcK0bPtnRhYsIjLkjh0FsTKIcznxTGnkA=="],
 
     "@nx/linter": ["@nx/linter@19.8.4", "", { "dependencies": { "@nx/eslint": "19.8.4" } }, "sha512-aK6Bic/iup5nkZDFQgBgilgtqfjuy+dT0agnE6HEdXKOIR++LJXpka5nrJ9VNNglp22DrFtBDAH/hfRpIwm8uw=="],
 
-    "@nx/nx-darwin-arm64": ["@nx/nx-darwin-arm64@20.6.2", "", { "os": "darwin", "cpu": "arm64" }, "sha512-ap7DJPx7goc0iXOaVETOmeTrQdWQfVVhM8rrjteARycJf7+kirEYPg9V/3ePA/lome7PudLVe2qGlOCaQbXbHw=="],
+    "@nx/nx-darwin-arm64": ["@nx/nx-darwin-arm64@20.6.4", "", { "os": "darwin", "cpu": "arm64" }, "sha512-urdLFCY0c2X11FBuokSgCktKTma7kjZKWJi8mVO8PbTJh0h2Qtp4l9/px8tv9EHeHuusA18p2Wq3ZM6c95qcBg=="],
 
-    "@nx/nx-darwin-x64": ["@nx/nx-darwin-x64@20.6.2", "", { "os": "darwin", "cpu": "x64" }, "sha512-xtOsd5Wh5J3/wzw0BVMNbzSjVEfc1IkgB53ofoEqBd80/dqqI/WIh8qkt+5oQjJwE2CHaZ+4UkVlwSylaHguPg=="],
+    "@nx/nx-darwin-x64": ["@nx/nx-darwin-x64@20.6.4", "", { "os": "darwin", "cpu": "x64" }, "sha512-nNOXc9ccdsdmylC/InRud/F977ldat2zQuSWfhoI5+9exHIjMo0TNU8gZdT53t3S1OTQKOEbNXZcoEaURb6STA=="],
 
-    "@nx/nx-freebsd-x64": ["@nx/nx-freebsd-x64@20.6.2", "", { "os": "freebsd", "cpu": "x64" }, "sha512-tSHAcIoSR4grW2uJNE+8ipHkB1PyGikYHBoy6iGu4upbLH0d3RqZVpiXS5qCY030XWo16yo4gXyMMyp84cjdDw=="],
+    "@nx/nx-freebsd-x64": ["@nx/nx-freebsd-x64@20.6.4", "", { "os": "freebsd", "cpu": "x64" }, "sha512-jPGzjdB9biMu8N4038qBe0VBfrQ+HDjXfxBhETqrVIJPBfgdxN1I8CXIhCqMPG2CHBAM6kDQCU6QCTMWADJcEw=="],
 
-    "@nx/nx-linux-arm-gnueabihf": ["@nx/nx-linux-arm-gnueabihf@20.6.2", "", { "os": "linux", "cpu": "arm" }, "sha512-x4EK2ydPcKAu8/DlesoWx/hfnK/CYp6BEjss/lsffLLMXNmzhCMulxqYhjwE5m38hauHQFSVrkHq6gSZeGkB8Q=="],
+    "@nx/nx-linux-arm-gnueabihf": ["@nx/nx-linux-arm-gnueabihf@20.6.4", "", { "os": "linux", "cpu": "arm" }, "sha512-j4ekxzZPc5lj+VbaLBpKJl6w2VyFXycLrT65CWQYAj9yqV5dUuDtTR33r50ddLtqQt3PVV5hJAj8+g7sGPXUWQ=="],
 
-    "@nx/nx-linux-arm64-gnu": ["@nx/nx-linux-arm64-gnu@20.6.2", "", { "os": "linux", "cpu": "arm64" }, "sha512-OjJ6UA/varsVfhuKAV/GLVkPZk7CzRKeTW0xEB6Ik9XjllXruYmNvMhtBuD+MNWqkKld9aIjAQhnJ3YI8hjMRA=="],
+    "@nx/nx-linux-arm64-gnu": ["@nx/nx-linux-arm64-gnu@20.6.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-nYMB4Sh5yI7WbunizZ/mgR21MQgrs77frnAChs+6aPF5HA7N1VGEn3FMKX+ypd3DjTl14zuwB/R5ilwNgKzL+A=="],
 
-    "@nx/nx-linux-arm64-musl": ["@nx/nx-linux-arm64-musl@20.6.2", "", { "os": "linux", "cpu": "arm64" }, "sha512-+Vq8STTtJi+o2BR2JmPf0CvZEotkMHYOlgzcFox8HBIRel3vXW2rJpISSExEtocb/qDj5+pRoiRf07vGY7utjg=="],
+    "@nx/nx-linux-arm64-musl": ["@nx/nx-linux-arm64-musl@20.6.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-ukjB1pmBvtinT0zeYJ1lWi7BAw6cDnPQnfXMbyV+afYnNRcgdDFzQaUpo3UUeai69Fo3TTr0SWx6DjMVifxJZw=="],
 
-    "@nx/nx-linux-x64-gnu": ["@nx/nx-linux-x64-gnu@20.6.2", "", { "os": "linux", "cpu": "x64" }, "sha512-PzZvYuYhD5JBddVN5l/VukW2Ju/BubKqrH0P3ndgh1atH/eBljJegSHryAMHhR9wNygwLTvbpVQzU5jOBX2HDQ=="],
+    "@nx/nx-linux-x64-gnu": ["@nx/nx-linux-x64-gnu@20.6.4", "", { "os": "linux", "cpu": "x64" }, "sha512-+6DloqqB8ZzuZOY4A1PryuPD5hGoxbSafRN++sXUFvKx6mRYNyLGrn5APT3Kiq1qPBxkAxcsreexcu/wsTcrcw=="],
 
-    "@nx/nx-linux-x64-musl": ["@nx/nx-linux-x64-musl@20.6.2", "", { "os": "linux", "cpu": "x64" }, "sha512-CZoWa6CY7fDHah49cnLSThbkvLoXkYtQ/2uEV7AzYm7k47VAOK191ymuEIRQKl4gw60e0BHr7T9UFsJoiJNohA=="],
+    "@nx/nx-linux-x64-musl": ["@nx/nx-linux-x64-musl@20.6.4", "", { "os": "linux", "cpu": "x64" }, "sha512-+ZuF6dobfGo5EN55syuUEdbYs9qxbLmTkGPMq66X7dZ/jm7kKTsVzDYnf9v3ynQCOq4DMFtdACneL32Ks22+NQ=="],
 
-    "@nx/nx-win32-arm64-msvc": ["@nx/nx-win32-arm64-msvc@20.6.2", "", { "os": "win32", "cpu": "arm64" }, "sha512-D9HFGyzqy6JqqokxoHAzsGmR6D+Y962ldcUrfaQWvBQSDDJRaDG0iL2crnj85pOh7NDMGF8avv2gv39oUxATaw=="],
+    "@nx/nx-win32-arm64-msvc": ["@nx/nx-win32-arm64-msvc@20.6.4", "", { "os": "win32", "cpu": "arm64" }, "sha512-z+Y8iwEPZ8L8SISh/tcyqEtAy9Ju6aB5kLe8E/E1Wwzy5DU/jNvqM9Wq4HRPMY0r1S4jzwC6x7W3/fkxeFjZ7A=="],
 
-    "@nx/nx-win32-x64-msvc": ["@nx/nx-win32-x64-msvc@20.6.2", "", { "os": "win32", "cpu": "x64" }, "sha512-WlSGOpt6lUC9NujVAi3Ky3wp/Ys+qAbxmrU5YKhuXhjVsuqPKw97OwptjXAdEt71Wxvdp4Ghlw12Pn9YScN0kw=="],
+    "@nx/nx-win32-x64-msvc": ["@nx/nx-win32-x64-msvc@20.6.4", "", { "os": "win32", "cpu": "x64" }, "sha512-9LMVHZQqc1m2Fulvfz1nPZFHUKvFjmU7igxoWJXj/m+q+DyYWEbE710ARK9JtMibLg+xSRfERKOcIy11k6Ro1A=="],
 
     "@nx/workspace": ["@nx/workspace@20.4.6", "", { "dependencies": { "@nx/devkit": "20.4.6", "chalk": "^4.1.0", "enquirer": "~2.3.6", "nx": "20.4.6", "tslib": "^2.3.0", "yargs-parser": "21.1.1" } }, "sha512-1rRRN4MJjghDvZSfCNpTn0IDkNJrU6W3VLn8cGjmJXJj8OXxbi3bYc1Ykk+zC99UmSRQ/8+SLorkX+FgTC1ODQ=="],
 
     "@openagenda/verror": ["@openagenda/verror@3.1.4", "", { "dependencies": { "assertion-error": "^1.1.0", "depd": "^2.0.0", "inherits": "^2.0.4", "sprintf-js": "^1.1.2" } }, "sha512-+V7QuD6v5sMWez7cu+5DXoXMim+iQssOcspoNgbWDW8sEyC54Mdo5VuIkcIjqhPmQYOzBWo5qlbzNGEpD6PzMA=="],
 
-    "@oven/bun-darwin-aarch64": ["@oven/bun-darwin-aarch64@1.2.5", "", { "os": "darwin", "cpu": "arm64" }, "sha512-ggZfdpgUJ/OiWrfcfTgHeSTHcec5HAjkGrZHL9FJ/R60sydRKPYHgAgexdIoJAGfsCVAL+x7y8NSTRIAX8J4Ng=="],
+    "@oven/bun-darwin-aarch64": ["@oven/bun-darwin-aarch64@1.2.6", "", { "os": "darwin", "cpu": "arm64" }, "sha512-nhBuCgiYO+JpWwodRh4QpAYSLG7ZvpETiz3l5AqQMtBeZnUXzfnpa03cNr3eOBn3sBF9ep85KzLtN8MlE3TARw=="],
 
-    "@oven/bun-darwin-x64": ["@oven/bun-darwin-x64@1.2.5", "", { "os": "darwin", "cpu": "x64" }, "sha512-4zqyQLJB33s99KcTxH6yQqH5EYBmF1qofQTtLsToIFbIZN1NqSp/aegYiGmxO5Kj/BuWsy8Wf8MS6vX2O0o2Lw=="],
+    "@oven/bun-darwin-x64": ["@oven/bun-darwin-x64@1.2.6", "", { "os": "darwin", "cpu": "x64" }, "sha512-+O7oTuH+iFdvH80q5Trrj6qqpzc12F1VTgJTicXvYDT0gvMOHHSkkuLXBDlaxVhYZTe4UX453nX2KlxE+K8dKQ=="],
 
-    "@oven/bun-darwin-x64-baseline": ["@oven/bun-darwin-x64-baseline@1.2.5", "", { "os": "darwin", "cpu": "x64" }, "sha512-3W1RO3/D6Z1S79J47F/DLzmK+dgkYq5hS1ShOCSBAYTTA2b1ZuymaN8avGzSb9ed5W0QfxtyeAksfEY2xUBOqA=="],
+    "@oven/bun-darwin-x64-baseline": ["@oven/bun-darwin-x64-baseline@1.2.6", "", { "os": "darwin", "cpu": "x64" }, "sha512-t2FSKWHmgoqbAw/d+wy8eiSYuvTiaq9QhtYQepwcAlNRuGJ05f5Ew3MLpPqczolovAOAy3I+QXo7r9zPQFRM5w=="],
 
-    "@oven/bun-linux-aarch64": ["@oven/bun-linux-aarch64@1.2.5", "", { "os": "linux", "cpu": "arm64" }, "sha512-NQFtAVyQyJhLYrhFVxKdh6cqrDNc60pBnBGLQSO8PU+oyFyiJ3e3gGXjLzMbxd6cJxNIK5FZ0JIq96WljKAhlg=="],
+    "@oven/bun-linux-aarch64": ["@oven/bun-linux-aarch64@1.2.6", "", { "os": "linux", "cpu": "arm64" }, "sha512-PcvQn3WFNr496rg/DnIMlw1v/4LkiPDm7UMqxRmP+dMHHH/zs4Xh/iOSiELJ0kxvBP5obhiaewi6PHDYI0vROA=="],
 
-    "@oven/bun-linux-aarch64-musl": ["@oven/bun-linux-aarch64-musl@1.2.5", "", { "os": "linux", "cpu": "none" }, "sha512-URlISBOE2HQi8qdru691OYywJRwChxMfXFbk26tCgdZ01LgGAKsIjAYylefuSsPuA697imDN3Pel3D7rveusmw=="],
+    "@oven/bun-linux-aarch64-musl": ["@oven/bun-linux-aarch64-musl@1.2.6", "", { "os": "linux", "cpu": "none" }, "sha512-731vpVFMVo3EKxv8duT6lywU14nLVKKqCmdTL8LxaogbHiZSjXVuMdX7QUdABsXBw1ThzzT8bLJRagIQOB8U4Q=="],
 
-    "@oven/bun-linux-x64": ["@oven/bun-linux-x64@1.2.5", "", { "os": "linux", "cpu": "x64" }, "sha512-pa3kQ4cXNV0jk5aM8+Hdmxr+b4QoPVgeAIA454SN5l3hMGfNsHjczKpsz0ksInZ8506iMMTCPEBXpyQJcSme+Q=="],
+    "@oven/bun-linux-x64": ["@oven/bun-linux-x64@1.2.6", "", { "os": "linux", "cpu": "x64" }, "sha512-s2r5bBzLVWE35AdS9P7j4xH4aOnaZ5/wPY+eWtsrcpWDA8SAQPzVifLk1A/fisNTWiPHg4GqhlT5ID/btwvEvg=="],
 
-    "@oven/bun-linux-x64-baseline": ["@oven/bun-linux-x64-baseline@1.2.5", "", { "os": "linux", "cpu": "x64" }, "sha512-fCm/qp7e3VYlaoRs6NIEsKubPqyxjzLv8/qZkxeLLOlPd7CS8L26UY4KPOSjA+wrhPT+Nxsyvl/EEJq2R/iauA=="],
+    "@oven/bun-linux-x64-baseline": ["@oven/bun-linux-x64-baseline@1.2.6", "", { "os": "linux", "cpu": "x64" }, "sha512-l9CMf4Z+GHP6WK00sl1+KyqukIEz1dYBhSlZgympKUSfg9s0GACsFaLb+ED2Uo4rP5wU51Tin7iFOMeE1FSEGg=="],
 
-    "@oven/bun-linux-x64-musl": ["@oven/bun-linux-x64-musl@1.2.5", "", { "os": "linux", "cpu": "x64" }, "sha512-DuU2kQnY48g9tNWjFrZqyG+U2emCBwlhOPxbuY/TMVVNSTMAcQbE/bb3s2pZdhZH5ssjc5SH/ZyWU1TePcYB2A=="],
+    "@oven/bun-linux-x64-musl": ["@oven/bun-linux-x64-musl@1.2.6", "", { "os": "linux", "cpu": "x64" }, "sha512-NIamulIWb11m/tqM/W4gYaA8J1PTWASbfawbeOG95Y5Qp3VQS9sTW6LX8kLoU3nADRLoA0Ic/mxLu1VVlnFLOA=="],
 
-    "@oven/bun-linux-x64-musl-baseline": ["@oven/bun-linux-x64-musl-baseline@1.2.5", "", { "os": "linux", "cpu": "x64" }, "sha512-H7tuJz7mZvOTPo4yLbIXIxkiDGWSGd2DbwGl4zNol/FURqGsKQVqpomv86yl9KCXsUUOm5FX2i5Ed+ro8N//Cg=="],
+    "@oven/bun-linux-x64-musl-baseline": ["@oven/bun-linux-x64-musl-baseline@1.2.6", "", { "os": "linux", "cpu": "x64" }, "sha512-zaxVTK6yuqhTFBoaZrjGZWARrKopcEVw1yauvY8qtGczs4Zk4lPeRZ1hEsrgpTXD92w1GFHxvRw76QKafUvHvg=="],
 
-    "@oven/bun-windows-x64": ["@oven/bun-windows-x64@1.2.5", "", { "os": "win32", "cpu": "x64" }, "sha512-oNDdPmzsCyvCATiYgkKWgxOeEx2F7m/i2MGUba+YJAeVXJsJg9iPJrLVBtETvKoSAgkXViwoUEw2U25jRYsp4g=="],
+    "@oven/bun-windows-x64": ["@oven/bun-windows-x64@1.2.6", "", { "os": "win32", "cpu": "x64" }, "sha512-4QUID8i+0yrpkqi81axd42/fQAA5BpZ/9JgUg5IZwrULHyLAkKa7TUiXKJkRDbLRe9FtDyux0pubzCJQZ6fYuQ=="],
 
-    "@oven/bun-windows-x64-baseline": ["@oven/bun-windows-x64-baseline@1.2.5", "", { "os": "win32", "cpu": "x64" }, "sha512-j5FxI8FeKfWI6rEXA+1O3ASBMTp5CFcZ7MR+/aCpiBKrDse32wLaZMVGnvqQqs4y0YHUvR8b7eXHHTboezjL1w=="],
+    "@oven/bun-windows-x64-baseline": ["@oven/bun-windows-x64-baseline@1.2.6", "", { "os": "win32", "cpu": "x64" }, "sha512-wFlZzGcBs6laNc0fBi2lGKta5+2JVlaqzkX4jLR9/59bR8dKRqUk+jy0vsoQTtSMRPdxNpUThnjpIG0U7u2zWA=="],
 
     "@paulmillr/qr": ["@paulmillr/qr@0.2.1", "", {}, "sha512-IHnV6A+zxU7XwmKFinmYjUcwlyK9+xkG3/s9KcQhI9BjQKycrJ1JRO+FbNYPwZiPKW3je/DR0k7w8/gLa5eaxQ=="],
 
@@ -940,7 +940,7 @@
 
     "@swc/helpers": ["@swc/helpers@0.5.15", "", { "dependencies": { "tslib": "^2.8.0" } }, "sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g=="],
 
-    "@swc/types": ["@swc/types@0.1.19", "", { "dependencies": { "@swc/counter": "^0.1.3" } }, "sha512-WkAZaAfj44kh/UFdAQcrMP1I0nwRqpt27u+08LMBYMqmQfwwMofYoMh/48NGkMMRfC4ynpfwRbJuu8ErfNloeA=="],
+    "@swc/types": ["@swc/types@0.1.20", "", { "dependencies": { "@swc/counter": "^0.1.3" } }, "sha512-/rlIpxwKrhz4BIplXf6nsEHtqlhzuNN34/k3kMAXH4/lvVoA3cdq+60aqVNnyvw2uITEaCi0WV3pxBe4dQqoXQ=="],
 
     "@tanstack/query-core": ["@tanstack/query-core@5.69.0", "", {}, "sha512-Kn410jq6vs1P8Nm+ZsRj9H+U3C0kjuEkYLxbiCyn3MDEiYor1j2DGVULqAz62SLZtUZ/e9Xt6xMXiJ3NJ65WyQ=="],
 
@@ -1272,7 +1272,7 @@
 
     "bufferutil": ["bufferutil@4.0.9", "", { "dependencies": { "node-gyp-build": "^4.3.0" } }, "sha512-WDtdLmJvAuNNPzByAYpRo2rF1Mmradw6gvWsQKf63476DDXmomT9zUiGypLcG4ibIM67vhAj8jJRdbmEws2Aqw=="],
 
-    "bun": ["bun@1.2.5", "", { "optionalDependencies": { "@oven/bun-darwin-aarch64": "1.2.5", "@oven/bun-darwin-x64": "1.2.5", "@oven/bun-darwin-x64-baseline": "1.2.5", "@oven/bun-linux-aarch64": "1.2.5", "@oven/bun-linux-aarch64-musl": "1.2.5", "@oven/bun-linux-x64": "1.2.5", "@oven/bun-linux-x64-baseline": "1.2.5", "@oven/bun-linux-x64-musl": "1.2.5", "@oven/bun-linux-x64-musl-baseline": "1.2.5", "@oven/bun-windows-x64": "1.2.5", "@oven/bun-windows-x64-baseline": "1.2.5" }, "os": [ "linux", "win32", "darwin", ], "cpu": [ "x64", "arm64", ], "bin": { "bun": "bin/bun.exe", "bunx": "bin/bun.exe" } }, "sha512-fbQLt+DPiGUrPKdmsHRRT7cQAlfjdxPVFvLZrsUPmKiTdv+pU50ypdx9yRJluknSbyaZchFVV7Lx2KXikXKX2Q=="],
+    "bun": ["bun@1.2.6", "", { "optionalDependencies": { "@oven/bun-darwin-aarch64": "1.2.6", "@oven/bun-darwin-x64": "1.2.6", "@oven/bun-darwin-x64-baseline": "1.2.6", "@oven/bun-linux-aarch64": "1.2.6", "@oven/bun-linux-aarch64-musl": "1.2.6", "@oven/bun-linux-x64": "1.2.6", "@oven/bun-linux-x64-baseline": "1.2.6", "@oven/bun-linux-x64-musl": "1.2.6", "@oven/bun-linux-x64-musl-baseline": "1.2.6", "@oven/bun-windows-x64": "1.2.6", "@oven/bun-windows-x64-baseline": "1.2.6" }, "os": [ "linux", "win32", "darwin", ], "cpu": [ "x64", "arm64", ], "bin": { "bun": "bin/bun.exe", "bunx": "bin/bun.exe" } }, "sha512-v0G1dOS5ALc4laomafP2h/PjO9qLF7mwzXySo3VJFiX2Ty70WmPjuGRNGdk65Djk0u3ahpFTtCrzsgIj/NDOiw=="],
 
     "busboy": ["busboy@1.6.0", "", { "dependencies": { "streamsearch": "^1.1.0" } }, "sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA=="],
 
@@ -1534,7 +1534,7 @@
 
     "eslint-plugin-jsx-a11y": ["eslint-plugin-jsx-a11y@6.10.2", "", { "dependencies": { "aria-query": "^5.3.2", "array-includes": "^3.1.8", "array.prototype.flatmap": "^1.3.2", "ast-types-flow": "^0.0.8", "axe-core": "^4.10.0", "axobject-query": "^4.1.0", "damerau-levenshtein": "^1.0.8", "emoji-regex": "^9.2.2", "hasown": "^2.0.2", "jsx-ast-utils": "^3.3.5", "language-tags": "^1.0.9", "minimatch": "^3.1.2", "object.fromentries": "^2.0.8", "safe-regex-test": "^1.0.3", "string.prototype.includes": "^2.0.1" }, "peerDependencies": { "eslint": "^3 || ^4 || ^5 || ^6 || ^7 || ^8 || ^9" } }, "sha512-scB3nz4WmG75pV8+3eRUQOHZlNSUhFNq37xnpgRkCCELU3XMvXAxLk1eqWWyE22Ki4Q01Fnsw9BA3cJHDPgn2Q=="],
 
-    "eslint-plugin-prettier": ["eslint-plugin-prettier@5.2.4", "", { "dependencies": { "prettier-linter-helpers": "^1.0.0", "synckit": "^0.10.2" }, "peerDependencies": { "@types/eslint": ">=8.0.0", "eslint": ">=8.0.0", "eslint-config-prettier": "*", "prettier": ">=3.0.0" }, "optionalPeers": ["@types/eslint", "eslint-config-prettier"] }, "sha512-SFtuYmnhwYCtuCDTKPoK+CEzCnEgKTU2qTLwoCxvrC0MFBTIXo1i6hDYOI4cwHaE5GZtlWmTN3YfucYi7KJwPw=="],
+    "eslint-plugin-prettier": ["eslint-plugin-prettier@5.2.5", "", { "dependencies": { "prettier-linter-helpers": "^1.0.0", "synckit": "^0.10.2" }, "peerDependencies": { "@types/eslint": ">=8.0.0", "eslint": ">=8.0.0", "eslint-config-prettier": ">= 7.0.0 <10.0.0 || >=10.1.0", "prettier": ">=3.0.0" }, "optionalPeers": ["@types/eslint", "eslint-config-prettier"] }, "sha512-IKKP8R87pJyMl7WWamLgPkloB16dagPIdd2FjBDbyRYPKo93wS/NbCOPh6gH+ieNLC+XZrhJt/kWj0PS/DFdmg=="],
 
     "eslint-plugin-react": ["eslint-plugin-react@7.37.4", "", { "dependencies": { "array-includes": "^3.1.8", "array.prototype.findlast": "^1.2.5", "array.prototype.flatmap": "^1.3.3", "array.prototype.tosorted": "^1.1.4", "doctrine": "^2.1.0", "es-iterator-helpers": "^1.2.1", "estraverse": "^5.3.0", "hasown": "^2.0.2", "jsx-ast-utils": "^2.4.1 || ^3.0.0", "minimatch": "^3.1.2", "object.entries": "^1.1.8", "object.fromentries": "^2.0.8", "object.values": "^1.2.1", "prop-types": "^15.8.1", "resolve": "^2.0.0-next.5", "semver": "^6.3.1", "string.prototype.matchall": "^4.0.12", "string.prototype.repeat": "^1.0.0" }, "peerDependencies": { "eslint": "^3 || ^4 || ^5 || ^6 || ^7 || ^8 || ^9.7" } }, "sha512-BGP0jRmfYyvOyvMoRX/uoUeW+GqNj9y16bPQzqAHf3AYII/tDs+jMN0dBVkl88/OZwNGwrVFxE7riHsXVfy/LQ=="],
 
@@ -2130,7 +2130,7 @@
 
     "npm-run-path": ["npm-run-path@4.0.1", "", { "dependencies": { "path-key": "^3.0.0" } }, "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw=="],
 
-    "nx": ["nx@20.6.2", "", { "dependencies": { "@napi-rs/wasm-runtime": "0.2.4", "@yarnpkg/lockfile": "^1.1.0", "@yarnpkg/parsers": "3.0.2", "@zkochan/js-yaml": "0.0.7", "axios": "^1.8.3", "chalk": "^4.1.0", "cli-cursor": "3.1.0", "cli-spinners": "2.6.1", "cliui": "^8.0.1", "dotenv": "~16.4.5", "dotenv-expand": "~11.0.6", "enquirer": "~2.3.6", "figures": "3.2.0", "flat": "^5.0.2", "front-matter": "^4.0.2", "ignore": "^5.0.4", "jest-diff": "^29.4.1", "jsonc-parser": "3.2.0", "lines-and-columns": "2.0.3", "minimatch": "9.0.3", "node-machine-id": "1.1.12", "npm-run-path": "^4.0.1", "open": "^8.4.0", "ora": "5.3.0", "resolve.exports": "2.0.3", "semver": "^7.5.3", "string-width": "^4.2.3", "tar-stream": "~2.2.0", "tmp": "~0.2.1", "tsconfig-paths": "^4.1.2", "tslib": "^2.3.0", "yaml": "^2.6.0", "yargs": "^17.6.2", "yargs-parser": "21.1.1" }, "optionalDependencies": { "@nx/nx-darwin-arm64": "20.6.2", "@nx/nx-darwin-x64": "20.6.2", "@nx/nx-freebsd-x64": "20.6.2", "@nx/nx-linux-arm-gnueabihf": "20.6.2", "@nx/nx-linux-arm64-gnu": "20.6.2", "@nx/nx-linux-arm64-musl": "20.6.2", "@nx/nx-linux-x64-gnu": "20.6.2", "@nx/nx-linux-x64-musl": "20.6.2", "@nx/nx-win32-arm64-msvc": "20.6.2", "@nx/nx-win32-x64-msvc": "20.6.2" }, "peerDependencies": { "@swc-node/register": "^1.8.0", "@swc/core": "^1.3.85" }, "optionalPeers": ["@swc-node/register", "@swc/core"], "bin": { "nx": "bin/nx.js", "nx-cloud": "bin/nx-cloud.js" } }, "sha512-FvdDpBRgTdlTO0ixFjtZnMsp25MMBUzHcylVphekVY4vdFOnJ54f9Y64oncqcj70gyKX6Qn9g9+hEzV4bomYeQ=="],
+    "nx": ["nx@20.6.4", "", { "dependencies": { "@napi-rs/wasm-runtime": "0.2.4", "@yarnpkg/lockfile": "^1.1.0", "@yarnpkg/parsers": "3.0.2", "@zkochan/js-yaml": "0.0.7", "axios": "^1.8.3", "chalk": "^4.1.0", "cli-cursor": "3.1.0", "cli-spinners": "2.6.1", "cliui": "^8.0.1", "dotenv": "~16.4.5", "dotenv-expand": "~11.0.6", "enquirer": "~2.3.6", "figures": "3.2.0", "flat": "^5.0.2", "front-matter": "^4.0.2", "ignore": "^5.0.4", "jest-diff": "^29.4.1", "jsonc-parser": "3.2.0", "lines-and-columns": "2.0.3", "minimatch": "9.0.3", "node-machine-id": "1.1.12", "npm-run-path": "^4.0.1", "open": "^8.4.0", "ora": "5.3.0", "resolve.exports": "2.0.3", "semver": "^7.5.3", "string-width": "^4.2.3", "tar-stream": "~2.2.0", "tmp": "~0.2.1", "tsconfig-paths": "^4.1.2", "tslib": "^2.3.0", "yaml": "^2.6.0", "yargs": "^17.6.2", "yargs-parser": "21.1.1" }, "optionalDependencies": { "@nx/nx-darwin-arm64": "20.6.4", "@nx/nx-darwin-x64": "20.6.4", "@nx/nx-freebsd-x64": "20.6.4", "@nx/nx-linux-arm-gnueabihf": "20.6.4", "@nx/nx-linux-arm64-gnu": "20.6.4", "@nx/nx-linux-arm64-musl": "20.6.4", "@nx/nx-linux-x64-gnu": "20.6.4", "@nx/nx-linux-x64-musl": "20.6.4", "@nx/nx-win32-arm64-msvc": "20.6.4", "@nx/nx-win32-x64-msvc": "20.6.4" }, "peerDependencies": { "@swc-node/register": "^1.8.0", "@swc/core": "^1.3.85" }, "optionalPeers": ["@swc-node/register", "@swc/core"], "bin": { "nx": "bin/nx.js", "nx-cloud": "bin/nx-cloud.js" } }, "sha512-mkRgGvPSZpezn65upZ9psuyywr03XTirHDsqlnRYp90qqDQqMH/I1FsHqqUG5qdy4gbm5qFkZ5Vvc8Z3RkN/jg=="],
 
     "obj-multiplex": ["obj-multiplex@1.0.0", "", { "dependencies": { "end-of-stream": "^1.4.0", "once": "^1.4.0", "readable-stream": "^2.3.3" } }, "sha512-0GNJAOsHoBHeNTvl5Vt6IWnpUEcc3uSRxzBri7EDyIcMgYvnY2JL2qdeV5zTMjWQX5OHcD5amcW2HFfDh0gjIA=="],
 
@@ -2630,7 +2630,7 @@
 
     "varint": ["varint@6.0.0", "", {}, "sha512-cXEIW6cfr15lFv563k4GuVuW/fiwjknytD37jIOLSdSWuOI6WnO/oKwmP2FQTU2l01LP8/M5TSAJpzUaGe3uWg=="],
 
-    "viem": ["viem@2.23.14", "", { "dependencies": { "@noble/curves": "1.8.1", "@noble/hashes": "1.7.1", "@scure/bip32": "1.6.2", "@scure/bip39": "1.5.4", "abitype": "1.0.8", "isows": "1.0.6", "ox": "0.6.9", "ws": "8.18.1" }, "peerDependencies": { "typescript": ">=5.0.4" }, "optionalPeers": ["typescript"] }, "sha512-ol8UKYT418u+7Lg83Ut7WJe7iOn1daGAqaofCoPe5z7eGR/XCu3ydja7eL7Z5ffwp6r0RoXeWkpun78UYhKygA=="],
+    "viem": ["viem@2.23.15", "", { "dependencies": { "@noble/curves": "1.8.1", "@noble/hashes": "1.7.1", "@scure/bip32": "1.6.2", "@scure/bip39": "1.5.4", "abitype": "1.0.8", "isows": "1.0.6", "ox": "0.6.9", "ws": "8.18.1" }, "peerDependencies": { "typescript": ">=5.0.4" }, "optionalPeers": ["typescript"] }, "sha512-2t9lROkSzj/ciEZ08NqAHZ6c+J1wKLwJ4qpUxcHdVHcLBt6GfO9+ycuZycTT05ckfJ6TbwnMXMa3bMonvhtUMw=="],
 
     "wagmi": ["wagmi@2.14.15", "", { "dependencies": { "@wagmi/connectors": "5.7.11", "@wagmi/core": "2.16.7", "use-sync-external-store": "1.4.0" }, "peerDependencies": { "@tanstack/react-query": ">=5.0.0", "react": ">=18", "typescript": ">=5.0.4", "viem": "2.x" }, "optionalPeers": ["typescript"] }, "sha512-sRa7FsEmgph1KsIK93wCS2MhZgUae18jI/+Ger+INSxytJbhzNkukpHxWlNfV/Skl8zxDAQfxucotZLi8UadZQ=="],
 
@@ -2940,7 +2940,7 @@
 
     "@nx/eslint/typescript": ["typescript@5.4.5", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-vcI4UpRgg81oIRUFwR0WSIHKt11nJ7SAVlYNIu+QpqeyXP+gpQJy/Z4+F0aGxSE4MqwjyXvW/TzgkLAx2AGHwQ=="],
 
-    "@nx/jest/@nx/js": ["@nx/js@20.6.2", "", { "dependencies": { "@babel/core": "^7.23.2", "@babel/plugin-proposal-decorators": "^7.22.7", "@babel/plugin-transform-class-properties": "^7.22.5", "@babel/plugin-transform-runtime": "^7.23.2", "@babel/preset-env": "^7.23.2", "@babel/preset-typescript": "^7.22.5", "@babel/runtime": "^7.22.6", "@nx/devkit": "20.6.2", "@nx/workspace": "20.6.2", "@zkochan/js-yaml": "0.0.7", "babel-plugin-const-enum": "^1.0.1", "babel-plugin-macros": "^3.1.0", "babel-plugin-transform-typescript-metadata": "^0.3.1", "chalk": "^4.1.0", "columnify": "^1.6.0", "detect-port": "^1.5.1", "enquirer": "~2.3.6", "ignore": "^5.0.4", "js-tokens": "^4.0.0", "jsonc-parser": "3.2.0", "npm-package-arg": "11.0.1", "npm-run-path": "^4.0.1", "ora": "5.3.0", "picocolors": "^1.1.0", "picomatch": "4.0.2", "semver": "^7.5.3", "source-map-support": "0.5.19", "tinyglobby": "^0.2.12", "ts-node": "10.9.1", "tsconfig-paths": "^4.1.2", "tslib": "^2.3.0" }, "peerDependencies": { "verdaccio": "^6.0.5" }, "optionalPeers": ["verdaccio"] }, "sha512-h6r1bPHL5u6IZHKYm+fdAgup5G5YOWjtbTddCP5TVWnKU7ume/5P8cpYch4jvc4T7+/PKJQxikdUz7isDztyJg=="],
+    "@nx/jest/@nx/js": ["@nx/js@20.6.4", "", { "dependencies": { "@babel/core": "^7.23.2", "@babel/plugin-proposal-decorators": "^7.22.7", "@babel/plugin-transform-class-properties": "^7.22.5", "@babel/plugin-transform-runtime": "^7.23.2", "@babel/preset-env": "^7.23.2", "@babel/preset-typescript": "^7.22.5", "@babel/runtime": "^7.22.6", "@nx/devkit": "20.6.4", "@nx/workspace": "20.6.4", "@zkochan/js-yaml": "0.0.7", "babel-plugin-const-enum": "^1.0.1", "babel-plugin-macros": "^3.1.0", "babel-plugin-transform-typescript-metadata": "^0.3.1", "chalk": "^4.1.0", "columnify": "^1.6.0", "detect-port": "^1.5.1", "enquirer": "~2.3.6", "ignore": "^5.0.4", "js-tokens": "^4.0.0", "jsonc-parser": "3.2.0", "npm-package-arg": "11.0.1", "npm-run-path": "^4.0.1", "ora": "5.3.0", "picocolors": "^1.1.0", "picomatch": "4.0.2", "semver": "^7.5.3", "source-map-support": "0.5.19", "tinyglobby": "^0.2.12", "tslib": "^2.3.0" }, "peerDependencies": { "verdaccio": "^6.0.5" }, "optionalPeers": ["verdaccio"] }, "sha512-GHYpqLi9pjdPrMZqgYjDat+WhL9k350/+g+hQiAoueEwQ1PbG3d/NwcA2dffX47VLXF1BhoQMtn0C3LPPx3Z/g=="],
 
     "@nx/jest/minimatch": ["minimatch@9.0.3", "", { "dependencies": { "brace-expansion": "^2.0.1" } }, "sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg=="],
 
@@ -2972,6 +2972,8 @@
 
     "@walletconnect/core/@walletconnect/jsonrpc-types": ["@walletconnect/jsonrpc-types@1.0.3", "", { "dependencies": { "keyvaluestorage-interface": "^1.0.0", "tslib": "1.14.1" } }, "sha512-iIQ8hboBl3o5ufmJ8cuduGad0CQm3ZlsHtujv9Eu16xq89q+BG7Nh5VLxxUgmtpnrePgFkTwXirCTkwJH1v+Yw=="],
 
+    "@walletconnect/core/uint8arrays": ["uint8arrays@3.1.0", "", { "dependencies": { "multiformats": "^9.4.2" } }, "sha512-ei5rfKtoRO8OyOIor2Rz5fhzjThwIHJZ3uyDPnDHTXbP0aMQ1RN/6AI5B5d9dBxJOU+BvOAk7ZQ1xphsX8Lrog=="],
+
     "@walletconnect/environment/tslib": ["tslib@1.14.1", "", {}, "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="],
 
     "@walletconnect/events/tslib": ["tslib@1.14.1", "", {}, "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="],
@@ -3001,6 +3003,8 @@
     "@walletconnect/types/@walletconnect/jsonrpc-types": ["@walletconnect/jsonrpc-types@1.0.3", "", { "dependencies": { "keyvaluestorage-interface": "^1.0.0", "tslib": "1.14.1" } }, "sha512-iIQ8hboBl3o5ufmJ8cuduGad0CQm3ZlsHtujv9Eu16xq89q+BG7Nh5VLxxUgmtpnrePgFkTwXirCTkwJH1v+Yw=="],
 
     "@walletconnect/universal-provider/@walletconnect/jsonrpc-provider": ["@walletconnect/jsonrpc-provider@1.0.13", "", { "dependencies": { "@walletconnect/jsonrpc-utils": "^1.0.8", "@walletconnect/safe-json": "^1.0.2", "tslib": "1.14.1" } }, "sha512-K73EpThqHnSR26gOyNEL+acEex3P7VWZe6KE12ZwKzAt2H4e5gldZHbjsu2QR9cLeJ8AXuO7kEMOIcRv1QEc7g=="],
+
+    "@walletconnect/utils/uint8arrays": ["uint8arrays@3.1.0", "", { "dependencies": { "multiformats": "^9.4.2" } }, "sha512-ei5rfKtoRO8OyOIor2Rz5fhzjThwIHJZ3uyDPnDHTXbP0aMQ1RN/6AI5B5d9dBxJOU+BvOAk7ZQ1xphsX8Lrog=="],
 
     "@walletconnect/window-getters/tslib": ["tslib@1.14.1", "", {}, "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="],
 
@@ -3432,7 +3436,7 @@
 
     "@nx/eslint/@nx/js/minimatch": ["minimatch@9.0.3", "", { "dependencies": { "brace-expansion": "^2.0.1" } }, "sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg=="],
 
-    "@nx/jest/@nx/js/@nx/workspace": ["@nx/workspace@20.6.2", "", { "dependencies": { "@nx/devkit": "20.6.2", "@zkochan/js-yaml": "0.0.7", "chalk": "^4.1.0", "enquirer": "~2.3.6", "nx": "20.6.2", "picomatch": "4.0.2", "tslib": "^2.3.0", "yargs-parser": "21.1.1" } }, "sha512-sZc1UnmuiMJWCa23ycYX4h5NaxRTj+q8iqIOd5zjwLQ/LxY4gkaUpWJJIG8zwl4EF+PIjHPtbnIj78G4ZM2FJw=="],
+    "@nx/jest/@nx/js/@nx/workspace": ["@nx/workspace@20.6.4", "", { "dependencies": { "@nx/devkit": "20.6.4", "@zkochan/js-yaml": "0.0.7", "chalk": "^4.1.0", "enquirer": "~2.3.6", "nx": "20.6.4", "picomatch": "4.0.2", "tslib": "^2.3.0", "yargs-parser": "21.1.1" } }, "sha512-HZK0XTJ1flx9NpAFW8ZVeMRrsAEOc4Bj5ZtBR1aVUSC/IzAGQH4dkVZMXX1oG3vBzhuz+4Ery2mfst1YsJNuxQ=="],
 
     "@nx/jest/minimatch/brace-expansion": ["brace-expansion@2.0.1", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA=="],
 

--- a/packages/dashboard/app/layout.tsx
+++ b/packages/dashboard/app/layout.tsx
@@ -12,6 +12,7 @@ import '@rainbow-me/rainbowkit/styles.css';
 import { yellowstone } from './config/chains';
 import { usePathname } from 'next/navigation';
 import { ErrorPopupProvider } from '@/providers/error-popup';
+import { LitContextProvider } from '@/providers/LitContext';
 
 const wagmiConfig = createConfig({
   chains: [yellowstone],
@@ -33,30 +34,34 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   const pathname = usePathname();
-  
+
   // Don't apply this layout to consent pages - let them use their own layout
   if (pathname?.startsWith('/consent')) {
     return <>{children}</>;
   }
-  
+
   return (
     <WagmiProvider config={wagmiConfig}>
       <QueryClientProvider client={queryClient}>
-          <html>
-            <body>
-              <RainbowKitProvider
-                theme={darkTheme()}
-                initialChain={yellowstone}
-                appInfo={demoAppInfo}
-              >
+        <html>
+          <body>
+            <RainbowKitProvider
+              theme={darkTheme()}
+              initialChain={yellowstone}
+              appInfo={demoAppInfo}
+            >
+              <LitContextProvider>
                 <ErrorPopupProvider>
                   <Header />
-                  <main className="max-w-screen-xl mx-auto p-6">{children}</main>
+                  <main className="max-w-screen-xl mx-auto p-6">
+                    {children}
+                  </main>
                 </ErrorPopupProvider>
-              </RainbowKitProvider>
-            </body>
-          </html>
-        </QueryClientProvider>
-      </WagmiProvider>
+              </LitContextProvider>
+            </RainbowKitProvider>
+          </body>
+        </html>
+      </QueryClientProvider>
+    </WagmiProvider>
   );
 }

--- a/packages/dashboard/components/contracts/GetAppsByManager.tsx
+++ b/packages/dashboard/components/contracts/GetAppsByManager.tsx
@@ -1,0 +1,150 @@
+import { useEffect, useState } from 'react';
+import { useLitContext } from '@/providers/LitContext';
+import { ArrowRight, Plus } from 'lucide-react';
+import { createDatilChainManager } from '@lit-protocol/vincent-contracts';
+import { StateWrapper } from './StateWrapper';
+import Link from 'next/link';
+
+type GetAppsByManagerReturn = Awaited<
+  ReturnType<
+    ReturnType<
+      typeof createDatilChainManager
+    >['vincentApi']['appManagerDashboard']['getAppsByManager']
+  >
+>;
+
+/**
+ * GetAppsByManager - Component to display a list of apps from the chain manager
+ * using simple HTML tables without custom styles
+ */
+export function GetAppsByManager() {
+  const { chainManager, connectedAddress } = useLitContext();
+  const [apps, setApps] = useState<GetAppsByManagerReturn>([]);
+  const [loading, setLoading] = useState<boolean>(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    async function getApps() {
+      if (chainManager && connectedAddress) {
+        setLoading(true);
+        setError(null);
+
+        try {
+          const fetchedApps =
+            await chainManager.vincentApi.appManagerDashboard.getAppsByManager({
+              manager: connectedAddress,
+            });
+
+          setApps(fetchedApps);
+          console.log('Apps fetched:', fetchedApps);
+        } catch (err) {
+          console.error('Error fetching apps:', err);
+          setError('Failed to load your applications. Please try again.');
+        } finally {
+          setLoading(false);
+        }
+      }
+    }
+
+    getApps();
+  }, [chainManager, connectedAddress]);
+
+  // Helper function to truncate long addresses/strings
+  const truncateAddress = (address: string) => {
+    return `${address.substring(0, 6)}...${address.substring(address.length - 4)}`;
+  };
+
+  return (
+    <StateWrapper
+      loading={loading}
+      error={error}
+      isEmpty={apps.length === 0}
+      loadingLabel="Loading Applications"
+      emptyComponent={<>No Apps Found!</>}
+      errorConfig={{
+        onRetry: () => window.location.reload(),
+      }}
+    >
+      {/* Simple table layout to display apps */}
+      <div>
+        <table cellPadding="8" cellSpacing="0" width="100%">
+          <thead>
+            <tr>
+              <th>App Name</th>
+              <th>ID</th>
+              <th>Description</th>
+              <th>Manager</th>
+              <th>Latest Version</th>
+              <th>Delegatees</th>
+              <th>Authorized Redirect URIs</th>
+              <th>Actions</th>
+            </tr>
+          </thead>
+          <tbody>
+            {apps.map((appData, index) => (
+              <tr key={appData.app.id || index}>
+                <td>{appData.app.name || 'Unnamed App'}</td>
+                <td>{appData.app.id.toString()}</td>
+                <td>{appData.app.description || 'No description provided'}</td>
+                <td>{appData.app.manager}</td>
+                <td>{appData.app.latestVersion.toString()}</td>
+                <td>
+                  {appData.app.delegatees.length > 0 ? (
+                    <ul>
+                      {appData.app.delegatees
+                        .slice(0, 3)
+                        .map((delegatee, idx) => (
+                          <li key={idx}>{truncateAddress(delegatee)}</li>
+                        ))}
+                      {appData.app.delegatees.length > 3 && (
+                        <li>+{appData.app.delegatees.length - 3} more</li>
+                      )}
+                    </ul>
+                  ) : (
+                    'No delegatees'
+                  )}
+                </td>
+                <td>
+                  {appData.app.authorizedRedirectUris.length > 0 ? (
+                    <ul>
+                      {appData.app.authorizedRedirectUris
+                        .slice(0, 2)
+                        .map((uri, idx) => (
+                          <li key={idx}>{uri}</li>
+                        ))}
+                      {appData.app.authorizedRedirectUris.length > 2 && (
+                        <li>
+                          +{appData.app.authorizedRedirectUris.length - 2} more
+                        </li>
+                      )}
+                    </ul>
+                  ) : (
+                    'No authorized redirect URIs'
+                  )}
+                </td>
+                <td>
+                  <Link href={`/app/${appData.app.id.toString()}`}>
+                    <button>
+                      Manage App <ArrowRight size={16} />
+                    </button>
+                  </Link>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+
+        {/* Create New App button as a simple HTML element */}
+        <div style={{ marginTop: '20px', textAlign: 'center' }}>
+          <h3>Create New App</h3>
+          <p>Create a new application to manage</p>
+          <button>
+            <Plus size={16} /> Create App
+          </button>
+        </div>
+      </div>
+    </StateWrapper>
+  );
+}
+
+export default GetAppsByManager;

--- a/packages/dashboard/components/contracts/StateWrapper.tsx
+++ b/packages/dashboard/components/contracts/StateWrapper.tsx
@@ -1,0 +1,102 @@
+import { useLitContext } from '@/providers/LitContext';
+import { ReactNode } from 'react';
+import { styles } from './style';
+
+type StateWrapperProps = {
+  children: ReactNode;
+  loading?: boolean;
+  error?: string | null;
+  isEmpty?: boolean;
+  emptyComponent?: ReactNode;
+  errorConfig?: {
+    onRetry?: () => void;
+  };
+  loadingLabel?: string;
+};
+
+export function StateWrapper({
+  children,
+  loading = false,
+  error = null,
+  isEmpty = false,
+  emptyComponent,
+  errorConfig = {},
+  loadingLabel = 'Loading',
+}: StateWrapperProps) {
+  const { isConnected } = useLitContext();
+
+  // Wallet not connected state
+  if (!isConnected) {
+    return (
+      <div className={styles.card.dashed}>
+        <div className={styles.header.default}>
+          <h2 className={styles.title.default}>Connect Wallet</h2>
+        </div>
+        <div className={styles.container.content}>
+          <p className={styles.text.centered}>
+            Please connect your wallet to view your applications
+          </p>
+        </div>
+      </div>
+    );
+  }
+
+  // Loading state
+  if (loading) {
+    return (
+      <div className={styles.card.default}>
+        <div className={styles.header.default}>
+          <h2 className={styles.title.default}>{loadingLabel}</h2>
+        </div>
+        <div className={styles.container.content}>
+          <div className={styles.container.centered}>
+            <div className={styles.spinner}></div>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  // Error state
+  if (error) {
+    return (
+      <div className={styles.card.error}>
+        <div className={styles.header.default}>
+          <h2 className={styles.title.default}>Error Loading Applications</h2>
+        </div>
+        <div className={styles.container.content}>
+          <p className={styles.text.error}>{error}</p>
+          <button
+            className={styles.button.outline}
+            onClick={errorConfig.onRetry || (() => window.location.reload())}
+          >
+            Refresh
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  // Empty state
+  if (isEmpty) {
+    // Render the provided empty component if available
+    if (emptyComponent) {
+      return <>{emptyComponent}</>;
+    }
+
+    // Default empty state if no custom component is provided
+    return (
+      <div className={styles.card.dashed}>
+        <div className={styles.header.default}>
+          <h2 className={styles.title.default}>No Data Found</h2>
+        </div>
+        <div className={styles.container.content}>
+          <p className={styles.text.centered}>No data available</p>
+        </div>
+      </div>
+    );
+  }
+
+  // Default: render children when all conditions are met
+  return <>{children}</>;
+}

--- a/packages/dashboard/components/contracts/style.tsx
+++ b/packages/dashboard/components/contracts/style.tsx
@@ -1,0 +1,39 @@
+export const styles = {
+  // Card styles
+  card: {
+    default: 'border rounded-lg p-4 shadow-sm',
+    dashed: 'border-dashed border rounded-lg p-4 shadow-sm',
+    error: 'border-red-300 border rounded-lg p-4 shadow-sm',
+  },
+
+  // Header styles
+  header: {
+    default: 'pb-2 mb-4 border-b',
+  },
+
+  // Title styles
+  title: {
+    default: 'text-xl font-semibold',
+  },
+
+  // Container styles
+  container: {
+    centered: 'flex justify-center',
+    content: 'p-4',
+  },
+
+  // Text styles
+  text: {
+    centered: 'text-center mb-4',
+    error: 'text-red-500',
+  },
+
+  // Button styles
+  button: {
+    outline:
+      'px-4 py-2 border border-gray-300 rounded-md hover:bg-gray-50 inline-flex items-center',
+  },
+
+  // Spinner
+  spinner: 'animate-spin h-6 w-6 border-2 border-t-blue-500 rounded-full',
+};

--- a/packages/dashboard/components/developer/Dashboard.tsx
+++ b/packages/dashboard/components/developer/Dashboard.tsx
@@ -15,6 +15,7 @@ import {
 } from '../ui/card';
 import { mapEnumToTypeName } from '@/services/types';
 import { useErrorPopup } from '@/providers/error-popup';
+import { GetAppsByManager } from '../contracts/GetAppsByManager';
 // The styles are now included in the main dashboard.css imported in layout.tsx
 
 // Status message component
@@ -468,6 +469,8 @@ export default function DashboardScreen({
   // Main dashboard view when no app is selected
   return (
     <div className="space-y-6">
+    <GetAppsByManager/>
+
       {/* Show status message at the top of the dashboard */}
       {statusMessage && <StatusMessage message={statusMessage} type={statusType} />}
       

--- a/packages/dashboard/components/ui/scroll-area.tsx
+++ b/packages/dashboard/components/ui/scroll-area.tsx
@@ -14,7 +14,7 @@ const ScrollArea = React.forwardRef<
     className={cn("relative overflow-hidden", className)}
     {...props}
   >
-    <ScrollAreaPrimitive.Viewport className="h-full w-full rounded-[inherit]">
+    <ScrollAreaPrimitive.Viewport className="h-full w-full rounded-[inherit] pr-4">
       {children}
     </ScrollAreaPrimitive.Viewport>
     <ScrollBar />

--- a/packages/dashboard/providers/LitContext.tsx
+++ b/packages/dashboard/providers/LitContext.tsx
@@ -1,14 +1,13 @@
+import { LogManager } from '@lit-protocol/logger';
 import { createDatilChainManager } from '@lit-protocol/vincent-contracts';
 import {
-  getWalletClient,
   getAccount,
+  getWalletClient,
   reconnect,
   watchAccount,
 } from '@wagmi/core';
-import { useContext, useEffect, useState, useRef } from 'react';
-import { createContext } from 'react';
+import { createContext, useContext, useEffect, useRef, useState } from 'react';
 import { useConfig } from 'wagmi';
-import { LogManager, Logger } from '@lit-protocol/logger';
 
 const DEFAULT_CATEGORY = '[LitContext]';
 
@@ -28,12 +27,14 @@ interface LitContextConfig {
   chainManager: ReturnType<typeof createDatilChainManager> | null;
   isConnected: boolean;
   error: Error | null;
+  connectedAddress: string | null;
 }
 
 export const LitContext = createContext<LitContextConfig>({
   chainManager: null,
   isConnected: false,
   error: null,
+  connectedAddress: null,
 });
 
 export const useLitContext = () => useContext(LitContext);
@@ -49,6 +50,7 @@ export const LitContextProvider = ({
   const [isConnected, setIsConnected] = useState(false);
   const [error, setError] = useState<Error | null>(null);
   const unwatch = useRef<() => void>(() => {});
+  const [connectedAddress, setConnectedAddress] = useState<string | null>(null);
 
   // Config for wagmi interactions
   const config = useConfig();
@@ -65,6 +67,8 @@ export const LitContextProvider = ({
         setIsConnected(false);
         return;
       }
+
+      setConnectedAddress(account.address ?? null);
 
       // Only attempt to get wallet client if we have a connected wallet
       const walletClient = await getWalletClient(config);
@@ -138,6 +142,7 @@ export const LitContextProvider = ({
     chainManager,
     isConnected,
     error,
+    connectedAddress,
   };
 
   return (

--- a/packages/dashboard/providers/LitContext.tsx
+++ b/packages/dashboard/providers/LitContext.tsx
@@ -1,0 +1,146 @@
+import { createDatilChainManager } from '@lit-protocol/vincent-contracts';
+import {
+  getWalletClient,
+  getAccount,
+  reconnect,
+  watchAccount,
+} from '@wagmi/core';
+import { useContext, useEffect, useState, useRef } from 'react';
+import { createContext } from 'react';
+import { useConfig } from 'wagmi';
+import { LogManager, Logger } from '@lit-protocol/logger';
+
+const DEFAULT_CATEGORY = '[LitContext]';
+
+LogManager.Instance.setPrefix(DEFAULT_CATEGORY);
+const logger = LogManager.Instance.get();
+
+const NETWORK = 'datil';
+
+// declare empty object to get types
+const { vincentApi: vincentApiType } = createDatilChainManager({
+  account: {} as any,
+  network: NETWORK,
+});
+
+// [from user]
+interface LitContextConfig {
+  chainManager: ReturnType<typeof createDatilChainManager> | null;
+  isConnected: boolean;
+  error: Error | null;
+}
+
+export const LitContext = createContext<LitContextConfig>({
+  chainManager: null,
+  isConnected: false,
+  error: null,
+});
+
+export const useLitContext = () => useContext(LitContext);
+
+export const LitContextProvider = ({
+  children,
+}: {
+  children: React.ReactNode;
+}) => {
+  const [chainManager, setChainManager] = useState<ReturnType<
+    typeof createDatilChainManager
+  > | null>(null);
+  const [isConnected, setIsConnected] = useState(false);
+  const [error, setError] = useState<Error | null>(null);
+  const unwatch = useRef<() => void>(() => {});
+
+  // Config for wagmi interactions
+  const config = useConfig();
+
+  // Function to initialize the chain manager
+  const initChainManager = async () => {
+    logger.info(`initialising chain manager`);
+    try {
+      // Check if a wallet is connected using the getAccount action
+      const account = getAccount(config);
+
+      if (!account.isConnected) {
+        logger.info('No wallet connected yet, waiting for connection');
+        setIsConnected(false);
+        return;
+      }
+
+      // Only attempt to get wallet client if we have a connected wallet
+      const walletClient = await getWalletClient(config);
+
+      if (!walletClient) {
+        logger.error('No wallet client available');
+        return;
+      }
+
+      const chainManager = createDatilChainManager({
+        account: walletClient,
+        network: NETWORK,
+      });
+
+      logger.info(`chain manager initialised`);
+
+      setChainManager(chainManager);
+      setIsConnected(true);
+    } catch (e) {
+      logger.error('Failed to initialise Lit chain manager:', e);
+      setError(
+        e instanceof Error
+          ? e
+          : new Error('Unknown error initialising Lit chain manager'),
+      );
+      setIsConnected(false);
+    }
+  };
+
+  // Effect to reconnect on mount
+  useEffect(() => {
+    const init = async () => {
+      logger.info(`trying to reconnect`);
+      try {
+        // Try to reconnect any existing wallet connection first
+        await reconnect(config);
+        // Initialize after reconnection attempt
+        initChainManager();
+      } catch (e) {
+        logger.error('Failed to reconnect:', e);
+      }
+    };
+
+    init();
+  }, [config]);
+
+  // Effect to watch for account changes
+  useEffect(() => {
+    // Setup account watcher to react to connection changes
+    unwatch.current = watchAccount(config, {
+      onChange(account) {
+        logger.info('Account changed:', account);
+        if (account.isConnected) {
+          initChainManager();
+        } else {
+          setIsConnected(false);
+          setChainManager(null);
+        }
+      },
+    });
+
+    // Cleanup function
+    return () => {
+      if (unwatch.current) {
+        unwatch.current();
+      }
+    };
+  }, [config]);
+
+  const contextValue: LitContextConfig = {
+    chainManager,
+    isConnected,
+    error,
+  };
+
+  return (
+    <LitContext.Provider value={contextValue}>{children}</LitContext.Provider>
+  );
+};

--- a/packages/dashboard/providers/LitContext.tsx
+++ b/packages/dashboard/providers/LitContext.tsx
@@ -16,13 +16,6 @@ const logger = LogManager.Instance.get();
 
 const NETWORK = 'datil';
 
-// declare empty object to get types
-const { vincentApi: vincentApiType } = createDatilChainManager({
-  account: {} as any,
-  network: NETWORK,
-});
-
-// [from user]
 interface LitContextConfig {
   chainManager: ReturnType<typeof createDatilChainManager> | null;
   isConnected: boolean;


### PR DESCRIPTION
# WHAT

An example of setting up a Lit Context provider that initialises the chain manager, so that all children can consume the APIs.

- [LitContext.tsx](https://github.com/LIT-Protocol/Vincent/blob/1d17171cd555f42898765739a7058a7a79ed5392/packages/dashboard/providers/LitContext.tsx) -> Provides a context for the whole app
- StateWrapper.tsx -> Manage states of the fetch/contract calls (eg. isLoading, isEmpty, isError, etc.)
- GetAppsByManager.tsx -> The filename maps 1:1 to the `getAppsByManager`API. It renders a list of apps from the chain manager.

[Here](https://github.com/LIT-Protocol/Vincent/pull/40/files#diff-7023f0455583b0efdb150d2a025917393d6e656a8dd0e0f1ea59f47a5a464995R8-R14) is how your set the return type as return type of the getAppsByManager API.

<img width="451" alt="image" src="https://github.com/user-attachments/assets/7a8f13b0-697c-48cd-add2-ba5f5a7e9b4f" />

<img width="376" alt="image" src="https://github.com/user-attachments/assets/11f8f530-4244-405d-82ee-0fa6a37e1c1e" />
