### PR TITLE
Refactor `VincentUserViewFacet`

### DIFF
--- a/packages/vincent-contracts/script/UpdateFacet.sol
+++ b/packages/vincent-contracts/script/UpdateFacet.sol
@@ -160,7 +160,7 @@ contract UpdateFacet is Script {
                 isTargetFacet = isSameFacetType(facetAddress, registerUserSelector);
             } else if (compareStrings(facetName, "VincentUserViewFacet")) {
                 // Check for a common selector in VincentUserViewFacet - using a selector from the library
-                bytes4 getUserSelector = VincentUserViewFacet.getAllRegisteredAgentPkps.selector;
+                bytes4 getUserSelector = VincentUserViewFacet.getRegisteredPkpsForAddress.selector;
                 isTargetFacet = isSameFacetType(facetAddress, getUserSelector);
             }
 
@@ -246,12 +246,15 @@ contract UpdateFacet is Script {
 
     /// @dev Get VincentUserViewFacet selectors
     function getVincentUserViewFacetSelectors() internal pure returns (bytes4[] memory) {
-        bytes4[] memory selectors = new bytes4[](5);
-        selectors[0] = VincentUserViewFacet.getAllRegisteredAgentPkps.selector;
+        bytes4[] memory selectors = new bytes4[](8);
+        selectors[0] = VincentUserViewFacet.getRegisteredPkpsForAddress.selector;
         selectors[1] = VincentUserViewFacet.getPermittedAppVersionForPkp.selector;
-        selectors[2] = VincentUserViewFacet.getAllPermittedAppIdsForPkp.selector;
-        selectors[3] = VincentUserViewFacet.validateToolExecutionAndGetPolicies.selector;
-        selectors[4] = VincentUserViewFacet.getAllToolsAndPoliciesForApp.selector;
+        selectors[2] = VincentUserViewFacet.getPermittedAppsForPkp.selector;
+        selectors[3] = VincentUserViewFacet.getPermittedToolsAndPoliciesForApp.selector;
+        selectors[4] = VincentUserViewFacet.isDelegateePermittedToExecuteToolUsingPkp.selector;
+        selectors[5] = VincentUserViewFacet.getRegisteredPoliciesForTool.selector;
+        selectors[6] = VincentUserViewFacet.checkIsPermittedAndGetRegisteredPoliciesForTool.selector;
+        selectors[7] = VincentUserViewFacet.getToolPolicyParameterValuesForPkp.selector;
         return selectors;
     }
 

--- a/packages/vincent-contracts/src/VincentDiamond.sol
+++ b/packages/vincent-contracts/src/VincentDiamond.sol
@@ -212,12 +212,15 @@ contract VincentDiamond {
     }
 
     function getVincentUserViewFacetSelectors() internal pure returns (bytes4[] memory) {
-        bytes4[] memory selectors = new bytes4[](5);
-        selectors[0] = VincentUserViewFacet.getAllRegisteredAgentPkps.selector;
+        bytes4[] memory selectors = new bytes4[](8);
+        selectors[0] = VincentUserViewFacet.getRegisteredPkpsForAddress.selector;
         selectors[1] = VincentUserViewFacet.getPermittedAppVersionForPkp.selector;
-        selectors[2] = VincentUserViewFacet.getAllPermittedAppIdsForPkp.selector;
-        selectors[3] = VincentUserViewFacet.validateToolExecutionAndGetPolicies.selector;
-        selectors[4] = VincentUserViewFacet.getAllToolsAndPoliciesForApp.selector;
+        selectors[2] = VincentUserViewFacet.getPermittedAppsForPkp.selector;
+        selectors[3] = VincentUserViewFacet.getPermittedToolsAndPoliciesForApp.selector;
+        selectors[4] = VincentUserViewFacet.isDelegateePermittedToExecuteToolUsingPkp.selector;
+        selectors[5] = VincentUserViewFacet.getRegisteredPoliciesForTool.selector;
+        selectors[6] = VincentUserViewFacet.checkIsPermittedAndGetRegisteredPoliciesForTool.selector;
+        selectors[7] = VincentUserViewFacet.getToolPolicyParameterValuesForPkp.selector;
         return selectors;
     }
 

--- a/packages/vincent-contracts/src/facets/VincentUserViewFacet.sol
+++ b/packages/vincent-contracts/src/facets/VincentUserViewFacet.sol
@@ -6,365 +6,217 @@ import "@openzeppelin/contracts/utils/structs/EnumerableSet.sol";
 import "../LibVincentDiamondStorage.sol";
 import "../VincentBase.sol";
 
-/**
- * @title VincentUserViewFacet
- * @dev View functions for user-related data stored in the VincentUserStorage
- */
 contract VincentUserViewFacet is VincentBase {
     using VincentUserStorage for VincentUserStorage.UserStorage;
-    using EnumerableSet for EnumerableSet.UintSet;
-    using EnumerableSet for EnumerableSet.Bytes32Set;
 
-    /**
-     * @notice Thrown when a PKP is not permitted for a specific app version
-     * @param pkpTokenId The PKP token ID
-     * @param appId The app ID
-     * @param appVersion The app version
-     */
-    error PkpNotPermittedForAppVersion(uint256 pkpTokenId, uint256 appId, uint256 appVersion);
-
-    /**
-     * @notice Thrown when a policy parameter is not set for a PKP
-     * @param pkpTokenId The PKP token ID
-     * @param appId The app ID
-     * @param appVersion The app version
-     * @param policyIpfsCid The policy IPFS CID
-     * @param parameterName The parameter name
-     */
-    error PolicyParameterNotSetForPkp(
-        uint256 pkpTokenId, uint256 appId, uint256 appVersion, string policyIpfsCid, string parameterName
-    );
-
-    /**
-     * @notice Thrown when a delegatee is not associated with any app
-     * @param delegatee The delegatee address
-     */
-    error DelegateeNotAssociatedWithApp(address delegatee);
-
-    /**
-     * @notice Thrown when an invalid PKP token ID is provided
-     */
-    error InvalidPkpTokenId();
-
-    /**
-     * @notice Thrown when an invalid app ID is provided
-     */
-    error InvalidAppId();
-
-    /**
-     * @notice Thrown when an empty tool IPFS CID is provided
-     */
-    error EmptyToolIpfsCid();
-
-    /**
-     * @notice Thrown when a zero address is provided
-     */
-    error ZeroAddressNotAllowed();
-
-    /**
-     * @notice Thrown when no registered PKPs are found for a user
-     * @param userAddress The user address
-     */
-    error NoRegisteredPkpsFound(address userAddress);
-
-    // Struct to hold the result of tool execution validation and policy retrieval
-    struct ToolExecutionValidation {
-        bool isPermitted; // Whether the delegatee is permitted to use the PKP to execute the tool
-        uint256 appId; // The ID of the app associated with the delegatee
-        uint256 appVersion; // The permitted app version
-        PolicyWithParameters[] policies; // All policies with their parameters
+    struct PermittedApp {
+        uint256 appId;
+        uint256 appVersion;
     }
 
-    // Struct to represent a tool with all its policies and parameters
+    struct PermittedToolsAndPolicies {
+        uint256 appId;
+        uint256 appVersion;
+        ToolWithPolicies[] tools;
+    }
+
     struct ToolWithPolicies {
-        string toolIpfsCid; // The IPFS CID of the tool
-        PolicyWithParameters[] policies; // All policies associated with this tool and their parameters
+        string toolIpfsCid;
+        Policy[] policies;
     }
 
-    // Struct to represent a policy with its parameters
-    struct PolicyWithParameters {
+    struct Policy {
         string policyIpfsCid;
         bytes policyParameterValues;
     }
 
-    /**
-     * @dev Gets all PKP tokens that are registered as agents in the system
-     * @return An array of PKP token IDs that are registered as agents
-     */
-    function getAllRegisteredAgentPkps(address userAddress) external view returns (uint256[] memory) {
-        // Check for zero address
-        if (userAddress == address(0)) {
-            revert ZeroAddressNotAllowed();
-        }
-
-        VincentUserStorage.UserStorage storage us_ = VincentUserStorage.userStorage();
-        uint256[] memory pkps = us_.userAddressToRegisteredAgentPkps[userAddress].values();
-
-        // Check if there are any registered PKPs
-        if (pkps.length == 0) {
-            revert NoRegisteredPkpsFound(userAddress);
-        }
-
-        return pkps;
+    struct DelegateePermission {
+        bool isPermitted;
+        uint256 appId;
+        uint256 appVersion;
     }
 
-    /**
-     * @dev Gets all permitted app versions for a specific app and PKP token
-     * @param pkpTokenId The PKP token ID
-     * @param appId The app ID
-     * @return An array of app versions that are permitted for the PKP token
-     */
-    function getPermittedAppVersionForPkp(uint256 pkpTokenId, uint256 appId)
-        external
+    error AppNotPermittedByPkp(uint256 appId);
+    error DelegateeNotAssociatedWithApp(address delegatee);
+    error AppNotEnabled(uint256 appId);
+    error ToolNotPermittedByAppVersion(uint256 appId, uint256 appVersion, string toolIpfsCid);
+
+    function getRegisteredPkpsForAddress(address userAddress) external view returns (uint256[] memory) {
+        VincentUserStorage.UserStorage storage us_ = VincentUserStorage.userStorage();
+        return us_.userAddressToRegisteredAgentPkps[userAddress].values();
+    }
+
+    function getPermittedAppVersionForPkp(uint256 appId, uint256 pkpTokenId)
+        public
         view
         appNotDeleted(appId)
         returns (uint256)
     {
-        // Check for invalid PKP token ID and app ID
-        if (pkpTokenId == 0) {
-            revert InvalidPkpTokenId();
-        }
-
-        if (appId == 0) {
-            revert InvalidAppId();
-        }
-
         VincentUserStorage.UserStorage storage us_ = VincentUserStorage.userStorage();
-        return us_.agentPkpTokenIdToAgentStorage[pkpTokenId].permittedAppVersion[appId];
+        uint256 permittedAppVersion = us_.agentPkpTokenIdToAgentStorage[pkpTokenId].permittedAppVersion[appId];
+        if (permittedAppVersion == 0) {
+            revert AppNotPermittedByPkp(appId);
+        }
+        return permittedAppVersion;
     }
 
-    /**
-     * @dev Gets all app IDs that have permissions for a specific PKP token, excluding deleted apps
-     * @param pkpTokenId The PKP token ID
-     * @return An array of app IDs that have permissions for the PKP token and haven't been deleted
-     */
-    function getAllPermittedAppIdsForPkp(uint256 pkpTokenId) external view returns (uint256[] memory) {
-        // Check for invalid PKP token ID
-        if (pkpTokenId == 0) {
-            revert InvalidPkpTokenId();
-        }
-
+    function getPermittedAppsForPkp(uint256 pkpTokenId)
+        external
+        view
+        returns (PermittedApp[] memory permittedApps)
+    {
         VincentUserStorage.UserStorage storage us_ = VincentUserStorage.userStorage();
         VincentAppStorage.AppStorage storage as_ = VincentAppStorage.appStorage();
 
-        // Get all permitted app IDs
         uint256[] memory allPermittedAppIds = us_.agentPkpTokenIdToAgentStorage[pkpTokenId].permittedApps.values();
+        VincentUserStorage.AgentStorage storage agentStorage = us_.agentPkpTokenIdToAgentStorage[pkpTokenId];
 
-        // Create dynamic array for active apps
-        uint256[] memory nonDeletedAppIds = new uint256[](allPermittedAppIds.length);
+        // Create a temporary array to store the results
+        PermittedApp[] memory tempPermittedApps = new PermittedApp[](allPermittedAppIds.length);
         uint256 nonDeletedCount = 0;
 
-        // Single loop to collect non-deleted apps
         for (uint256 i = 0; i < allPermittedAppIds.length; i++) {
             if (!as_.appIdToApp[allPermittedAppIds[i]].isDeleted) {
-                nonDeletedAppIds[nonDeletedCount] = allPermittedAppIds[i];
+                tempPermittedApps[nonDeletedCount] = PermittedApp({
+                    appId: allPermittedAppIds[i],
+                    appVersion: agentStorage.permittedAppVersion[allPermittedAppIds[i]]
+                });
                 nonDeletedCount++;
             }
         }
 
-        // Resize array to actual size
-        assembly {
-            mstore(nonDeletedAppIds, nonDeletedCount)
+        // Create the final array with the correct size
+        permittedApps = new PermittedApp[](nonDeletedCount);
+        
+        // Copy the elements to the final array
+        for (uint256 i = 0; i < nonDeletedCount; i++) {
+            permittedApps[i] = tempPermittedApps[i];
         }
 
-        return nonDeletedAppIds;
+        return permittedApps;
     }
 
-    /**
-     * @dev Gets all permitted tools, policies, and policy parameters for a specific app and PKP
-     * @param pkpTokenId The PKP token ID
-     * @param appId The app ID
-     * @return tools An array of tools with their policies and parameters
-     */
-    function getAllToolsAndPoliciesForApp(uint256 pkpTokenId, uint256 appId)
+    function getPermittedToolsAndPoliciesForApp(uint256 appId, uint256 pkpTokenId)
         external
         view
-        returns (ToolWithPolicies[] memory tools)
+        returns (ToolWithPolicies[] memory)
     {
-        // Check for invalid PKP token ID and app ID
-        if (pkpTokenId == 0) {
-            revert InvalidPkpTokenId();
-        }
+        // getPermittedAppVersionForPkp checks if app is deleted
+        uint256 permittedAppVersion = getPermittedAppVersionForPkp(appId, pkpTokenId);
 
-        if (appId == 0) {
-            revert InvalidAppId();
-        }
+        VincentAppStorage.AppVersion storage appVersion =
+            as_.appIdToApp[appId].appVersions[getAppVersionIndex(permittedAppVersion)];
 
-        VincentAppStorage.AppStorage storage as_ = VincentAppStorage.appStorage();
-
-        if (as_.appIdToApp[appId].isDeleted) {
-            revert AppHasBeenDeleted(appId);
-        }
+        bytes32[] memory toolIpfsCidHashes = appVersion.toolIpfsCidHashes.values();
+        ToolWithPolicies[] memory toolWithPolicies = new ToolWithPolicies[](toolIpfsCidHashes.length);
 
         VincentUserStorage.UserStorage storage us_ = VincentUserStorage.userStorage();
         VincentLitActionStorage.LitActionStorage storage ls_ = VincentLitActionStorage.litActionStorage();
 
-        // Get the permitted app version for this PKP and app
-        uint256 appVersion = us_.agentPkpTokenIdToAgentStorage[pkpTokenId].permittedAppVersion[appId];
-
-        // If no version is permitted (appVersion == 0), return an empty array
-        if (appVersion == 0) {
-            return new ToolWithPolicies[](0);
+        for (uint256 i = 0; i < toolIpfsCidHashes.length; i++) {
+            toolWithPolicies[i] = ToolWithPolicies({
+                toolIpfsCid: ls_.ipfsCidHashToIpfsCid[toolIpfsCidHashes[i]],
+                policies: _getPoliciesForTool(
+                    appId,
+                    permittedAppVersion,
+                    toolIpfsCidHashes[i],
+                    pkpTokenId,
+                    us_,
+                    ls_
+                )
+            });
         }
 
-        // Get the app version
-        VincentAppStorage.AppVersion storage versionedApp =
-            as_.appIdToApp[appId].appVersions[getAppVersionIndex(appVersion)];
-
-        // Get all tool hashes for this app version
-        bytes32[] memory toolHashes = versionedApp.toolIpfsCidHashes.values();
-        uint256 toolCount = toolHashes.length;
-
-        // Create the result array
-        tools = new ToolWithPolicies[](toolCount);
-
-        // For each tool, get its policies and parameters
-        for (uint256 i = 0; i < toolCount; i++) {
-            bytes32 toolHash = toolHashes[i];
-            tools[i] = _getToolWithPolicies(toolHash, pkpTokenId, appId, appVersion, versionedApp, us_, ls_);
-        }
-
-        return tools;
+        return toolWithPolicies;
     }
 
-    /**
-     * @dev Validates if a delegatee is permitted to execute a tool with a PKP and returns all relevant policies
-     * @param delegatee The address of the delegatee
-     * @param pkpTokenId The PKP token ID
-     * @param toolIpfsCid The IPFS CID of the tool
-     * @return validation A struct containing validation result and policy information
-     */
-    function validateToolExecutionAndGetPolicies(address delegatee, uint256 pkpTokenId, string calldata toolIpfsCid)
-        external
+    function isDelegateePermittedToExecuteToolUsingPkp(address delegatee, uint256 pkpTokenId, string calldata toolIpfsCid)
+        public
         view
-        returns (ToolExecutionValidation memory validation)
+        returns (DelegateePermission)
     {
-        // Check for invalid inputs
-        if (delegatee == address(0)) {
-            revert ZeroAddressNotAllowed();
-        }
-
-        if (pkpTokenId == 0) {
-            revert InvalidPkpTokenId();
-        }
-
-        if (bytes(toolIpfsCid).length == 0) {
-            revert EmptyToolIpfsCid();
-        }
-
         VincentAppStorage.AppStorage storage as_ = VincentAppStorage.appStorage();
-        VincentUserStorage.UserStorage storage us_ = VincentUserStorage.userStorage();
-        VincentLitActionStorage.LitActionStorage storage ls_ = VincentLitActionStorage.litActionStorage();
-
-        // Initialize the validation result
-        validation.isPermitted = false;
-
-        // Get the app ID that the delegatee belongs to
-        uint256 appId = as_.delegateeAddressToAppId[delegatee];
-        validation.appId = appId;
-
-        // If appId is 0, delegatee is not associated with any app
-        if (appId == 0) {
+        
+        uint256 appIdDelegateeBelongsTo = as_.delegateeAddressToAppId[delegatee];
+        if (appIdDelegateeBelongsTo == 0) {
             revert DelegateeNotAssociatedWithApp(delegatee);
         }
 
-        if (as_.appIdToApp[appId].isDeleted) {
-            revert AppHasBeenDeleted(appId);
+        // getPermittedAppVersionForPkp checks if app is deleted
+        uint256 permittedAppVersion = getPermittedAppVersionForPkp(appIdDelegateeBelongsTo, pkpTokenId);
+
+        VincentAppStorage.AppVersion storage appVersion =
+            as_.appIdToApp[appIdDelegateeBelongsTo].appVersions[getAppVersionIndex(permittedAppVersion)];
+
+        if (!appVersion.enabled) {
+            revert AppNotEnabled(appIdDelegateeBelongsTo);
         }
 
-        // Hash the tool IPFS CID once to avoid repeated hashing
-        bytes32 hashedToolIpfsCid = keccak256(abi.encodePacked(toolIpfsCid));
-
-        // Get the permitted app version for this PKP and app
-        uint256 appVersion = us_.agentPkpTokenIdToAgentStorage[pkpTokenId].permittedAppVersion[appId];
-
-        // If no version is permitted (appVersion == 0), return early with isPermitted = false
-        if (appVersion == 0) {
-            return validation;
+        if (!appVersion.toolIpfsCidHashes.contains(keccak256(abi.encodePacked(toolIpfsCid)))) {
+            revert ToolNotPermittedByAppVersion(appIdDelegateeBelongsTo, permittedAppVersion, toolIpfsCid);
         }
 
-        validation.appVersion = appVersion;
-
-        // Check if the app version is enabled and the tool is registered for this app version
-        VincentAppStorage.AppVersion storage versionedApp =
-            as_.appIdToApp[appId].appVersions[getAppVersionIndex(appVersion)];
-
-        if (!versionedApp.enabled || !versionedApp.toolIpfsCidHashes.contains(hashedToolIpfsCid)) {
-            return validation;
-        }
-
-        // If we've reached here, the tool is permitted
-        validation.isPermitted = true;
-
-        // Get all policies registered for this tool in the app version
-        VincentAppStorage.ToolPolicies storage appToolPolicies =
-            versionedApp.toolIpfsCidHashToToolPolicies[hashedToolIpfsCid];
-
-        // Get all policy hashes for this tool from the app version
-        bytes32[] memory allPolicyHashes = appToolPolicies.policyIpfsCidHashes.values();
-        uint256 policyCount = allPolicyHashes.length;
-
-        // Create the policies array
-        validation.policies = new PolicyWithParameters[](policyCount);
-
-        // Get the tool policy storage for this PKP, app, app version, and tool
-        VincentUserStorage.ToolPolicyStorage storage toolPolicyStorage =
-            us_.agentPkpTokenIdToAgentStorage[pkpTokenId].toolPolicyStorage[appId][appVersion][hashedToolIpfsCid];
-
-        // For each policy, get all its parameters
-        for (uint256 i = 0; i < policyCount; i++) {
-            bytes32 policyHash = allPolicyHashes[i];
-
-            // Get the policy IPFS CID
-            validation.policies[i].policyIpfsCid = ls_.ipfsCidHashToIpfsCid[policyHash];
-            validation.policies[i].policyParameterValues = toolPolicyStorage.policyIpfsCidHashToParameterValues[policyHash];
-        }
-
-        return validation;
+        return DelegateePermission({
+            isPermitted: true,
+            appId: appIdDelegateeBelongsTo,
+            appVersion: permittedAppVersion
+        });
     }
 
-    /**
-     * @dev Internal function to get a tool with its policies and parameters
-     * @param toolHash The hash of the tool IPFS CID
-     * @param pkpTokenId The PKP token ID
-     * @param appId The app ID
-     * @param appVersion The app version
-     * @param versionedApp The versioned app storage
-     * @param us_ The user storage
-     * @param ls_ The lit action storage
-     * @return toolWithPolicies The tool with its policies and parameters
-     */
-    function _getToolWithPolicies(
-        bytes32 toolHash,
-        uint256 pkpTokenId,
+    function getRegisteredPoliciesForTool(uint256 appId, uint256 pkpTokenId, string calldata toolIpfsCid)
+        public
+        view
+        returns (Policy[] memory)
+    {
+        uint256 permittedAppVersion = getPermittedAppVersionForPkp(appId, pkpTokenId);
+
+        VincentUserStorage.UserStorage storage us_ = VincentUserStorage.userStorage();
+        VincentLitActionStorage.LitActionStorage storage ls_ = VincentLitActionStorage.litActionStorage();
+
+        return _getPoliciesForTool(appId, permittedAppVersion, keccak256(abi.encodePacked(toolIpfsCid)), pkpTokenId, us_, ls_);
+    }
+
+    function checkIsPermittedAndGetRegisteredPoliciesForTool(address delegatee, uint256 pkpTokenId, string calldata toolIpfsCid)
+        external
+        view
+        returns (DelegateePermission delegateePermission, Policy[] memory policies)
+    {
+        DelegateePermission delegateePermission = isDelegateePermittedToExecuteToolUsingPkp(delegatee, pkpTokenId, toolIpfsCid);
+        return (delegateePermission, getRegisteredPoliciesForTool(delegateePermission.appId, delegateePermission.appVersion, toolIpfsCid));
+    }
+
+    function getToolPolicyParameterValuesForPkp(address delegatee, uint256 pkpTokenId, string calldata toolIpfsCid, string calldata policyIpfsCid)
+        external
+        view
+        returns (DelegateePermission delegateePermission, bytes memory policyParameterValues)
+    {
+        DelegateePermission delegateePermission = isDelegateePermittedToExecuteToolUsingPkp(delegatee, pkpTokenId, toolIpfsCid);
+
+        VincentUserStorage.UserStorage storage us_ = VincentUserStorage.userStorage();
+        ToolPolicyStorage storage toolPolicyStorage = us_.agentPkpTokenIdToAgentStorage[pkpTokenId].toolPolicyStorage[delegateePermission.appId][delegateePermission.appVersion][toolIpfsCidHash];
+
+        return (delegateePermission, toolPolicyStorage.policyIpfsCidHashToParameterValues[keccak256(abi.encodePacked(policyIpfsCid))]);
+    }
+
+    function _getPoliciesForTool(
         uint256 appId,
         uint256 appVersion,
-        VincentAppStorage.AppVersion storage versionedApp,
+        bytes32 toolIpfsCidHash,
+        uint256 pkpTokenId,
         VincentUserStorage.UserStorage storage us_,
         VincentLitActionStorage.LitActionStorage storage ls_
-    ) internal view returns (ToolWithPolicies memory toolWithPolicies) {
-        // Get the tool IPFS CID
-        toolWithPolicies.toolIpfsCid = ls_.ipfsCidHashToIpfsCid[toolHash];
+    ) internal view returns (Policy[] memory) {
+        ToolPolicyStorage storage toolPolicyStorage = us_.agentPkpTokenIdToAgentStorage[pkpTokenId].toolPolicyStorage[appId][appVersion][toolIpfsCidHash];
 
-        // Get all policies registered for this tool in the app version
-        VincentAppStorage.ToolPolicies storage appToolPolicies = versionedApp.toolIpfsCidHashToToolPolicies[toolHash];
+        bytes32[] memory policyHashes = toolPolicyStorage.policyIpfsCidHashes.values();
+        Policy[] memory policies = new Policy[](policyHashes.length);        
 
-        // Get all policy hashes for this tool from the app version
-        bytes32[] memory allPolicyHashes = appToolPolicies.policyIpfsCidHashes.values();
-        uint256 policyCount = allPolicyHashes.length;
-
-        // Create the policies array for this tool
-        toolWithPolicies.policies = new PolicyWithParameters[](policyCount);
-
-        // Get the tool policy storage for this PKP, app, and tool
-        VincentUserStorage.ToolPolicyStorage storage toolPolicyStorage =
-            us_.agentPkpTokenIdToAgentStorage[pkpTokenId].toolPolicyStorage[appId][appVersion][toolHash];
-
-        // For each policy, get all its parameters
-        for (uint256 i = 0; i < policyCount; i++) {
-            bytes32 policyHash = allPolicyHashes[i];
-            toolWithPolicies.policies[i].policyIpfsCid = ls_.ipfsCidHashToIpfsCid[policyHash];
-            toolWithPolicies.policies[i].policyParameterValues = toolPolicyStorage.policyIpfsCidHashToParameterValues[policyHash];
+        for (uint256 i = 0; i < policyHashes.length; i++) {
+            policies[i] = Policy({
+                policyIpfsCid: ls_.ipfsCidHashToIpfsCid[policyHashes[i]],
+                policyParameterValues: toolPolicyStorage.policyIpfsCidHashToParameterValues[policyHashes[i]]
+            });
         }
+        return policies;
     }
 }

--- a/packages/vincent-contracts/src/facets/VincentUserViewFacet.sol
+++ b/packages/vincent-contracts/src/facets/VincentUserViewFacet.sol
@@ -8,6 +8,8 @@ import "../VincentBase.sol";
 
 contract VincentUserViewFacet is VincentBase {
     using VincentUserStorage for VincentUserStorage.UserStorage;
+    using EnumerableSet for EnumerableSet.UintSet;
+    using EnumerableSet for EnumerableSet.Bytes32Set;
 
     struct PermittedApp {
         uint256 appId;
@@ -60,21 +62,17 @@ contract VincentUserViewFacet is VincentBase {
         return permittedAppVersion;
     }
 
-    function getPermittedAppsForPkp(uint256 pkpTokenId)
-        external
-        view
-        returns (PermittedApp[] memory permittedApps)
-    {
+    function getPermittedAppsForPkp(uint256 pkpTokenId) external view returns (PermittedApp[] memory permittedApps) {
         VincentUserStorage.UserStorage storage us_ = VincentUserStorage.userStorage();
         VincentAppStorage.AppStorage storage as_ = VincentAppStorage.appStorage();
 
         uint256[] memory allPermittedAppIds = us_.agentPkpTokenIdToAgentStorage[pkpTokenId].permittedApps.values();
-        VincentUserStorage.AgentStorage storage agentStorage = us_.agentPkpTokenIdToAgentStorage[pkpTokenId];
 
         // Create a temporary array to store the results
         PermittedApp[] memory tempPermittedApps = new PermittedApp[](allPermittedAppIds.length);
         uint256 nonDeletedCount = 0;
 
+        VincentUserStorage.AgentStorage storage agentStorage = us_.agentPkpTokenIdToAgentStorage[pkpTokenId];
         for (uint256 i = 0; i < allPermittedAppIds.length; i++) {
             if (!as_.appIdToApp[allPermittedAppIds[i]].isDeleted) {
                 tempPermittedApps[nonDeletedCount] = PermittedApp({
@@ -87,7 +85,7 @@ contract VincentUserViewFacet is VincentBase {
 
         // Create the final array with the correct size
         permittedApps = new PermittedApp[](nonDeletedCount);
-        
+
         // Copy the elements to the final array
         for (uint256 i = 0; i < nonDeletedCount; i++) {
             permittedApps[i] = tempPermittedApps[i];
@@ -104,6 +102,7 @@ contract VincentUserViewFacet is VincentBase {
         // getPermittedAppVersionForPkp checks if app is deleted
         uint256 permittedAppVersion = getPermittedAppVersionForPkp(appId, pkpTokenId);
 
+        VincentAppStorage.AppStorage storage as_ = VincentAppStorage.appStorage();
         VincentAppStorage.AppVersion storage appVersion =
             as_.appIdToApp[appId].appVersions[getAppVersionIndex(permittedAppVersion)];
 
@@ -116,27 +115,20 @@ contract VincentUserViewFacet is VincentBase {
         for (uint256 i = 0; i < toolIpfsCidHashes.length; i++) {
             toolWithPolicies[i] = ToolWithPolicies({
                 toolIpfsCid: ls_.ipfsCidHashToIpfsCid[toolIpfsCidHashes[i]],
-                policies: _getPoliciesForTool(
-                    appId,
-                    permittedAppVersion,
-                    toolIpfsCidHashes[i],
-                    pkpTokenId,
-                    us_,
-                    ls_
-                )
+                policies: _getPoliciesForTool(appId, permittedAppVersion, toolIpfsCidHashes[i], pkpTokenId, us_, ls_)
             });
         }
 
         return toolWithPolicies;
     }
 
-    function isDelegateePermittedToExecuteToolUsingPkp(address delegatee, uint256 pkpTokenId, string calldata toolIpfsCid)
-        public
-        view
-        returns (DelegateePermission)
-    {
+    function isDelegateePermittedToExecuteToolUsingPkp(
+        address delegatee,
+        uint256 pkpTokenId,
+        string calldata toolIpfsCid
+    ) public view returns (DelegateePermission memory) {
         VincentAppStorage.AppStorage storage as_ = VincentAppStorage.appStorage();
-        
+
         uint256 appIdDelegateeBelongsTo = as_.delegateeAddressToAppId[delegatee];
         if (appIdDelegateeBelongsTo == 0) {
             revert DelegateeNotAssociatedWithApp(delegatee);
@@ -156,11 +148,7 @@ contract VincentUserViewFacet is VincentBase {
             revert ToolNotPermittedByAppVersion(appIdDelegateeBelongsTo, permittedAppVersion, toolIpfsCid);
         }
 
-        return DelegateePermission({
-            isPermitted: true,
-            appId: appIdDelegateeBelongsTo,
-            appVersion: permittedAppVersion
-        });
+        return DelegateePermission({isPermitted: true, appId: appIdDelegateeBelongsTo, appVersion: permittedAppVersion});
     }
 
     function getRegisteredPoliciesForTool(uint256 appId, uint256 pkpTokenId, string calldata toolIpfsCid)
@@ -173,29 +161,41 @@ contract VincentUserViewFacet is VincentBase {
         VincentUserStorage.UserStorage storage us_ = VincentUserStorage.userStorage();
         VincentLitActionStorage.LitActionStorage storage ls_ = VincentLitActionStorage.litActionStorage();
 
-        return _getPoliciesForTool(appId, permittedAppVersion, keccak256(abi.encodePacked(toolIpfsCid)), pkpTokenId, us_, ls_);
+        return _getPoliciesForTool(
+            appId, permittedAppVersion, keccak256(abi.encodePacked(toolIpfsCid)), pkpTokenId, us_, ls_
+        );
     }
 
-    function checkIsPermittedAndGetRegisteredPoliciesForTool(address delegatee, uint256 pkpTokenId, string calldata toolIpfsCid)
-        external
-        view
-        returns (DelegateePermission delegateePermission, Policy[] memory policies)
-    {
-        DelegateePermission delegateePermission = isDelegateePermittedToExecuteToolUsingPkp(delegatee, pkpTokenId, toolIpfsCid);
-        return (delegateePermission, getRegisteredPoliciesForTool(delegateePermission.appId, delegateePermission.appVersion, toolIpfsCid));
+    function checkIsPermittedAndGetRegisteredPoliciesForTool(
+        address delegatee,
+        uint256 pkpTokenId,
+        string calldata toolIpfsCid
+    ) external view returns (DelegateePermission memory delegateePermission, Policy[] memory policies) {
+        delegateePermission =
+            isDelegateePermittedToExecuteToolUsingPkp(delegatee, pkpTokenId, toolIpfsCid);
+        return (
+            delegateePermission,
+            getRegisteredPoliciesForTool(delegateePermission.appId, delegateePermission.appVersion, toolIpfsCid)
+        );
     }
 
-    function getToolPolicyParameterValuesForPkp(address delegatee, uint256 pkpTokenId, string calldata toolIpfsCid, string calldata policyIpfsCid)
-        external
-        view
-        returns (DelegateePermission delegateePermission, bytes memory policyParameterValues)
-    {
-        DelegateePermission delegateePermission = isDelegateePermittedToExecuteToolUsingPkp(delegatee, pkpTokenId, toolIpfsCid);
+    function getToolPolicyParameterValuesForPkp(
+        address delegatee,
+        uint256 pkpTokenId,
+        string calldata toolIpfsCid,
+        string calldata policyIpfsCid
+    ) external view returns (DelegateePermission memory delegateePermission, bytes memory policyParameterValues) {
+        delegateePermission =
+            isDelegateePermittedToExecuteToolUsingPkp(delegatee, pkpTokenId, toolIpfsCid);
 
         VincentUserStorage.UserStorage storage us_ = VincentUserStorage.userStorage();
-        ToolPolicyStorage storage toolPolicyStorage = us_.agentPkpTokenIdToAgentStorage[pkpTokenId].toolPolicyStorage[delegateePermission.appId][delegateePermission.appVersion][toolIpfsCidHash];
+        VincentUserStorage.ToolPolicyStorage storage toolPolicyStorage = us_.agentPkpTokenIdToAgentStorage[pkpTokenId].toolPolicyStorage[delegateePermission
+            .appId][delegateePermission.appVersion][keccak256(abi.encodePacked(toolIpfsCid))];
 
-        return (delegateePermission, toolPolicyStorage.policyIpfsCidHashToParameterValues[keccak256(abi.encodePacked(policyIpfsCid))]);
+        return (
+            delegateePermission,
+            toolPolicyStorage.policyIpfsCidHashToParameterValues[keccak256(abi.encodePacked(policyIpfsCid))]
+        );
     }
 
     function _getPoliciesForTool(
@@ -206,10 +206,11 @@ contract VincentUserViewFacet is VincentBase {
         VincentUserStorage.UserStorage storage us_,
         VincentLitActionStorage.LitActionStorage storage ls_
     ) internal view returns (Policy[] memory) {
-        ToolPolicyStorage storage toolPolicyStorage = us_.agentPkpTokenIdToAgentStorage[pkpTokenId].toolPolicyStorage[appId][appVersion][toolIpfsCidHash];
+        VincentUserStorage.ToolPolicyStorage storage toolPolicyStorage =
+            us_.agentPkpTokenIdToAgentStorage[pkpTokenId].toolPolicyStorage[appId][appVersion][toolIpfsCidHash];
 
-        bytes32[] memory policyHashes = toolPolicyStorage.policyIpfsCidHashes.values();
-        Policy[] memory policies = new Policy[](policyHashes.length);        
+        bytes32[] memory policyHashes = toolPolicyStorage.policyIpfsCidHashesWithParameters.values();
+        Policy[] memory policies = new Policy[](policyHashes.length);
 
         for (uint256 i = 0; i < policyHashes.length; i++) {
             policies[i] = Policy({

--- a/packages/vincent-contracts/src/facets/VincentUserViewFacet.sol
+++ b/packages/vincent-contracts/src/facets/VincentUserViewFacet.sol
@@ -175,7 +175,7 @@ contract VincentUserViewFacet is VincentBase {
             isDelegateePermittedToExecuteToolUsingPkp(delegatee, pkpTokenId, toolIpfsCid);
         return (
             delegateePermission,
-            getRegisteredPoliciesForTool(delegateePermission.appId, delegateePermission.appVersion, toolIpfsCid)
+            getRegisteredPoliciesForTool(delegateePermission.appId, pkpTokenId, toolIpfsCid)
         );
     }
 

--- a/packages/vincent-contracts/test/facets/VincentUserFacet.t.sol
+++ b/packages/vincent-contracts/test/facets/VincentUserFacet.t.sol
@@ -115,12 +115,7 @@ contract VincentUserFacetTest is Test {
 
         // Permit App 1 Version 1 for PKP 1 (Frank)
         vincentUserFacet.permitAppVersion(
-            PKP_TOKEN_ID_1,
-            newAppId_1,
-            newAppVersion_1,
-            toolIpfsCids,
-            policyIpfsCids,
-            policyParameterValues
+            PKP_TOKEN_ID_1, newAppId_1, newAppVersion_1, toolIpfsCids, policyIpfsCids, policyParameterValues
         );
 
         // Expect events for second permit
@@ -137,12 +132,7 @@ contract VincentUserFacetTest is Test {
 
         // Permit App 2 Version 1 for PKP 1 (Frank)
         vincentUserFacet.permitAppVersion(
-            PKP_TOKEN_ID_1,
-            newAppId_2,
-            newAppVersion_2,
-            toolIpfsCids,
-            policyIpfsCids,
-            policyParameterValues
+            PKP_TOKEN_ID_1, newAppId_2, newAppVersion_2, toolIpfsCids, policyIpfsCids, policyParameterValues
         );
         vm.stopPrank();
 
@@ -163,50 +153,46 @@ contract VincentUserFacetTest is Test {
 
         // Permit App 3 Version 1 for PKP 2 (George)
         vincentUserFacet.permitAppVersion(
-            PKP_TOKEN_ID_2,
-            newAppId_3,
-            newAppVersion_3,
-            toolIpfsCids,
-            policyIpfsCids,
-            policyParameterValues
+            PKP_TOKEN_ID_2, newAppId_3, newAppVersion_3, toolIpfsCids, policyIpfsCids, policyParameterValues
         );
         vm.stopPrank();
 
         // Check that Frank has registered PKP 1
-        uint256[] memory registeredAgentPkps = vincentUserViewFacet.getAllRegisteredAgentPkps(APP_USER_FRANK);
+        uint256[] memory registeredAgentPkps = vincentUserViewFacet.getRegisteredPkpsForAddress(APP_USER_FRANK);
         assertEq(registeredAgentPkps.length, 1);
         assertEq(registeredAgentPkps[0], PKP_TOKEN_ID_1);
 
         // Check that George has registered PKP 2
-        registeredAgentPkps = vincentUserViewFacet.getAllRegisteredAgentPkps(APP_USER_GEORGE);
+        registeredAgentPkps = vincentUserViewFacet.getRegisteredPkpsForAddress(APP_USER_GEORGE);
         assertEq(registeredAgentPkps.length, 1);
         assertEq(registeredAgentPkps[0], PKP_TOKEN_ID_2);
 
         // Check that Frank has permitted App 1 Version 1
-        uint256 permittedAppVersion = vincentUserViewFacet.getPermittedAppVersionForPkp(PKP_TOKEN_ID_1, newAppId_1);
+        uint256 permittedAppVersion = vincentUserViewFacet.getPermittedAppVersionForPkp(newAppId_1, PKP_TOKEN_ID_1);
         assertEq(permittedAppVersion, newAppVersion_1);
 
         // Check that Frank has permitted App 2 Version 1
-        permittedAppVersion = vincentUserViewFacet.getPermittedAppVersionForPkp(PKP_TOKEN_ID_1, newAppId_2);
+        permittedAppVersion = vincentUserViewFacet.getPermittedAppVersionForPkp(newAppId_2, PKP_TOKEN_ID_1);
         assertEq(permittedAppVersion, newAppVersion_2);
 
         // Check that George has permitted App 3 Version 1
-        permittedAppVersion = vincentUserViewFacet.getPermittedAppVersionForPkp(PKP_TOKEN_ID_2, newAppId_3);
+        permittedAppVersion = vincentUserViewFacet.getPermittedAppVersionForPkp(newAppId_3, PKP_TOKEN_ID_2);
         assertEq(permittedAppVersion, newAppVersion_3);
 
         // Check that Frank has permitted App 1 and App 2
-        uint256[] memory permittedAppIds = vincentUserViewFacet.getAllPermittedAppIdsForPkp(PKP_TOKEN_ID_1);
-        assertEq(permittedAppIds.length, 2);
-        assertEq(permittedAppIds[0], newAppId_1);
-        assertEq(permittedAppIds[1], newAppId_2);
+        VincentUserViewFacet.PermittedApp[] memory permittedApps = vincentUserViewFacet.getPermittedAppsForPkp(PKP_TOKEN_ID_1);
+        assertEq(permittedApps.length, 2);
+        assertEq(permittedApps[0].appId, newAppId_1);
+        assertEq(permittedApps[1].appId, newAppId_2);
 
         // Check that George has permitted App 3
-        permittedAppIds = vincentUserViewFacet.getAllPermittedAppIdsForPkp(PKP_TOKEN_ID_2);
-        assertEq(permittedAppIds.length, 1);
-        assertEq(permittedAppIds[0], newAppId_3);
+        permittedApps = vincentUserViewFacet.getPermittedAppsForPkp(PKP_TOKEN_ID_2);
+        assertEq(permittedApps.length, 1);
+        assertEq(permittedApps[0].appId, newAppId_3);
 
         // Check the Tool and Policies for App 1 Version 1 for PKP 1 (Frank)
-        VincentUserViewFacet.ToolWithPolicies[] memory toolsWithPolicies = vincentUserViewFacet.getAllToolsAndPoliciesForApp(PKP_TOKEN_ID_1, newAppId_1);
+        VincentUserViewFacet.ToolWithPolicies[] memory toolsWithPolicies =
+            vincentUserViewFacet.getPermittedToolsAndPoliciesForApp(newAppId_1, PKP_TOKEN_ID_1);
         assertEq(toolsWithPolicies.length, 2);
         assertEq(toolsWithPolicies[0].toolIpfsCid, TOOL_IPFS_CID_1);
         assertEq(toolsWithPolicies[0].policies.length, 1);
@@ -217,7 +203,7 @@ contract VincentUserFacetTest is Test {
         assertEq(toolsWithPolicies[1].policies.length, 0);
 
         // Check the Tool and Policies for App 2 Version 1 for PKP 1 (Frank)
-        toolsWithPolicies = vincentUserViewFacet.getAllToolsAndPoliciesForApp(PKP_TOKEN_ID_1, newAppId_2);
+        toolsWithPolicies = vincentUserViewFacet.getPermittedToolsAndPoliciesForApp(newAppId_2, PKP_TOKEN_ID_1);
         assertEq(toolsWithPolicies.length, 2);
         assertEq(toolsWithPolicies[0].toolIpfsCid, TOOL_IPFS_CID_1);
         assertEq(toolsWithPolicies[0].policies.length, 1);
@@ -225,58 +211,66 @@ contract VincentUserFacetTest is Test {
         assertEq(toolsWithPolicies[0].policies[0].policyParameterValues, POLICY_PARAMETER_VALUES_1);
 
         // Check the Tool and Policies for App 3 Version 1 for PKP 2 (George)
-        toolsWithPolicies = vincentUserViewFacet.getAllToolsAndPoliciesForApp(PKP_TOKEN_ID_2, newAppId_3);
+        toolsWithPolicies = vincentUserViewFacet.getPermittedToolsAndPoliciesForApp(newAppId_3, PKP_TOKEN_ID_2);
         assertEq(toolsWithPolicies.length, 2);
         assertEq(toolsWithPolicies[0].toolIpfsCid, TOOL_IPFS_CID_1);
         assertEq(toolsWithPolicies[0].policies.length, 1);
         assertEq(toolsWithPolicies[0].policies[0].policyIpfsCid, POLICY_IPFS_CID_1);
         assertEq(toolsWithPolicies[0].policies[0].policyParameterValues, POLICY_PARAMETER_VALUES_1);
 
-        VincentUserViewFacet.ToolExecutionValidation memory toolExecutionValidation = vincentUserViewFacet.validateToolExecutionAndGetPolicies(
-            APP_DELEGATEE_CHARLIE,
-            PKP_TOKEN_ID_1,
-            TOOL_IPFS_CID_1
-        );
-        assertTrue(toolExecutionValidation.isPermitted);
-        assertEq(toolExecutionValidation.appId, newAppId_1);
-        assertEq(toolExecutionValidation.appVersion, newAppVersion_1);
-        assertEq(toolExecutionValidation.policies.length, 1);
-        assertEq(toolExecutionValidation.policies[0].policyIpfsCid, POLICY_IPFS_CID_1);
-        assertEq(toolExecutionValidation.policies[0].policyParameterValues, POLICY_PARAMETER_VALUES_1);
+        VincentUserViewFacet.DelegateePermission memory delegateePermission;
+        bytes memory policyParameterValues_;
+        (delegateePermission, policyParameterValues_) = 
+            vincentUserViewFacet.getToolPolicyParameterValuesForPkp(APP_DELEGATEE_CHARLIE, PKP_TOKEN_ID_1, TOOL_IPFS_CID_1, POLICY_IPFS_CID_1);
+        assertEq(policyParameterValues_, POLICY_PARAMETER_VALUES_1);
 
-        toolExecutionValidation = vincentUserViewFacet.validateToolExecutionAndGetPolicies(
-            APP_DELEGATEE_CHARLIE,
-            PKP_TOKEN_ID_1,
-            TOOL_IPFS_CID_2
+        (delegateePermission, policyParameterValues_) = vincentUserViewFacet.getToolPolicyParameterValuesForPkp(
+            APP_DELEGATEE_DAVID, PKP_TOKEN_ID_1, TOOL_IPFS_CID_1, POLICY_IPFS_CID_1
         );
-        assertTrue(toolExecutionValidation.isPermitted);
-        assertEq(toolExecutionValidation.appId, newAppId_1);
-        assertEq(toolExecutionValidation.appVersion, newAppVersion_1);
-        assertEq(toolExecutionValidation.policies.length, 0);
+        assertEq(policyParameterValues_, POLICY_PARAMETER_VALUES_1);
 
-        toolExecutionValidation = vincentUserViewFacet.validateToolExecutionAndGetPolicies(
-            APP_DELEGATEE_DAVID,
-            PKP_TOKEN_ID_1,
-            TOOL_IPFS_CID_1
+        (delegateePermission, policyParameterValues_) = vincentUserViewFacet.getToolPolicyParameterValuesForPkp(
+            APP_DELEGATEE_EVE, PKP_TOKEN_ID_2, TOOL_IPFS_CID_1, POLICY_IPFS_CID_1
         );
-        assertTrue(toolExecutionValidation.isPermitted);
-        assertEq(toolExecutionValidation.appId, newAppId_2);
-        assertEq(toolExecutionValidation.appVersion, newAppVersion_2);
-        assertEq(toolExecutionValidation.policies.length, 1);
-        assertEq(toolExecutionValidation.policies[0].policyIpfsCid, POLICY_IPFS_CID_1);
-        assertEq(toolExecutionValidation.policies[0].policyParameterValues, POLICY_PARAMETER_VALUES_1);
+        assertEq(policyParameterValues_, POLICY_PARAMETER_VALUES_1);
 
-        toolExecutionValidation = vincentUserViewFacet.validateToolExecutionAndGetPolicies(
-            APP_DELEGATEE_EVE,
-            PKP_TOKEN_ID_2,
-            TOOL_IPFS_CID_1
+        VincentUserViewFacet.Policy[] memory policies;
+        (delegateePermission, policies) = 
+            vincentUserViewFacet.checkIsPermittedAndGetRegisteredPoliciesForTool(APP_DELEGATEE_CHARLIE, PKP_TOKEN_ID_1, TOOL_IPFS_CID_1);
+        assertTrue(delegateePermission.isPermitted);
+        assertEq(delegateePermission.appId, newAppId_1);
+        assertEq(delegateePermission.appVersion, newAppVersion_1);
+        assertEq(policies.length, 1);
+        assertEq(policies[0].policyIpfsCid, POLICY_IPFS_CID_1);
+        assertEq(policies[0].policyParameterValues, POLICY_PARAMETER_VALUES_1);
+
+        (delegateePermission, policies) = vincentUserViewFacet.checkIsPermittedAndGetRegisteredPoliciesForTool(
+            APP_DELEGATEE_CHARLIE, PKP_TOKEN_ID_1, TOOL_IPFS_CID_2
         );
-        assertTrue(toolExecutionValidation.isPermitted);
-        assertEq(toolExecutionValidation.appId, newAppId_3);
-        assertEq(toolExecutionValidation.appVersion, newAppVersion_3);
-        assertEq(toolExecutionValidation.policies.length, 1);
-        assertEq(toolExecutionValidation.policies[0].policyIpfsCid, POLICY_IPFS_CID_1);
-        assertEq(toolExecutionValidation.policies[0].policyParameterValues, POLICY_PARAMETER_VALUES_1);
+        assertTrue(delegateePermission.isPermitted);
+        assertEq(delegateePermission.appId, newAppId_1);
+        assertEq(delegateePermission.appVersion, newAppVersion_1);
+        assertEq(policies.length, 0);
+
+        (delegateePermission, policies) = vincentUserViewFacet.checkIsPermittedAndGetRegisteredPoliciesForTool(
+            APP_DELEGATEE_DAVID, PKP_TOKEN_ID_1, TOOL_IPFS_CID_1
+        );
+        assertTrue(delegateePermission.isPermitted);
+        assertEq(delegateePermission.appId, newAppId_2);
+        assertEq(delegateePermission.appVersion, newAppVersion_2);
+        assertEq(policies.length, 1);
+        assertEq(policies[0].policyIpfsCid, POLICY_IPFS_CID_1);
+        assertEq(policies[0].policyParameterValues, POLICY_PARAMETER_VALUES_1);
+
+        (delegateePermission, policies) = vincentUserViewFacet.checkIsPermittedAndGetRegisteredPoliciesForTool(
+            APP_DELEGATEE_EVE, PKP_TOKEN_ID_2, TOOL_IPFS_CID_1
+        );
+        assertTrue(delegateePermission.isPermitted);
+        assertEq(delegateePermission.appId, newAppId_3);
+        assertEq(delegateePermission.appVersion, newAppVersion_3);
+        assertEq(policies.length, 1);
+        assertEq(policies[0].policyIpfsCid, POLICY_IPFS_CID_1);
+        assertEq(policies[0].policyParameterValues, POLICY_PARAMETER_VALUES_1);
     }
 
     function testUnPermitAppVersion() public {
@@ -304,12 +298,7 @@ contract VincentUserFacetTest is Test {
 
         // Permit App 1 Version 1 for PKP 1 (Frank)
         vincentUserFacet.permitAppVersion(
-            PKP_TOKEN_ID_1,
-            newAppId_1,
-            newAppVersion_1,
-            toolIpfsCids,
-            policyIpfsCids,
-            policyParameterValues
+            PKP_TOKEN_ID_1, newAppId_1, newAppVersion_1, toolIpfsCids, policyIpfsCids, policyParameterValues
         );
 
         // Expect events for second permit
@@ -326,20 +315,15 @@ contract VincentUserFacetTest is Test {
 
         // Permit App 2 Version 1 for PKP 1 (Frank)
         vincentUserFacet.permitAppVersion(
-            PKP_TOKEN_ID_1,
-            newAppId_2,
-            newAppVersion_2,
-            toolIpfsCids,
-            policyIpfsCids,
-            policyParameterValues
+            PKP_TOKEN_ID_1, newAppId_2, newAppVersion_2, toolIpfsCids, policyIpfsCids, policyParameterValues
         );
         vm.stopPrank();
 
         // Verify initial state
-        uint256[] memory permittedAppIds = vincentUserViewFacet.getAllPermittedAppIdsForPkp(PKP_TOKEN_ID_1);
-        assertEq(permittedAppIds.length, 2);
-        assertEq(permittedAppIds[0], newAppId_1);
-        assertEq(permittedAppIds[1], newAppId_2);
+        VincentUserViewFacet.PermittedApp[] memory permittedApps = vincentUserViewFacet.getPermittedAppsForPkp(PKP_TOKEN_ID_1);
+        assertEq(permittedApps.length, 2);
+        assertEq(permittedApps[0].appId, newAppId_1);
+        assertEq(permittedApps[1].appId, newAppId_2);
 
         // Expect event for unpermit
         vm.startPrank(APP_USER_FRANK);
@@ -351,31 +335,26 @@ contract VincentUserFacetTest is Test {
         vm.stopPrank();
 
         // Verify App 1 is no longer permitted
-        uint256 permittedAppVersion = vincentUserViewFacet.getPermittedAppVersionForPkp(PKP_TOKEN_ID_1, newAppId_1);
+        uint256 permittedAppVersion = vincentUserViewFacet.getPermittedAppVersionForPkp(newAppId_1, PKP_TOKEN_ID_1);
         assertEq(permittedAppVersion, 0);
 
         // Verify App 2 is still permitted
-        permittedAppVersion = vincentUserViewFacet.getPermittedAppVersionForPkp(PKP_TOKEN_ID_1, newAppId_2);
+        permittedAppVersion = vincentUserViewFacet.getPermittedAppVersionForPkp(newAppId_2, PKP_TOKEN_ID_1);
         assertEq(permittedAppVersion, newAppVersion_2);
 
         // Verify permitted apps list is updated
-        permittedAppIds = vincentUserViewFacet.getAllPermittedAppIdsForPkp(PKP_TOKEN_ID_1);
-        assertEq(permittedAppIds.length, 1);
-        assertEq(permittedAppIds[0], newAppId_2);
+        permittedApps = vincentUserViewFacet.getPermittedAppsForPkp(PKP_TOKEN_ID_1);
+        assertEq(permittedApps.length, 1);
+        assertEq(permittedApps[0].appId, newAppId_2);
 
         // Verify tool execution validation for App 1 is no longer permitted
-        VincentUserViewFacet.ToolExecutionValidation memory toolExecutionValidation = vincentUserViewFacet.validateToolExecutionAndGetPolicies(
-            APP_DELEGATEE_CHARLIE,
-            PKP_TOKEN_ID_1,
-            TOOL_IPFS_CID_1
-        );
+        (VincentUserViewFacet.DelegateePermission memory toolExecutionValidation, VincentUserViewFacet.Policy[] memory policies) = 
+            vincentUserViewFacet.checkIsPermittedAndGetRegisteredPoliciesForTool(APP_DELEGATEE_CHARLIE, PKP_TOKEN_ID_1, TOOL_IPFS_CID_1);
         assertFalse(toolExecutionValidation.isPermitted);
 
         // Verify tool execution validation for App 2 is still permitted
-        toolExecutionValidation = vincentUserViewFacet.validateToolExecutionAndGetPolicies(
-            APP_DELEGATEE_DAVID,
-            PKP_TOKEN_ID_1,
-            TOOL_IPFS_CID_1
+        (toolExecutionValidation, policies) = vincentUserViewFacet.checkIsPermittedAndGetRegisteredPoliciesForTool(
+            APP_DELEGATEE_DAVID, PKP_TOKEN_ID_1, TOOL_IPFS_CID_1
         );
         assertTrue(toolExecutionValidation.isPermitted);
         assertEq(toolExecutionValidation.appId, newAppId_2);
@@ -404,19 +383,12 @@ contract VincentUserFacetTest is Test {
         );
 
         vincentUserFacet.permitAppVersion(
-            PKP_TOKEN_ID_1,
-            newAppId,
-            newAppVersion,
-            toolIpfsCids,
-            policyIpfsCids,
-            policyParameterValues
+            PKP_TOKEN_ID_1, newAppId, newAppVersion, toolIpfsCids, policyIpfsCids, policyParameterValues
         );
 
         // Verify initial policy parameters
-        VincentUserViewFacet.ToolWithPolicies[] memory toolsWithPolicies = vincentUserViewFacet.getAllToolsAndPoliciesForApp(
-            PKP_TOKEN_ID_1,
-            newAppId
-        );
+        VincentUserViewFacet.ToolWithPolicies[] memory toolsWithPolicies =
+            vincentUserViewFacet.getPermittedToolsAndPoliciesForApp(newAppId, PKP_TOKEN_ID_1);
         assertEq(toolsWithPolicies.length, 2);
         assertEq(toolsWithPolicies[0].policies.length, 1);
         assertEq(toolsWithPolicies[0].policies[0].policyParameterValues, POLICY_PARAMETER_VALUES_1);
@@ -439,34 +411,23 @@ contract VincentUserFacetTest is Test {
         );
 
         vincentUserFacet.setToolPolicyParameters(
-            PKP_TOKEN_ID_1,
-            newAppId,
-            newAppVersion,
-            toolIpfsCids,
-            policyIpfsCids,
-            newPolicyParameterValues
+            PKP_TOKEN_ID_1, newAppId, newAppVersion, toolIpfsCids, policyIpfsCids, newPolicyParameterValues
         );
         vm.stopPrank();
 
         // Verify updated policy parameters
-        toolsWithPolicies = vincentUserViewFacet.getAllToolsAndPoliciesForApp(
-            PKP_TOKEN_ID_1,
-            newAppId
-        );
+        toolsWithPolicies = vincentUserViewFacet.getPermittedToolsAndPoliciesForApp(newAppId, PKP_TOKEN_ID_1);
         assertEq(toolsWithPolicies.length, 2);
         assertEq(toolsWithPolicies[0].policies.length, 1);
         assertEq(toolsWithPolicies[0].policies[0].policyParameterValues, POLICY_PARAMETER_VALUES_2);
         assertEq(toolsWithPolicies[1].policies.length, 0);
 
         // Verify tool execution validation returns updated parameters
-        VincentUserViewFacet.ToolExecutionValidation memory toolExecutionValidation = vincentUserViewFacet.validateToolExecutionAndGetPolicies(
-            APP_DELEGATEE_CHARLIE,
-            PKP_TOKEN_ID_1,
-            TOOL_IPFS_CID_1
-        );
+        (VincentUserViewFacet.DelegateePermission memory toolExecutionValidation, VincentUserViewFacet.Policy[] memory policies) = 
+            vincentUserViewFacet.checkIsPermittedAndGetRegisteredPoliciesForTool(APP_DELEGATEE_CHARLIE, PKP_TOKEN_ID_1, TOOL_IPFS_CID_1);
         assertTrue(toolExecutionValidation.isPermitted);
-        assertEq(toolExecutionValidation.policies.length, 1);
-        assertEq(toolExecutionValidation.policies[0].policyParameterValues, POLICY_PARAMETER_VALUES_2);
+        assertEq(policies.length, 1);
+        assertEq(policies[0].policyParameterValues, POLICY_PARAMETER_VALUES_2);
     }
 
     function testRemoveToolPolicyParameters() public {
@@ -491,19 +452,12 @@ contract VincentUserFacetTest is Test {
         );
 
         vincentUserFacet.permitAppVersion(
-            PKP_TOKEN_ID_1,
-            newAppId,
-            newAppVersion,
-            toolIpfsCids,
-            policyIpfsCids,
-            policyParameterValues
+            PKP_TOKEN_ID_1, newAppId, newAppVersion, toolIpfsCids, policyIpfsCids, policyParameterValues
         );
 
         // Verify initial policy parameters
-        VincentUserViewFacet.ToolWithPolicies[] memory toolsWithPolicies = vincentUserViewFacet.getAllToolsAndPoliciesForApp(
-            PKP_TOKEN_ID_1,
-            newAppId
-        );
+        VincentUserViewFacet.ToolWithPolicies[] memory toolsWithPolicies =
+            vincentUserViewFacet.getPermittedToolsAndPoliciesForApp(newAppId, PKP_TOKEN_ID_1);
         assertEq(toolsWithPolicies.length, 2);
         assertEq(toolsWithPolicies[0].policies.length, 1);
         assertEq(toolsWithPolicies[0].policies[0].policyParameterValues, POLICY_PARAMETER_VALUES_1);
@@ -512,41 +466,28 @@ contract VincentUserFacetTest is Test {
         // Expect event for removing policy parameters
         vm.expectEmit(true, true, true, true);
         emit LibVincentUserFacet.ToolPolicyParametersRemoved(
-            PKP_TOKEN_ID_1,
-            newAppId,
-            newAppVersion,
-            keccak256(abi.encodePacked(TOOL_IPFS_CID_1))
+            PKP_TOKEN_ID_1, newAppId, newAppVersion, keccak256(abi.encodePacked(TOOL_IPFS_CID_1))
         );
 
         // Remove policy parameters
         vincentUserFacet.removeToolPolicyParameters(
-            newAppId,
-            PKP_TOKEN_ID_1,
-            newAppVersion,
-            toolIpfsCids,
-            policyIpfsCids
+            newAppId, PKP_TOKEN_ID_1, newAppVersion, toolIpfsCids, policyIpfsCids
         );
         vm.stopPrank();
 
         // Verify policy parameters are removed
-        toolsWithPolicies = vincentUserViewFacet.getAllToolsAndPoliciesForApp(
-            PKP_TOKEN_ID_1,
-            newAppId
-        );
+        toolsWithPolicies = vincentUserViewFacet.getPermittedToolsAndPoliciesForApp(newAppId, PKP_TOKEN_ID_1);
         assertEq(toolsWithPolicies.length, 2);
         assertEq(toolsWithPolicies[0].policies.length, 1);
         assertEq(toolsWithPolicies[0].policies[0].policyParameterValues, bytes("")); // Empty bytes after removal
         assertEq(toolsWithPolicies[1].policies.length, 0);
 
         // Verify tool execution validation returns empty parameters
-        VincentUserViewFacet.ToolExecutionValidation memory toolExecutionValidation = vincentUserViewFacet.validateToolExecutionAndGetPolicies(
-            APP_DELEGATEE_CHARLIE,
-            PKP_TOKEN_ID_1,
-            TOOL_IPFS_CID_1
-        );
+        (VincentUserViewFacet.DelegateePermission memory toolExecutionValidation, VincentUserViewFacet.Policy[] memory policies) = 
+            vincentUserViewFacet.checkIsPermittedAndGetRegisteredPoliciesForTool(APP_DELEGATEE_CHARLIE, PKP_TOKEN_ID_1, TOOL_IPFS_CID_1);
         assertTrue(toolExecutionValidation.isPermitted);
-        assertEq(toolExecutionValidation.policies.length, 1);
-        assertEq(toolExecutionValidation.policies[0].policyParameterValues, bytes("")); // Empty bytes after removal
+        assertEq(policies.length, 1);
+        assertEq(policies[0].policyParameterValues, bytes("")); // Empty bytes after removal
     }
 
     /**
@@ -564,12 +505,7 @@ contract VincentUserFacetTest is Test {
         vm.startPrank(APP_USER_FRANK);
         vm.expectRevert(abi.encodeWithSelector(VincentBase.AppHasBeenDeleted.selector, newAppId));
         vincentUserFacet.permitAppVersion(
-            PKP_TOKEN_ID_1,
-            newAppId,
-            newAppVersion,
-            toolIpfsCids,
-            policyIpfsCids,
-            policyParameterValues
+            PKP_TOKEN_ID_1, newAppId, newAppVersion, toolIpfsCids, policyIpfsCids, policyParameterValues
         );
     }
 
@@ -579,28 +515,18 @@ contract VincentUserFacetTest is Test {
         (uint256 newAppId, uint256 newAppVersion) = _registerBasicApp(delegatees);
 
         vm.startPrank(APP_USER_GEORGE);
-        vm.expectRevert(abi.encodeWithSelector(LibVincentUserFacet.NotPkpOwner.selector, PKP_TOKEN_ID_1, APP_USER_GEORGE));
+        vm.expectRevert(
+            abi.encodeWithSelector(LibVincentUserFacet.NotPkpOwner.selector, PKP_TOKEN_ID_1, APP_USER_GEORGE)
+        );
         vincentUserFacet.permitAppVersion(
-            PKP_TOKEN_ID_1,
-            newAppId,
-            newAppVersion,
-            toolIpfsCids,
-            policyIpfsCids,
-            policyParameterValues
+            PKP_TOKEN_ID_1, newAppId, newAppVersion, toolIpfsCids, policyIpfsCids, policyParameterValues
         );
     }
 
     function testPermitAppVersion_AppNotRegistered() public {
         vm.startPrank(APP_USER_FRANK);
         vm.expectRevert(abi.encodeWithSelector(VincentBase.AppNotRegistered.selector, 1));
-        vincentUserFacet.permitAppVersion(
-            PKP_TOKEN_ID_1,
-            1,
-            1,
-            toolIpfsCids,
-            policyIpfsCids,
-            policyParameterValues
-        );
+        vincentUserFacet.permitAppVersion(PKP_TOKEN_ID_1, 1, 1, toolIpfsCids, policyIpfsCids, policyParameterValues);
     }
 
     function testPermitAppVersion_AppVersionNotRegistered() public {
@@ -609,7 +535,9 @@ contract VincentUserFacetTest is Test {
         (uint256 newAppId, uint256 newAppVersion) = _registerBasicApp(delegatees);
 
         vm.startPrank(APP_USER_FRANK);
-        vm.expectRevert(abi.encodeWithSelector(VincentBase.AppVersionNotRegistered.selector, newAppId, newAppVersion + 1));
+        vm.expectRevert(
+            abi.encodeWithSelector(VincentBase.AppVersionNotRegistered.selector, newAppId, newAppVersion + 1)
+        );
         vincentUserFacet.permitAppVersion(
             PKP_TOKEN_ID_1,
             newAppId,
@@ -639,12 +567,7 @@ contract VincentUserFacetTest is Test {
         vm.startPrank(APP_USER_FRANK);
         vm.expectRevert(abi.encodeWithSelector(LibVincentUserFacet.ToolsAndPoliciesLengthMismatch.selector));
         vincentUserFacet.permitAppVersion(
-            PKP_TOKEN_ID_1,
-            newAppId,
-            newAppVersion,
-            toolIpfsCids,
-            _policyIpfsCids,
-            _policyParameterValues
+            PKP_TOKEN_ID_1, newAppId, newAppVersion, toolIpfsCids, _policyIpfsCids, _policyParameterValues
         );
     }
 
@@ -656,23 +579,17 @@ contract VincentUserFacetTest is Test {
         // First permit the app version
         vm.startPrank(APP_USER_FRANK);
         vincentUserFacet.permitAppVersion(
-            PKP_TOKEN_ID_1,
-            newAppId,
-            newAppVersion,
-            toolIpfsCids,
-            policyIpfsCids,
-            policyParameterValues
+            PKP_TOKEN_ID_1, newAppId, newAppVersion, toolIpfsCids, policyIpfsCids, policyParameterValues
         );
 
         // Try to permit the same version again
-        vm.expectRevert(abi.encodeWithSelector(LibVincentUserFacet.AppVersionAlreadyPermitted.selector, PKP_TOKEN_ID_1, newAppId, newAppVersion));
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                LibVincentUserFacet.AppVersionAlreadyPermitted.selector, PKP_TOKEN_ID_1, newAppId, newAppVersion
+            )
+        );
         vincentUserFacet.permitAppVersion(
-            PKP_TOKEN_ID_1,
-            newAppId,
-            newAppVersion,
-            toolIpfsCids,
-            policyIpfsCids,
-            policyParameterValues
+            PKP_TOKEN_ID_1, newAppId, newAppVersion, toolIpfsCids, policyIpfsCids, policyParameterValues
         );
     }
 
@@ -686,14 +603,11 @@ contract VincentUserFacetTest is Test {
         vm.stopPrank();
 
         vm.startPrank(APP_USER_FRANK);
-        vm.expectRevert(abi.encodeWithSelector(LibVincentUserFacet.AppVersionNotEnabled.selector, newAppId, newAppVersion));
+        vm.expectRevert(
+            abi.encodeWithSelector(LibVincentUserFacet.AppVersionNotEnabled.selector, newAppId, newAppVersion)
+        );
         vincentUserFacet.permitAppVersion(
-            PKP_TOKEN_ID_1,
-            newAppId,
-            newAppVersion,
-            toolIpfsCids,
-            policyIpfsCids,
-            policyParameterValues
+            PKP_TOKEN_ID_1, newAppId, newAppVersion, toolIpfsCids, policyIpfsCids, policyParameterValues
         );
     }
 
@@ -715,14 +629,11 @@ contract VincentUserFacetTest is Test {
         _policyParameterValues[0][0] = POLICY_PARAMETER_VALUES_1;
 
         vm.startPrank(APP_USER_FRANK);
-        vm.expectRevert(abi.encodeWithSelector(LibVincentUserFacet.NotAllRegisteredToolsProvided.selector, newAppId, newAppVersion));
+        vm.expectRevert(
+            abi.encodeWithSelector(LibVincentUserFacet.NotAllRegisteredToolsProvided.selector, newAppId, newAppVersion)
+        );
         vincentUserFacet.permitAppVersion(
-            PKP_TOKEN_ID_1,
-            newAppId,
-            newAppVersion,
-            _toolIpfsCids,
-            _policyIpfsCids,
-            _policyParameterValues
+            PKP_TOKEN_ID_1, newAppId, newAppVersion, _toolIpfsCids, _policyIpfsCids, _policyParameterValues
         );
     }
 
@@ -737,14 +648,13 @@ contract VincentUserFacetTest is Test {
         _toolIpfsCids[1] = TOOL_IPFS_CID_3; // This tool is not registered for the app version
 
         vm.startPrank(APP_USER_FRANK);
-        vm.expectRevert(abi.encodeWithSelector(LibVincentUserFacet.ToolNotRegisteredForAppVersion.selector, newAppId, newAppVersion, TOOL_IPFS_CID_3));
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                LibVincentUserFacet.ToolNotRegisteredForAppVersion.selector, newAppId, newAppVersion, TOOL_IPFS_CID_3
+            )
+        );
         vincentUserFacet.permitAppVersion(
-            PKP_TOKEN_ID_1,
-            newAppId,
-            newAppVersion,
-            _toolIpfsCids,
-            policyIpfsCids,
-            policyParameterValues
+            PKP_TOKEN_ID_1, newAppId, newAppVersion, _toolIpfsCids, policyIpfsCids, policyParameterValues
         );
     }
 
@@ -758,17 +668,14 @@ contract VincentUserFacetTest is Test {
 
         vm.startPrank(APP_USER_FRANK);
         vincentUserFacet.permitAppVersion(
-            PKP_TOKEN_ID_1,
-            newAppId,
-            newAppVersion,
-            toolIpfsCids,
-            policyIpfsCids,
-            policyParameterValues
+            PKP_TOKEN_ID_1, newAppId, newAppVersion, toolIpfsCids, policyIpfsCids, policyParameterValues
         );
         vm.stopPrank();
 
         vm.startPrank(APP_DELEGATEE_CHARLIE);
-        vm.expectRevert(abi.encodeWithSelector(LibVincentUserFacet.NotPkpOwner.selector, PKP_TOKEN_ID_1, APP_DELEGATEE_CHARLIE));
+        vm.expectRevert(
+            abi.encodeWithSelector(LibVincentUserFacet.NotPkpOwner.selector, PKP_TOKEN_ID_1, APP_DELEGATEE_CHARLIE)
+        );
         vincentUserFacet.unPermitAppVersion(PKP_TOKEN_ID_1, newAppId, newAppVersion);
     }
 
@@ -784,7 +691,9 @@ contract VincentUserFacetTest is Test {
         (uint256 newAppId, uint256 newAppVersion) = _registerBasicApp(delegatees);
 
         vm.startPrank(APP_USER_FRANK);
-        vm.expectRevert(abi.encodeWithSelector(VincentBase.AppVersionNotRegistered.selector, newAppId, newAppVersion + 1));
+        vm.expectRevert(
+            abi.encodeWithSelector(VincentBase.AppVersionNotRegistered.selector, newAppId, newAppVersion + 1)
+        );
         vincentUserFacet.unPermitAppVersion(PKP_TOKEN_ID_1, newAppId, newAppVersion + 1);
     }
 
@@ -794,7 +703,11 @@ contract VincentUserFacetTest is Test {
         (uint256 newAppId, uint256 newAppVersion) = _registerBasicApp(delegatees);
 
         vm.startPrank(APP_USER_FRANK);
-        vm.expectRevert(abi.encodeWithSelector(LibVincentUserFacet.AppVersionNotPermitted.selector, PKP_TOKEN_ID_1, newAppId, newAppVersion));
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                LibVincentUserFacet.AppVersionNotPermitted.selector, PKP_TOKEN_ID_1, newAppId, newAppVersion
+            )
+        );
         vincentUserFacet.unPermitAppVersion(PKP_TOKEN_ID_1, newAppId, newAppVersion);
     }
 
@@ -808,24 +721,16 @@ contract VincentUserFacetTest is Test {
 
         vm.startPrank(APP_USER_FRANK);
         vincentUserFacet.permitAppVersion(
-            PKP_TOKEN_ID_1,
-            newAppId,
-            newAppVersion,
-            toolIpfsCids,
-            policyIpfsCids,
-            policyParameterValues
+            PKP_TOKEN_ID_1, newAppId, newAppVersion, toolIpfsCids, policyIpfsCids, policyParameterValues
         );
         vm.stopPrank();
 
         vm.startPrank(APP_USER_GEORGE);
-        vm.expectRevert(abi.encodeWithSelector(LibVincentUserFacet.NotPkpOwner.selector, PKP_TOKEN_ID_1, APP_USER_GEORGE));
+        vm.expectRevert(
+            abi.encodeWithSelector(LibVincentUserFacet.NotPkpOwner.selector, PKP_TOKEN_ID_1, APP_USER_GEORGE)
+        );
         vincentUserFacet.setToolPolicyParameters(
-            PKP_TOKEN_ID_1,
-            newAppId,
-            newAppVersion,
-            toolIpfsCids,
-            policyIpfsCids,
-            policyParameterValues
+            PKP_TOKEN_ID_1, newAppId, newAppVersion, toolIpfsCids, policyIpfsCids, policyParameterValues
         );
     }
 
@@ -833,12 +738,7 @@ contract VincentUserFacetTest is Test {
         vm.startPrank(APP_USER_FRANK);
         vm.expectRevert(abi.encodeWithSelector(VincentBase.AppNotRegistered.selector, 1));
         vincentUserFacet.setToolPolicyParameters(
-            PKP_TOKEN_ID_1,
-            1,
-            1,
-            toolIpfsCids,
-            policyIpfsCids,
-            policyParameterValues
+            PKP_TOKEN_ID_1, 1, 1, toolIpfsCids, policyIpfsCids, policyParameterValues
         );
     }
 
@@ -848,7 +748,9 @@ contract VincentUserFacetTest is Test {
         (uint256 newAppId, uint256 newAppVersion) = _registerBasicApp(delegatees);
 
         vm.startPrank(APP_USER_FRANK);
-        vm.expectRevert(abi.encodeWithSelector(VincentBase.AppVersionNotRegistered.selector, newAppId, newAppVersion + 1));
+        vm.expectRevert(
+            abi.encodeWithSelector(VincentBase.AppVersionNotRegistered.selector, newAppId, newAppVersion + 1)
+        );
         vincentUserFacet.setToolPolicyParameters(
             PKP_TOKEN_ID_1,
             newAppId,
@@ -867,12 +769,7 @@ contract VincentUserFacetTest is Test {
         // First permit the app version with valid parameters
         vm.startPrank(APP_USER_FRANK);
         vincentUserFacet.permitAppVersion(
-            PKP_TOKEN_ID_1,
-            newAppId,
-            newAppVersion,
-            toolIpfsCids,
-            policyIpfsCids,
-            policyParameterValues
+            PKP_TOKEN_ID_1, newAppId, newAppVersion, toolIpfsCids, policyIpfsCids, policyParameterValues
         );
 
         // Now try to set parameters with an empty tool IPFS CIDs array
@@ -880,12 +777,7 @@ contract VincentUserFacetTest is Test {
 
         vm.expectRevert(abi.encodeWithSelector(LibVincentUserFacet.InvalidInput.selector));
         vincentUserFacet.setToolPolicyParameters(
-            PKP_TOKEN_ID_1,
-            newAppId,
-            newAppVersion,
-            emptyToolIpfsCids,
-            policyIpfsCids,
-            policyParameterValues
+            PKP_TOKEN_ID_1, newAppId, newAppVersion, emptyToolIpfsCids, policyIpfsCids, policyParameterValues
         );
     }
 
@@ -897,12 +789,7 @@ contract VincentUserFacetTest is Test {
         // First permit the app version with valid parameters
         vm.startPrank(APP_USER_FRANK);
         vincentUserFacet.permitAppVersion(
-            PKP_TOKEN_ID_1,
-            newAppId,
-            newAppVersion,
-            toolIpfsCids,
-            policyIpfsCids,
-            policyParameterValues
+            PKP_TOKEN_ID_1, newAppId, newAppVersion, toolIpfsCids, policyIpfsCids, policyParameterValues
         );
 
         // Create arrays with an empty tool IPFS CID
@@ -910,14 +797,9 @@ contract VincentUserFacetTest is Test {
         _toolIpfsCids[0] = ""; // Empty string for first tool
         _toolIpfsCids[1] = TOOL_IPFS_CID_2;
 
-        vm.expectRevert(abi.encodeWithSelector(VincentUserViewFacet.EmptyToolIpfsCid.selector));
+        vm.expectRevert(abi.encodeWithSelector(LibVincentUserFacet.EmptyToolIpfsCid.selector));
         vincentUserFacet.setToolPolicyParameters(
-            PKP_TOKEN_ID_1,
-            newAppId,
-            newAppVersion,
-            _toolIpfsCids,
-            policyIpfsCids,
-            policyParameterValues
+            PKP_TOKEN_ID_1, newAppId, newAppVersion, _toolIpfsCids, policyIpfsCids, policyParameterValues
         );
     }
 
@@ -929,12 +811,7 @@ contract VincentUserFacetTest is Test {
         // First permit the app version with valid parameters
         vm.startPrank(APP_USER_FRANK);
         vincentUserFacet.permitAppVersion(
-            PKP_TOKEN_ID_1,
-            newAppId,
-            newAppVersion,
-            toolIpfsCids,
-            policyIpfsCids,
-            policyParameterValues
+            PKP_TOKEN_ID_1, newAppId, newAppVersion, toolIpfsCids, policyIpfsCids, policyParameterValues
         );
 
         // Create arrays with only one tool instead of both registered tools
@@ -949,14 +826,11 @@ contract VincentUserFacetTest is Test {
         _policyParameterValues[0] = new bytes[](1);
         _policyParameterValues[0][0] = POLICY_PARAMETER_VALUES_1;
 
-        vm.expectRevert(abi.encodeWithSelector(LibVincentUserFacet.NotAllRegisteredToolsProvided.selector, newAppId, newAppVersion));
+        vm.expectRevert(
+            abi.encodeWithSelector(LibVincentUserFacet.NotAllRegisteredToolsProvided.selector, newAppId, newAppVersion)
+        );
         vincentUserFacet.setToolPolicyParameters(
-            PKP_TOKEN_ID_1,
-            newAppId,
-            newAppVersion,
-            _toolIpfsCids,
-            _policyIpfsCids,
-            _policyParameterValues
+            PKP_TOKEN_ID_1, newAppId, newAppVersion, _toolIpfsCids, _policyIpfsCids, _policyParameterValues
         );
     }
 
@@ -968,12 +842,7 @@ contract VincentUserFacetTest is Test {
         // First permit the app version with valid parameters
         vm.startPrank(APP_USER_FRANK);
         vincentUserFacet.permitAppVersion(
-            PKP_TOKEN_ID_1,
-            newAppId,
-            newAppVersion,
-            toolIpfsCids,
-            policyIpfsCids,
-            policyParameterValues
+            PKP_TOKEN_ID_1, newAppId, newAppVersion, toolIpfsCids, policyIpfsCids, policyParameterValues
         );
 
         // Create arrays with an unregistered policy (POLICY_IPFS_CID_3)
@@ -997,12 +866,7 @@ contract VincentUserFacetTest is Test {
             )
         );
         vincentUserFacet.setToolPolicyParameters(
-            PKP_TOKEN_ID_1,
-            newAppId,
-            newAppVersion,
-            toolIpfsCids,
-            _policyIpfsCids,
-            _policyParameterValues
+            PKP_TOKEN_ID_1, newAppId, newAppVersion, toolIpfsCids, _policyIpfsCids, _policyParameterValues
         );
     }
 
@@ -1016,36 +880,23 @@ contract VincentUserFacetTest is Test {
 
         vm.startPrank(APP_USER_FRANK);
         vincentUserFacet.permitAppVersion(
-            PKP_TOKEN_ID_1,
-            newAppId,
-            newAppVersion,
-            toolIpfsCids,
-            policyIpfsCids,
-            policyParameterValues
+            PKP_TOKEN_ID_1, newAppId, newAppVersion, toolIpfsCids, policyIpfsCids, policyParameterValues
         );
         vm.stopPrank();
 
         vm.startPrank(APP_DELEGATEE_CHARLIE);
-        vm.expectRevert(abi.encodeWithSelector(LibVincentUserFacet.NotPkpOwner.selector, PKP_TOKEN_ID_1, APP_DELEGATEE_CHARLIE));
+        vm.expectRevert(
+            abi.encodeWithSelector(LibVincentUserFacet.NotPkpOwner.selector, PKP_TOKEN_ID_1, APP_DELEGATEE_CHARLIE)
+        );
         vincentUserFacet.removeToolPolicyParameters(
-            newAppId,
-            PKP_TOKEN_ID_1,
-            newAppVersion,
-            toolIpfsCids,
-            policyIpfsCids
+            newAppId, PKP_TOKEN_ID_1, newAppVersion, toolIpfsCids, policyIpfsCids
         );
     }
 
     function testRemoveToolPolicyParameters_AppNotRegistered() public {
         vm.startPrank(APP_USER_FRANK);
         vm.expectRevert(abi.encodeWithSelector(VincentBase.AppNotRegistered.selector, 1));
-        vincentUserFacet.removeToolPolicyParameters(
-            1,
-            PKP_TOKEN_ID_1,
-            1,
-            toolIpfsCids,
-            policyIpfsCids
-        );
+        vincentUserFacet.removeToolPolicyParameters(1, PKP_TOKEN_ID_1, 1, toolIpfsCids, policyIpfsCids);
     }
 
     function testRemoveToolPolicyParameters_AppVersionNotRegistered() public {
@@ -1054,7 +905,9 @@ contract VincentUserFacetTest is Test {
         (uint256 newAppId, uint256 newAppVersion) = _registerBasicApp(delegatees);
 
         vm.startPrank(APP_USER_FRANK);
-        vm.expectRevert(abi.encodeWithSelector(VincentBase.AppVersionNotRegistered.selector, newAppId, newAppVersion + 1));
+        vm.expectRevert(
+            abi.encodeWithSelector(VincentBase.AppVersionNotRegistered.selector, newAppId, newAppVersion + 1)
+        );
         vincentUserFacet.removeToolPolicyParameters(
             newAppId,
             PKP_TOKEN_ID_1,
@@ -1072,12 +925,7 @@ contract VincentUserFacetTest is Test {
         // First permit the app version with valid parameters
         vm.startPrank(APP_USER_FRANK);
         vincentUserFacet.permitAppVersion(
-            PKP_TOKEN_ID_1,
-            newAppId,
-            newAppVersion,
-            toolIpfsCids,
-            policyIpfsCids,
-            policyParameterValues
+            PKP_TOKEN_ID_1, newAppId, newAppVersion, toolIpfsCids, policyIpfsCids, policyParameterValues
         );
 
         // Now try to set parameters with an empty tool IPFS CIDs array
@@ -1085,11 +933,7 @@ contract VincentUserFacetTest is Test {
 
         vm.expectRevert(abi.encodeWithSelector(LibVincentUserFacet.InvalidInput.selector));
         vincentUserFacet.removeToolPolicyParameters(
-            PKP_TOKEN_ID_1,
-            newAppId,
-            newAppVersion,
-            emptyToolIpfsCids,
-            policyIpfsCids
+            PKP_TOKEN_ID_1, newAppId, newAppVersion, emptyToolIpfsCids, policyIpfsCids
         );
     }
 
@@ -1101,12 +945,7 @@ contract VincentUserFacetTest is Test {
         // First permit the app version with valid parameters
         vm.startPrank(APP_USER_FRANK);
         vincentUserFacet.permitAppVersion(
-            PKP_TOKEN_ID_1,
-            newAppId,
-            newAppVersion,
-            toolIpfsCids,
-            policyIpfsCids,
-            policyParameterValues
+            PKP_TOKEN_ID_1, newAppId, newAppVersion, toolIpfsCids, policyIpfsCids, policyParameterValues
         );
 
         // Create arrays with an empty tool IPFS CID
@@ -1114,13 +953,9 @@ contract VincentUserFacetTest is Test {
         _toolIpfsCids[0] = ""; // Empty string for first tool
         _toolIpfsCids[1] = TOOL_IPFS_CID_2;
 
-        vm.expectRevert(abi.encodeWithSelector(VincentUserViewFacet.EmptyToolIpfsCid.selector));
+        vm.expectRevert(abi.encodeWithSelector(LibVincentUserFacet.EmptyToolIpfsCid.selector));
         vincentUserFacet.removeToolPolicyParameters(
-            PKP_TOKEN_ID_1,
-            newAppId,
-            newAppVersion,
-            _toolIpfsCids,
-            policyIpfsCids
+            PKP_TOKEN_ID_1, newAppId, newAppVersion, _toolIpfsCids, policyIpfsCids
         );
     }
 
@@ -1132,12 +967,7 @@ contract VincentUserFacetTest is Test {
         // First permit the app version with valid parameters
         vm.startPrank(APP_USER_FRANK);
         vincentUserFacet.permitAppVersion(
-            PKP_TOKEN_ID_1,
-            newAppId,
-            newAppVersion,
-            toolIpfsCids,
-            policyIpfsCids,
-            policyParameterValues
+            PKP_TOKEN_ID_1, newAppId, newAppVersion, toolIpfsCids, policyIpfsCids, policyParameterValues
         );
 
         // Create arrays with an unregistered policy (POLICY_IPFS_CID_3)
@@ -1156,18 +986,14 @@ contract VincentUserFacetTest is Test {
             )
         );
         vincentUserFacet.removeToolPolicyParameters(
-            newAppId,
-            PKP_TOKEN_ID_1,
-            newAppVersion,
-            toolIpfsCids,
-            _policyIpfsCids
+            newAppId, PKP_TOKEN_ID_1, newAppVersion, toolIpfsCids, _policyIpfsCids
         );
     }
 
-    function _registerApp(
-        address[] memory delegatees,
-        VincentAppFacet.AppVersionTools memory versionTools
-    ) private returns (uint256, uint256) {
+    function _registerApp(address[] memory delegatees, VincentAppFacet.AppVersionTools memory versionTools)
+        private
+        returns (uint256, uint256)
+    {
         vm.startPrank(APP_MANAGER_ALICE);
         (uint256 newAppId, uint256 newAppVersion) = vincentAppFacet.registerApp(delegatees, versionTools);
         vm.stopPrank();
@@ -1195,7 +1021,7 @@ contract VincentUserFacetTest is Test {
         versionTools.toolPolicyParameterMetadata[0][0] = POLICY_PARAMETER_METADATA_1;
 
         versionTools.toolPolicyParameterMetadata[1] = new bytes[](0);
-        
+
         (newAppId, newAppVersion) = _registerApp(delegatees, versionTools);
     }
 }


### PR DESCRIPTION
- Renamed functions
- Deduped code
- Add new functions to better fit what's needed by the new Tool/Policy handlers
    - Before we used to have a single method that returned all the policies and policy parameters for a tool, now we have two separate methods:
        - `checkIsPermittedAndGetRegisteredPoliciesForTool` which will check if the delegatee is permitted to execute the tool using the PKP, as well as providing all the IPFS CIDs for the registered policies for that tool
        - `getToolPolicyParameterValuesForPkp` which will only return if the delegatee is permitted to execute the policy using the PKP and the specific policy parameters for the executing policy (so the policy no longer has to filter out it's parameters from all the other policies)