### PR TITLE
Feature/drel 740 optimize contract storage

### DIFF
--- a/packages/vincent-contracts/script/UpdateFacet.sol
+++ b/packages/vincent-contracts/script/UpdateFacet.sol
@@ -240,7 +240,6 @@ contract UpdateFacet is Script {
         selectors[0] = VincentUserFacet.permitAppVersion.selector;
         selectors[1] = VincentUserFacet.unPermitAppVersion.selector;
         selectors[2] = VincentUserFacet.setToolPolicyParameters.selector;
-        selectors[3] = VincentUserFacet.removeToolPolicyParameters.selector;
         return selectors;
     }
 

--- a/packages/vincent-contracts/src/LibVincentDiamondStorage.sol
+++ b/packages/vincent-contracts/src/LibVincentDiamondStorage.sol
@@ -14,6 +14,7 @@ library VincentAppStorage {
 
     struct AppVersion {
         EnumerableSet.Bytes32Set toolIpfsCidHashes;
+        // EnumerableSet instead of an array since the App needs to know all the delegated Agents
         EnumerableSet.UintSet delegatedAgentPkps;
         // Tool IPFS CID hash => Tool Policy IPFS CID hashes
         mapping(bytes32 => EnumerableSet.Bytes32Set) toolIpfsCidHashToToolPolicyIpfsCidHashes;
@@ -76,6 +77,7 @@ library VincentUserStorage {
     }
 
     struct UserStorage {
+        // EnumerableSet instead of an array because we register the Agent PKP during the first App registration so we need to check for duplicates.
         // User PKP ETH address => Registered Agent PKP token IDs
         mapping(address => EnumerableSet.UintSet) userAddressToRegisteredAgentPkps;
         // PKP Token ID -> Agent storage

--- a/packages/vincent-contracts/src/VincentBase.sol
+++ b/packages/vincent-contracts/src/VincentBase.sol
@@ -12,6 +12,7 @@ contract VincentBase {
     error AppNotRegistered(uint256 appId);
     error AppVersionNotRegistered(uint256 appId, uint256 appVersion);
     error AppHasBeenDeleted(uint256 appId);
+    error AppVersionNotEnabled(uint256 appId, uint256 appVersion);
 
     /**
      * @notice Validates that an app exists
@@ -45,6 +46,14 @@ contract VincentBase {
         VincentAppStorage.AppStorage storage as_ = VincentAppStorage.appStorage();
         if (as_.appIdToApp[appId].isDeleted) {
             revert AppHasBeenDeleted(appId);
+        }
+        _;
+    }
+
+    modifier appEnabled(uint256 appId, uint256 appVersion) {
+        VincentAppStorage.AppStorage storage as_ = VincentAppStorage.appStorage();
+        if (!as_.appIdToApp[appId].appVersions[getAppVersionIndex(appVersion)].enabled) {
+            revert AppVersionNotEnabled(appId, appVersion);
         }
         _;
     }

--- a/packages/vincent-contracts/src/VincentDiamond.sol
+++ b/packages/vincent-contracts/src/VincentDiamond.sol
@@ -207,7 +207,6 @@ contract VincentDiamond {
         selectors[0] = VincentUserFacet.permitAppVersion.selector;
         selectors[1] = VincentUserFacet.unPermitAppVersion.selector;
         selectors[2] = VincentUserFacet.setToolPolicyParameters.selector;
-        selectors[3] = VincentUserFacet.removeToolPolicyParameters.selector;
         return selectors;
     }
 

--- a/packages/vincent-contracts/src/libs/LibVincentAppFacet.sol
+++ b/packages/vincent-contracts/src/libs/LibVincentAppFacet.sol
@@ -106,6 +106,21 @@ library LibVincentAppFacet {
     error EmptyToolIpfsCidNotAllowed(uint256 appId, uint256 toolIndex);
 
     /**
+     * @notice Error thrown when a tool IPFS CID is present more than once
+     * @param appId ID of the app
+     * @param toolIndex Index of the tool in the tools array
+     */
+    error DuplicateToolIpfsCidNotAllowed(uint256 appId, uint256 toolIndex);
+
+    /**
+     * @notice Error thrown when a policy IPFS CID is present more than once
+     * @param appId ID of the app
+     * @param toolIndex Index of the tool in the tools array
+     * @param policyIndex Index of the policy in the policies array
+     */
+    error DuplicateToolPolicyIpfsCidNotAllowed(uint256 appId, uint256 toolIndex, uint256 policyIndex);
+
+    /**
      * @notice Error thrown when a delegatee address is the zero address
      */
     error ZeroAddressDelegateeNotAllowed();

--- a/packages/vincent-contracts/src/libs/LibVincentUserFacet.sol
+++ b/packages/vincent-contracts/src/libs/LibVincentUserFacet.sol
@@ -134,6 +134,23 @@ library LibVincentUserFacet {
     );
 
     /**
+     * @notice Error thrown when a duplicate tool IPFS CID is provided
+     * @param appId The ID of the app
+     * @param appVersion The version of the app
+     * @param toolIpfsCid The IPFS CID of the tool
+     */
+    error DuplicateToolIpfsCid(uint256 appId, uint256 appVersion, string toolIpfsCid);
+    
+    /**
+     * @notice Error thrown when a duplicate tool policy IPFS CID is provided
+     * @param appId The ID of the app
+     * @param appVersion The version of the app
+     * @param toolIpfsCid The IPFS CID of the tool
+     * @param toolPolicyIpfsCid The IPFS CID of the tool policy
+     */
+    error DuplicateToolPolicyIpfsCid(uint256 appId, uint256 appVersion, string toolIpfsCid, string toolPolicyIpfsCid);
+
+    /**
      * @notice Error thrown when invalid input is provided
      */
     error InvalidInput();

--- a/packages/vincent-contracts/test/facets/VincentUserFacet.t.sol
+++ b/packages/vincent-contracts/test/facets/VincentUserFacet.t.sol
@@ -382,27 +382,13 @@ contract VincentUserFacetTest is Test {
         assertEq(toolExecutionValidation.appVersion, newAppVersion_2);
     }
 
-    function testSetToolPolicyParameters() public {
+    function testSetToolPolicyParameters_ToolPolicyNotRegisteredForAppVersion() public {
         address[] memory delegatees = new address[](1);
         delegatees[0] = APP_DELEGATEE_CHARLIE;
         (uint256 newAppId, uint256 newAppVersion) = _registerBasicApp(delegatees);
 
-        // First permit the app version
+        // First permit the app version with valid parameters
         vm.startPrank(APP_USER_FRANK);
-        // Expect events for initial permit
-        vm.expectEmit(true, true, true, true);
-        emit LibVincentUserFacet.NewUserAgentPkpRegistered(APP_USER_FRANK, PKP_TOKEN_ID_1);
-        vm.expectEmit(true, true, true, true);
-        emit LibVincentUserFacet.AppVersionPermitted(PKP_TOKEN_ID_1, newAppId, newAppVersion);
-        vm.expectEmit(true, true, true, true);
-        emit LibVincentUserFacet.ToolPolicyParametersSet(
-            PKP_TOKEN_ID_1,
-            newAppId,
-            newAppVersion,
-            keccak256(abi.encodePacked(TOOL_IPFS_CID_1)),
-            POLICY_PARAMETER_VALUES_1
-        );
-
         vincentUserFacet.permitAppVersion(
             PKP_TOKEN_ID_1,
             newAppId,
@@ -412,61 +398,34 @@ contract VincentUserFacetTest is Test {
             policyParameterValues
         );
 
-        // Verify initial policy parameters
-        VincentUserViewFacet.ToolWithPolicies[] memory toolsWithPolicies = vincentUserViewFacet.getAllToolsAndPoliciesForApp(
-            PKP_TOKEN_ID_1,
-            newAppId
+        // Create arrays with an unregistered policy (POLICY_IPFS_CID_3)
+        string[][] memory _policyIpfsCids = new string[][](2);
+        _policyIpfsCids[0] = new string[](1);
+        _policyIpfsCids[0][0] = POLICY_IPFS_CID_3; // This policy is not registered for the tool
+        _policyIpfsCids[1] = new string[](0);
+
+        bytes[][] memory _policyParameterValues = new bytes[][](2);
+        _policyParameterValues[0] = new bytes[](1);
+        _policyParameterValues[0][0] = POLICY_PARAMETER_VALUES_1;
+        _policyParameterValues[1] = new bytes[](0);
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                LibVincentUserFacet.ToolPolicyNotRegisteredForAppVersion.selector,
+                newAppId,
+                newAppVersion,
+                TOOL_IPFS_CID_1,
+                POLICY_IPFS_CID_3
+            )
         );
-        assertEq(toolsWithPolicies.length, 2);
-        assertEq(toolsWithPolicies[0].policies.length, 1);
-        assertEq(toolsWithPolicies[0].policies[0].policyParameterValues, POLICY_PARAMETER_VALUES_1);
-        assertEq(toolsWithPolicies[1].policies.length, 0);
-
-        // Update policy parameters
-        bytes[][] memory newPolicyParameterValues = new bytes[][](2);
-        newPolicyParameterValues[0] = new bytes[](1);
-        newPolicyParameterValues[0][0] = POLICY_PARAMETER_VALUES_2; // Change to different value
-        newPolicyParameterValues[1] = new bytes[](0);
-
-        // Expect event for setting new policy parameters
-        vm.expectEmit(true, true, true, true);
-        emit LibVincentUserFacet.ToolPolicyParametersSet(
-            PKP_TOKEN_ID_1,
-            newAppId,
-            newAppVersion,
-            keccak256(abi.encodePacked(TOOL_IPFS_CID_1)),
-            POLICY_PARAMETER_VALUES_2
-        );
-
         vincentUserFacet.setToolPolicyParameters(
             PKP_TOKEN_ID_1,
             newAppId,
             newAppVersion,
             toolIpfsCids,
-            policyIpfsCids,
-            newPolicyParameterValues
+            _policyIpfsCids,
+            _policyParameterValues
         );
-        vm.stopPrank();
-
-        // Verify updated policy parameters
-        toolsWithPolicies = vincentUserViewFacet.getAllToolsAndPoliciesForApp(
-            PKP_TOKEN_ID_1,
-            newAppId
-        );
-        assertEq(toolsWithPolicies.length, 2);
-        assertEq(toolsWithPolicies[0].policies.length, 1);
-        assertEq(toolsWithPolicies[0].policies[0].policyParameterValues, POLICY_PARAMETER_VALUES_2);
-        assertEq(toolsWithPolicies[1].policies.length, 0);
-
-        // Verify tool execution validation returns updated parameters
-        VincentUserViewFacet.ToolExecutionValidation memory toolExecutionValidation = vincentUserViewFacet.validateToolExecutionAndGetPolicies(
-            APP_DELEGATEE_CHARLIE,
-            PKP_TOKEN_ID_1,
-            TOOL_IPFS_CID_1
-        );
-        assertTrue(toolExecutionValidation.isPermitted);
-        assertEq(toolExecutionValidation.policies.length, 1);
-        assertEq(toolExecutionValidation.policies[0].policyParameterValues, POLICY_PARAMETER_VALUES_2);
     }
 
     function testRemoveToolPolicyParameters() public {
@@ -509,22 +468,36 @@ contract VincentUserFacetTest is Test {
         assertEq(toolsWithPolicies[0].policies[0].policyParameterValues, POLICY_PARAMETER_VALUES_1);
         assertEq(toolsWithPolicies[1].policies.length, 0);
 
-        // Expect event for removing policy parameters
+        // Create subset arrays containing only the tool and policy we want to zero out
+        string[] memory subsetToolIpfsCids = new string[](1);
+        subsetToolIpfsCids[0] = TOOL_IPFS_CID_1;
+
+        string[][] memory subsetPolicyIpfsCids = new string[][](1);
+        subsetPolicyIpfsCids[0] = new string[](1);
+        subsetPolicyIpfsCids[0][0] = POLICY_IPFS_CID_1;
+
+        bytes[][] memory emptyPolicyParameterValues = new bytes[][](1);
+        emptyPolicyParameterValues[0] = new bytes[](1);
+        emptyPolicyParameterValues[0][0] = bytes(""); // Empty bytes to remove parameter
+
+        // Expect event for setting empty policy parameters
         vm.expectEmit(true, true, true, true);
-        emit LibVincentUserFacet.ToolPolicyParametersRemoved(
+        emit LibVincentUserFacet.ToolPolicyParametersSet(
             PKP_TOKEN_ID_1,
             newAppId,
             newAppVersion,
-            keccak256(abi.encodePacked(TOOL_IPFS_CID_1))
+            keccak256(abi.encodePacked(TOOL_IPFS_CID_1)),
+            bytes("")
         );
 
-        // Remove policy parameters
-        vincentUserFacet.removeToolPolicyParameters(
-            newAppId,
+        // Set empty policy parameters to effectively remove them
+        vincentUserFacet.setToolPolicyParameters(
             PKP_TOKEN_ID_1,
+            newAppId,
             newAppVersion,
-            toolIpfsCids,
-            policyIpfsCids
+            subsetToolIpfsCids,
+            subsetPolicyIpfsCids,
+            emptyPolicyParameterValues
         );
         vm.stopPrank();
 
@@ -986,210 +959,6 @@ contract VincentUserFacetTest is Test {
         assertEq(updatedToolsWithPolicies[0].policies.length, 1);
         assertEq(updatedToolsWithPolicies[0].policies[0].policyParameterValues, POLICY_PARAMETER_VALUES_2);
         assertEq(updatedToolsWithPolicies[1].policies.length, 0); // Second tool unchanged
-    }
-
-    function testSetToolPolicyParameters_ToolPolicyNotRegisteredForAppVersion() public {
-        address[] memory delegatees = new address[](1);
-        delegatees[0] = APP_DELEGATEE_CHARLIE;
-        (uint256 newAppId, uint256 newAppVersion) = _registerBasicApp(delegatees);
-
-        // First permit the app version with valid parameters
-        vm.startPrank(APP_USER_FRANK);
-        vincentUserFacet.permitAppVersion(
-            PKP_TOKEN_ID_1,
-            newAppId,
-            newAppVersion,
-            toolIpfsCids,
-            policyIpfsCids,
-            policyParameterValues
-        );
-
-        // Create arrays with an unregistered policy (POLICY_IPFS_CID_3)
-        string[][] memory _policyIpfsCids = new string[][](2);
-        _policyIpfsCids[0] = new string[](1);
-        _policyIpfsCids[0][0] = POLICY_IPFS_CID_3; // This policy is not registered for the tool
-        _policyIpfsCids[1] = new string[](0);
-
-        bytes[][] memory _policyParameterValues = new bytes[][](2);
-        _policyParameterValues[0] = new bytes[](1);
-        _policyParameterValues[0][0] = POLICY_PARAMETER_VALUES_1;
-        _policyParameterValues[1] = new bytes[](0);
-
-        vm.expectRevert(
-            abi.encodeWithSelector(
-                LibVincentUserFacet.ToolPolicyNotRegisteredForAppVersion.selector,
-                newAppId,
-                newAppVersion,
-                TOOL_IPFS_CID_1,
-                POLICY_IPFS_CID_3
-            )
-        );
-        vincentUserFacet.setToolPolicyParameters(
-            PKP_TOKEN_ID_1,
-            newAppId,
-            newAppVersion,
-            toolIpfsCids,
-            _policyIpfsCids,
-            _policyParameterValues
-        );
-    }
-
-    /**
-     * ######################### removeToolPolicyParameters ERROR CASES #########################
-     */
-    function testRemoveToolPolicyParameters_NotPkpOwner() public {
-        address[] memory delegatees = new address[](1);
-        delegatees[0] = APP_DELEGATEE_CHARLIE;
-        (uint256 newAppId, uint256 newAppVersion) = _registerBasicApp(delegatees);
-
-        vm.startPrank(APP_USER_FRANK);
-        vincentUserFacet.permitAppVersion(
-            PKP_TOKEN_ID_1,
-            newAppId,
-            newAppVersion,
-            toolIpfsCids,
-            policyIpfsCids,
-            policyParameterValues
-        );
-        vm.stopPrank();
-
-        vm.startPrank(APP_DELEGATEE_CHARLIE);
-        vm.expectRevert(abi.encodeWithSelector(LibVincentUserFacet.NotPkpOwner.selector, PKP_TOKEN_ID_1, APP_DELEGATEE_CHARLIE));
-        vincentUserFacet.removeToolPolicyParameters(
-            newAppId,
-            PKP_TOKEN_ID_1,
-            newAppVersion,
-            toolIpfsCids,
-            policyIpfsCids
-        );
-    }
-
-    function testRemoveToolPolicyParameters_AppNotRegistered() public {
-        vm.startPrank(APP_USER_FRANK);
-        vm.expectRevert(abi.encodeWithSelector(VincentBase.AppNotRegistered.selector, 1));
-        vincentUserFacet.removeToolPolicyParameters(
-            1,
-            PKP_TOKEN_ID_1,
-            1,
-            toolIpfsCids,
-            policyIpfsCids
-        );
-    }
-
-    function testRemoveToolPolicyParameters_AppVersionNotRegistered() public {
-        address[] memory delegatees = new address[](1);
-        delegatees[0] = APP_DELEGATEE_CHARLIE;
-        (uint256 newAppId, uint256 newAppVersion) = _registerBasicApp(delegatees);
-
-        vm.startPrank(APP_USER_FRANK);
-        vm.expectRevert(abi.encodeWithSelector(VincentBase.AppVersionNotRegistered.selector, newAppId, newAppVersion + 1));
-        vincentUserFacet.removeToolPolicyParameters(
-            newAppId,
-            PKP_TOKEN_ID_1,
-            newAppVersion + 1, // Try to remove parameters for a version that hasn't been registered
-            toolIpfsCids,
-            policyIpfsCids
-        );
-    }
-
-    function testRemoveToolPolicyParameters_InvalidInput() public {
-        address[] memory delegatees = new address[](1);
-        delegatees[0] = APP_DELEGATEE_CHARLIE;
-        (uint256 newAppId, uint256 newAppVersion) = _registerBasicApp(delegatees);
-
-        // First permit the app version with valid parameters
-        vm.startPrank(APP_USER_FRANK);
-        vincentUserFacet.permitAppVersion(
-            PKP_TOKEN_ID_1,
-            newAppId,
-            newAppVersion,
-            toolIpfsCids,
-            policyIpfsCids,
-            policyParameterValues
-        );
-
-        // Now try to set parameters with an empty tool IPFS CIDs array
-        string[] memory emptyToolIpfsCids = new string[](0);
-
-        vm.expectRevert(abi.encodeWithSelector(LibVincentUserFacet.InvalidInput.selector));
-        vincentUserFacet.removeToolPolicyParameters(
-            PKP_TOKEN_ID_1,
-            newAppId,
-            newAppVersion,
-            emptyToolIpfsCids,
-            policyIpfsCids
-        );
-    }
-
-    function testRemoveToolPolicyParameters_EmptyToolIpfsCid() public {
-        address[] memory delegatees = new address[](1);
-        delegatees[0] = APP_DELEGATEE_CHARLIE;
-        (uint256 newAppId, uint256 newAppVersion) = _registerBasicApp(delegatees);
-
-        // First permit the app version with valid parameters
-        vm.startPrank(APP_USER_FRANK);
-        vincentUserFacet.permitAppVersion(
-            PKP_TOKEN_ID_1,
-            newAppId,
-            newAppVersion,
-            toolIpfsCids,
-            policyIpfsCids,
-            policyParameterValues
-        );
-
-        // Create arrays with an empty tool IPFS CID
-        string[] memory _toolIpfsCids = new string[](2);
-        _toolIpfsCids[0] = ""; // Empty string for first tool
-        _toolIpfsCids[1] = TOOL_IPFS_CID_2;
-
-        vm.expectRevert(abi.encodeWithSelector(VincentUserViewFacet.EmptyToolIpfsCid.selector));
-        vincentUserFacet.removeToolPolicyParameters(
-            PKP_TOKEN_ID_1,
-            newAppId,
-            newAppVersion,
-            _toolIpfsCids,
-            policyIpfsCids
-        );
-    }
-
-    function testRemoveToolPolicyParameters_ToolPolicyNotRegisteredForAppVersion() public {
-        address[] memory delegatees = new address[](1);
-        delegatees[0] = APP_DELEGATEE_CHARLIE;
-        (uint256 newAppId, uint256 newAppVersion) = _registerBasicApp(delegatees);
-
-        // First permit the app version with valid parameters
-        vm.startPrank(APP_USER_FRANK);
-        vincentUserFacet.permitAppVersion(
-            PKP_TOKEN_ID_1,
-            newAppId,
-            newAppVersion,
-            toolIpfsCids,
-            policyIpfsCids,
-            policyParameterValues
-        );
-
-        // Create arrays with an unregistered policy (POLICY_IPFS_CID_3)
-        string[][] memory _policyIpfsCids = new string[][](2);
-        _policyIpfsCids[0] = new string[](1);
-        _policyIpfsCids[0][0] = POLICY_IPFS_CID_3; // This policy is not registered for the tool
-        _policyIpfsCids[1] = new string[](0);
-
-        vm.expectRevert(
-            abi.encodeWithSelector(
-                LibVincentUserFacet.ToolPolicyNotRegisteredForAppVersion.selector,
-                newAppId,
-                newAppVersion,
-                TOOL_IPFS_CID_1,
-                POLICY_IPFS_CID_3
-            )
-        );
-        vincentUserFacet.removeToolPolicyParameters(
-            newAppId,
-            PKP_TOKEN_ID_1,
-            newAppVersion,
-            toolIpfsCids,
-            _policyIpfsCids
-        );
     }
 
     function _registerApp(


### PR DESCRIPTION
# What

1. Optimize PolicyVar setting by the user
2. Allow subset updates for permitted Apps
3. Remove `removeToolPolicyParameters()` since we can just reuse `setToolPolicyParameters()` to set the PolicyVars to zero

# Why

1. Remove duplicate logic and consolidate common steps for permitting App and updating PolicyVars
2. Since Apps can un-delete and enable their Apps anytime we should allows updating the PolicyVars irrespective of the App status
3. Removes one function and a bunch of duplicate tests

# Next

Will raise a few more PRs:
1. Comparing the gas of the new permit app v/s the old implementation. It might also include additonal gas optimizations
2. Optimization and functionality changes for the App Facet
3. Better Error messages and improved tests removing the redundancies