### PR TITLE
Release V0.0.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "@lit-protocol/misc": "^7.0.8",
     "@lit-protocol/pkp-ethers": "^7.0.8",
     "@lit-protocol/types": "^7.0.8",
-    "@lit-protocol/vincent-sdk": "0.0.6",
+    "@lit-protocol/vincent-sdk": "0.0.7",
     "bs58": "^6.0.0",
     "ethers": "5.7.2",
     "viem": "^2.28.0",

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -36,6 +36,7 @@
   "dependencies": {
     "@lit-protocol/constants": "^7.1.1",
     "@lit-protocol/contracts-sdk": "^7.1.1",
+    "@lit-protocol/vincent-sdk": "0.0.7",
     "@modelcontextprotocol/sdk": "^1.11.2",
     "@t3-oss/env-core": "^0.13.4",
     "ethers": "^5.8.0",

--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -1,0 +1,53 @@
+## 0.0.7 (2025-05-26)
+
+### 🚀 Features
+
+- improved mcp api doc ([0389014](https://github.com/LIT-Protocol/Vincent/commit/0389014))
+- updated Vincent MCP documentation with its own section ([3457891](https://github.com/LIT-Protocol/Vincent/commit/3457891))
+- add documentation ([f539eb5](https://github.com/LIT-Protocol/Vincent/commit/f539eb5))
+- implementation of the vincent mcp server stdio and http runners using the app to mcp transformer in the sdk ([aa58c17](https://github.com/LIT-Protocol/Vincent/commit/aa58c17))
+- implementation of the vincent app mcp wrapper ([02dd8ca](https://github.com/LIT-Protocol/Vincent/commit/02dd8ca))
+- add release script to release SDK and its doc to npm and vercel ([eaccd5f](https://github.com/LIT-Protocol/Vincent/commit/eaccd5f))
+- **docs:** change title, downgrade for plugin extras ([cdd62c0](https://github.com/LIT-Protocol/Vincent/commit/cdd62c0))
+- use standard syntax for jwt validation errors and move validation to decoding step ([fefbbc6](https://github.com/LIT-Protocol/Vincent/commit/fefbbc6))
+- deduplicate vincent data in decoded jwt and revert building config changes ([481d131](https://github.com/LIT-Protocol/Vincent/commit/481d131))
+- change ts compiler config to increase compatibility surface and fix usage in DCA FE vite app ([027582d](https://github.com/LIT-Protocol/Vincent/commit/027582d))
+- add authorized app and user info to jwt ([237f70d](https://github.com/LIT-Protocol/Vincent/commit/237f70d))
+- **vincent-sdk:** add Express authentication helpers and update docs ([14a04b3](https://github.com/LIT-Protocol/Vincent/commit/14a04b3))
+- **vincent-sdk:** Update README.md ([d052e18](https://github.com/LIT-Protocol/Vincent/commit/d052e18))
+- **vincent-sdk:** Add sdk-docs TypeDocs to root of repo ([fb15599](https://github.com/LIT-Protocol/Vincent/commit/fb15599))
+- **vincent-sdk:** Return both the original JWT string and the decoded JWT object from `decodeVincentLoginJWT()` - Also fixed inverted logic check for `isLoginUri()`, and converted to object params for `isLoginUri()` ([c2f3a19](https://github.com/LIT-Protocol/Vincent/commit/c2f3a19))
+- **vincent-sdk:** Add `removeLoginJWTFromURI()` method to `VincentWebAppClient` ([17072f4](https://github.com/LIT-Protocol/Vincent/commit/17072f4))
+- **vincent-sdk:** Replace `pkp/delegatee-sigs` with a `VincentToolClient` - Exposes a single method, `getVincentToolClient()`, which Vincent app developers will use to interact with Vincent Tool LIT actions - Fixes existing code that created new instances of LitNodeClient and connecting to them every time the tool is interacted with, using newly minted singleton module - Initial TSDoc configurations for exposing the tool client construction and usage under a 'Vincent Tools' category. ([2052ebe](https://github.com/LIT-Protocol/Vincent/commit/2052ebe))
+- **vincent-sdk:** Define an internal module for managing a singleton instance of a LitNodeClient ([d297b0c](https://github.com/LIT-Protocol/Vincent/commit/d297b0c))
+- update vincent sdk readme ([090614d](https://github.com/LIT-Protocol/Vincent/commit/090614d))
+- added contracts class ([ef1851e](https://github.com/LIT-Protocol/Vincent/commit/ef1851e))
+
+### 🩹 Fixes
+
+- ZodSchemmaMap typo ([095f38e](https://github.com/LIT-Protocol/Vincent/commit/095f38e))
+- doc reference ([b1450f8](https://github.com/LIT-Protocol/Vincent/commit/b1450f8))
+- remove unnecessary type annotation ([c71eeac](https://github.com/LIT-Protocol/Vincent/commit/c71eeac))
+- sdk nx project linting tool ([82dd819](https://github.com/LIT-Protocol/Vincent/commit/82dd819))
+- **docs:** rename (remove API) ([a4b8e83](https://github.com/LIT-Protocol/Vincent/commit/a4b8e83))
+- **docs:** formatting fixes, custom css for :::info ([6f2fcef](https://github.com/LIT-Protocol/Vincent/commit/6f2fcef))
+- **vincent-sdk:** Fix import of `JWT_ERROR` to import from root of `did-jwt` package ([dd96111](https://github.com/LIT-Protocol/Vincent/commit/dd96111))
+- do not export simple jwt manipulating functions. Consumers should use the sdk directly ([6e46eee](https://github.com/LIT-Protocol/Vincent/commit/6e46eee))
+- **publish:** need to include 'dist' ([ecf38c3](https://github.com/LIT-Protocol/Vincent/commit/ecf38c3))
+- **sdk:** package.json exports ([dd35563](https://github.com/LIT-Protocol/Vincent/commit/dd35563))
+- no need types node ([af98c0e](https://github.com/LIT-Protocol/Vincent/commit/af98c0e))
+- **build:** add missing tsconfig.lib.json ([ce47c23](https://github.com/LIT-Protocol/Vincent/commit/ce47c23))
+- **jest:** enable `passWithNoTests` ([0f4ac57](https://github.com/LIT-Protocol/Vincent/commit/0f4ac57))
+- lint and any ([c4fc2ab](https://github.com/LIT-Protocol/Vincent/commit/c4fc2ab))
+- **deps:** correctly scope dependencies between global & individual packages ([b3fdb8c](https://github.com/LIT-Protocol/Vincent/commit/b3fdb8c))
+- **build:** remove rollup and use default nx settings ([b3769df](https://github.com/LIT-Protocol/Vincent/commit/b3769df))
+- minor changes ([0a70d4a](https://github.com/LIT-Protocol/Vincent/commit/0a70d4a))
+- removed umd build ([6e532fa](https://github.com/LIT-Protocol/Vincent/commit/6e532fa))
+
+### ❤️ Thank You
+
+- Ansh Saxena @anshss
+- Anson
+- awisniew207 @awisniew207
+- Daryl Collins
+- FedericoAmura @FedericoAmura

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lit-protocol/vincent-sdk",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "description": "Vincent SDK for browser and backend",
   "author": "Lit Protocol",
   "license": "ISC",

--- a/packages/sdk/project.json
+++ b/packages/sdk/project.json
@@ -8,7 +8,7 @@
       "executor": "nx:run-commands",
       "options": {
         "commands": [
-          "pnpm typedoc",
+          "pnpm typedoc --skipErrorChecking",
           "mkdir ./sdk-docs/.vercel",
           "printf '{\"projectId\": \"%s\", \"orgId\": \"%s\"}\\n' \"$SDK_DOCS_VERCEL_PROJECT_ID\" \"$SDK_DOCS_VERCEL_ORG_ID\" > ./sdk-docs/.vercel/project.json\n",
           "pnpm dotenvx run -- vercel --prod --cwd=./sdk-docs --yes",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -45,8 +45,8 @@ importers:
         specifier: ^7.0.8
         version: 7.1.1(bufferutil@4.0.9)(utf-8-validate@5.0.10)
       '@lit-protocol/vincent-sdk':
-        specifier: 0.0.6
-        version: 0.0.6(@walletconnect/modal@2.7.0(@types/react@19.1.2)(react@19.1.0))(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)
+        specifier: 0.0.7
+        version: 0.0.7(@modelcontextprotocol/sdk@1.11.4)(@walletconnect/modal@2.7.0(@types/react@19.1.2)(react@19.1.0))(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)
       bs58:
         specifier: ^6.0.0
         version: 6.0.0
@@ -316,6 +316,9 @@ importers:
       '@lit-protocol/contracts-sdk':
         specifier: ^7.1.1
         version: 7.1.1(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)
+      '@lit-protocol/vincent-sdk':
+        specifier: 0.0.7
+        version: 0.0.7(@modelcontextprotocol/sdk@1.11.4)(@walletconnect/modal@2.7.0(@types/react@19.1.2)(react@19.1.0))(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)
       '@modelcontextprotocol/sdk':
         specifier: ^1.11.2
         version: 1.11.4
@@ -1936,9 +1939,11 @@ packages:
   '@lit-protocol/vincent-contracts@0.1.1-4':
     resolution: {integrity: sha512-rAEH26hbDfAKOOkZ9qP1gFtJKIiIznE+oc5ivbh1CS41qzCdF2aA+qJx9CaEUF3LfKJRikBfH+vryx9PRo9D0g==}
 
-  '@lit-protocol/vincent-sdk@0.0.6':
-    resolution: {integrity: sha512-oLZEE3REcRuS0N1SO3WTUR9Lstpku0eKuNZ693YaJuRAlu2sMTeodHFUr68D9hPpdhn5G7LCtRkXlbGu4EFpAA==}
-    engines: {node: 20.11.1}
+  '@lit-protocol/vincent-sdk@0.0.7':
+    resolution: {integrity: sha512-u7B7GX/Aiu1umLW+L96RBGX7T3IQylgHaLiozY6ruUFSh1A2mtQsrV2Fds+3DsaQokBcbUrIN4c9hwbnxVIOdA==}
+    engines: {node: ^20.11.1, pnpm: 10.7.0}
+    peerDependencies:
+      '@modelcontextprotocol/sdk': ^1.11.2
 
   '@lit-protocol/wasm@7.1.1':
     resolution: {integrity: sha512-B7qojNwmftZ+kOUgivm73pBL96LxDZKMn9XSmfOQ0HoirUbO0oLTIMV1UEbtU5Fkr4N+v+zKKcv+XJ7O1ZUCRw==}
@@ -11878,11 +11883,12 @@ snapshots:
 
   '@lit-protocol/vincent-contracts@0.1.1-4': {}
 
-  '@lit-protocol/vincent-sdk@0.0.6(@walletconnect/modal@2.7.0(@types/react@19.1.2)(react@19.1.0))(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)':
+  '@lit-protocol/vincent-sdk@0.0.7(@modelcontextprotocol/sdk@1.11.4)(@walletconnect/modal@2.7.0(@types/react@19.1.2)(react@19.1.0))(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)':
     dependencies:
       '@lit-protocol/auth-helpers': 7.1.1(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)
       '@lit-protocol/constants': 7.1.1(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)
       '@lit-protocol/lit-node-client': 7.1.1(@walletconnect/modal@2.7.0(@types/react@19.1.2)(react@19.1.0))(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)
+      '@modelcontextprotocol/sdk': 1.11.4
       '@noble/secp256k1': 2.2.3
       did-jwt: 8.0.14
       ethers: 5.7.1(bufferutil@4.0.9)(utf-8-validate@5.0.10)


### PR DESCRIPTION
- Published @lit-protocol/vincent-sdk@0.0.7

Includes:
- Independent versioning https://github.com/LIT-Protocol/Vincent/pull/86
- API section in docs rename https://github.com/LIT-Protocol/Vincent/pull/88
- MCP Server https://github.com/LIT-Protocol/Vincent/pull/104
