### PR TITLE
Styling for info boxes when using darkmode

### DIFF
--- a/.nx/version-plans/version-plan-1749960117243.md
+++ b/.nx/version-plans/version-plan-1749960117243.md
@@ -1,0 +1,5 @@
+---
+vincent-sdk: minor
+---
+
+Styling fix for Vincent docs

--- a/.nx/version-plans/version-plan-1749960117243.md
+++ b/.nx/version-plans/version-plan-1749960117243.md
@@ -1,5 +1,0 @@
----
-vincent-sdk: minor
----
-
-Styling fix for Vincent docs

--- a/packages/sdk/docs/src/css/custom.css
+++ b/packages/sdk/docs/src/css/custom.css
@@ -8,6 +8,22 @@
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.05);
 }
 
+/* Dark theme overrides */
+[data-theme='dark'] .info-box {
+  background-color: #1a2b3c;
+  border-left: 8px solid #4a9eff;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
+}
+
+/* OS theme overrides */
+@media (prefers-color-scheme: dark) {
+  .info-box {
+    background-color: #1a2b3c;
+    border-left: 8px solid #4a9eff;
+    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
+  }
+}
+
 /* Info box title */
 .info-box-title {
   color: #2980b9;
@@ -17,6 +33,18 @@
   margin-bottom: 8px;
   display: flex;
   align-items: center;
+}
+
+/* Dark theme title override */
+[data-theme='dark'] .info-box-title {
+  color: #4a9eff;
+}
+
+/* OS theme title overrides */
+@media (prefers-color-scheme: dark) {
+  .info-box-title {
+    color: #4a9eff;
+  }
 }
 
 /* Info icon - using inline SVG data URI */


### PR DESCRIPTION
# Description

Before fix:

<img width="1570" alt="image" src="https://github.com/user-attachments/assets/640af9a4-a2d6-4e4d-a30a-25aac15ce48c" />

After:

<img width="1066" alt="image" src="https://github.com/user-attachments/assets/cea3f86c-cf73-4be2-bb4b-31c188e14b5d" />

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] I created a [release plan](https://nx.dev/recipes/nx-release/file-based-versioning-version-plans) (`nx release plan`) describing my changes and the version bump
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
