### PR TITLE
docs: Update tools-sdk doc output to be less verbose and clarify some content

### DIFF
--- a/packages/libs/tool-sdk/docs/json
+++ b/packages/libs/tool-sdk/docs/json
@@ -6,14 +6,429 @@
 	"flags": {},
 	"children": [
 		{
-			"id": 223,
-			"name": "BaseToolContext",
+			"id": 164,
+			"name": "PolicyContext",
 			"variant": "declaration",
 			"kind": 256,
 			"flags": {},
+			"comment": {
+				"summary": [],
+				"blockTags": [
+					{
+						"tag": "@category",
+						"content": [
+							{
+								"kind": "text",
+								"text": "Interfaces"
+							}
+						]
+					}
+				],
+				"modifierTags": [
+					"@expand"
+				]
+			},
 			"children": [
 				{
-					"id": 226,
+					"id": 165,
+					"name": "allow",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {},
+					"sources": [
+						{
+							"fileName": "policyCore/policyDef/context/types.ts",
+							"line": 44,
+							"character": 2,
+							"url": "https://github.com/LIT-Protocol/Vincent/blob/46a7999ef358981de990d808b7484f24731b23f9/packages/libs/tool-sdk/src/lib/policyCore/policyDef/context/types.ts#L44"
+						}
+					],
+					"type": {
+						"type": "conditional",
+						"checkType": {
+							"type": "reference",
+							"target": 190,
+							"name": "AllowSchema",
+							"package": "@lit-protocol/vincent-tool-sdk",
+							"qualifiedName": "PolicyContext.AllowSchema",
+							"refersToTypeParameter": true
+						},
+						"extendsType": {
+							"type": "reference",
+							"target": {
+								"sourceFileName": "../../../node_modules/.pnpm/zod@3.25.64/node_modules/zod/dist/types/v3/types.d.ts",
+								"qualifiedName": "ZodUndefined"
+							},
+							"name": "ZodUndefined",
+							"package": "zod"
+						},
+						"trueType": {
+							"type": "reflection",
+							"declaration": {
+								"id": 166,
+								"name": "__type",
+								"variant": "declaration",
+								"kind": 65536,
+								"flags": {},
+								"sources": [
+									{
+										"fileName": "policyCore/policyDef/context/types.ts",
+										"line": 45,
+										"character": 6,
+										"url": "https://github.com/LIT-Protocol/Vincent/blob/46a7999ef358981de990d808b7484f24731b23f9/packages/libs/tool-sdk/src/lib/policyCore/policyDef/context/types.ts#L45"
+									}
+								],
+								"signatures": [
+									{
+										"id": 167,
+										"name": "__type",
+										"variant": "signature",
+										"kind": 4096,
+										"flags": {},
+										"sources": [
+											{
+												"fileName": "policyCore/policyDef/context/types.ts",
+												"line": 45,
+												"character": 6,
+												"url": "https://github.com/LIT-Protocol/Vincent/blob/46a7999ef358981de990d808b7484f24731b23f9/packages/libs/tool-sdk/src/lib/policyCore/policyDef/context/types.ts#L45"
+											}
+										],
+										"type": {
+											"type": "reference",
+											"target": {
+												"sourceFileName": "src/lib/policyCore/policyDef/context/types.ts",
+												"qualifiedName": "ContextAllowResponseNoResult"
+											},
+											"name": "ContextAllowResponseNoResult",
+											"package": "@lit-protocol/vincent-tool-sdk"
+										}
+									}
+								]
+							}
+						},
+						"falseType": {
+							"type": "reflection",
+							"declaration": {
+								"id": 168,
+								"name": "__type",
+								"variant": "declaration",
+								"kind": 65536,
+								"flags": {},
+								"sources": [
+									{
+										"fileName": "policyCore/policyDef/context/types.ts",
+										"line": 46,
+										"character": 6,
+										"url": "https://github.com/LIT-Protocol/Vincent/blob/46a7999ef358981de990d808b7484f24731b23f9/packages/libs/tool-sdk/src/lib/policyCore/policyDef/context/types.ts#L46"
+									}
+								],
+								"signatures": [
+									{
+										"id": 169,
+										"name": "__type",
+										"variant": "signature",
+										"kind": 4096,
+										"flags": {},
+										"sources": [
+											{
+												"fileName": "policyCore/policyDef/context/types.ts",
+												"line": 46,
+												"character": 6,
+												"url": "https://github.com/LIT-Protocol/Vincent/blob/46a7999ef358981de990d808b7484f24731b23f9/packages/libs/tool-sdk/src/lib/policyCore/policyDef/context/types.ts#L46"
+											}
+										],
+										"parameters": [
+											{
+												"id": 170,
+												"name": "result",
+												"variant": "param",
+												"kind": 32768,
+												"flags": {},
+												"type": {
+													"type": "reference",
+													"target": {
+														"sourceFileName": "../../../node_modules/.pnpm/zod@3.25.64/node_modules/zod/dist/types/v3/types.d.ts",
+														"qualifiedName": "TypeOf"
+													},
+													"typeArguments": [
+														{
+															"type": "reference",
+															"target": 190,
+															"name": "AllowSchema",
+															"package": "@lit-protocol/vincent-tool-sdk",
+															"qualifiedName": "PolicyContext.AllowSchema",
+															"refersToTypeParameter": true
+														}
+													],
+													"name": "TypeOf",
+													"package": "zod"
+												}
+											}
+										],
+										"type": {
+											"type": "reference",
+											"target": {
+												"sourceFileName": "src/lib/policyCore/policyDef/context/types.ts",
+												"qualifiedName": "ContextAllowResponse"
+											},
+											"typeArguments": [
+												{
+													"type": "reference",
+													"target": {
+														"sourceFileName": "../../../node_modules/.pnpm/zod@3.25.64/node_modules/zod/dist/types/v3/types.d.ts",
+														"qualifiedName": "TypeOf"
+													},
+													"typeArguments": [
+														{
+															"type": "reference",
+															"target": 190,
+															"name": "AllowSchema",
+															"package": "@lit-protocol/vincent-tool-sdk",
+															"qualifiedName": "PolicyContext.AllowSchema",
+															"refersToTypeParameter": true
+														}
+													],
+													"name": "TypeOf",
+													"package": "zod"
+												}
+											],
+											"name": "ContextAllowResponse",
+											"package": "@lit-protocol/vincent-tool-sdk"
+										}
+									}
+								]
+							}
+						}
+					}
+				},
+				{
+					"id": 171,
+					"name": "deny",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {},
+					"sources": [
+						{
+							"fileName": "policyCore/policyDef/context/types.ts",
+							"line": 48,
+							"character": 2,
+							"url": "https://github.com/LIT-Protocol/Vincent/blob/46a7999ef358981de990d808b7484f24731b23f9/packages/libs/tool-sdk/src/lib/policyCore/policyDef/context/types.ts#L48"
+						}
+					],
+					"type": {
+						"type": "conditional",
+						"checkType": {
+							"type": "reference",
+							"target": 191,
+							"name": "DenySchema",
+							"package": "@lit-protocol/vincent-tool-sdk",
+							"qualifiedName": "PolicyContext.DenySchema",
+							"refersToTypeParameter": true
+						},
+						"extendsType": {
+							"type": "reference",
+							"target": {
+								"sourceFileName": "../../../node_modules/.pnpm/zod@3.25.64/node_modules/zod/dist/types/v3/types.d.ts",
+								"qualifiedName": "ZodUndefined"
+							},
+							"name": "ZodUndefined",
+							"package": "zod"
+						},
+						"trueType": {
+							"type": "reflection",
+							"declaration": {
+								"id": 172,
+								"name": "__type",
+								"variant": "declaration",
+								"kind": 65536,
+								"flags": {},
+								"sources": [
+									{
+										"fileName": "policyCore/policyDef/context/types.ts",
+										"line": 49,
+										"character": 6,
+										"url": "https://github.com/LIT-Protocol/Vincent/blob/46a7999ef358981de990d808b7484f24731b23f9/packages/libs/tool-sdk/src/lib/policyCore/policyDef/context/types.ts#L49"
+									}
+								],
+								"signatures": [
+									{
+										"id": 173,
+										"name": "__type",
+										"variant": "signature",
+										"kind": 4096,
+										"flags": {},
+										"sources": [
+											{
+												"fileName": "policyCore/policyDef/context/types.ts",
+												"line": 49,
+												"character": 6,
+												"url": "https://github.com/LIT-Protocol/Vincent/blob/46a7999ef358981de990d808b7484f24731b23f9/packages/libs/tool-sdk/src/lib/policyCore/policyDef/context/types.ts#L49"
+											}
+										],
+										"parameters": [
+											{
+												"id": 174,
+												"name": "error",
+												"variant": "param",
+												"kind": 32768,
+												"flags": {
+													"isOptional": true
+												},
+												"type": {
+													"type": "intrinsic",
+													"name": "string"
+												}
+											}
+										],
+										"type": {
+											"type": "reference",
+											"target": {
+												"sourceFileName": "src/lib/policyCore/policyDef/context/types.ts",
+												"qualifiedName": "ContextDenyResponseNoResult"
+											},
+											"name": "ContextDenyResponseNoResult",
+											"package": "@lit-protocol/vincent-tool-sdk"
+										}
+									}
+								]
+							}
+						},
+						"falseType": {
+							"type": "reflection",
+							"declaration": {
+								"id": 175,
+								"name": "__type",
+								"variant": "declaration",
+								"kind": 65536,
+								"flags": {},
+								"sources": [
+									{
+										"fileName": "policyCore/policyDef/context/types.ts",
+										"line": 50,
+										"character": 6,
+										"url": "https://github.com/LIT-Protocol/Vincent/blob/46a7999ef358981de990d808b7484f24731b23f9/packages/libs/tool-sdk/src/lib/policyCore/policyDef/context/types.ts#L50"
+									}
+								],
+								"signatures": [
+									{
+										"id": 176,
+										"name": "__type",
+										"variant": "signature",
+										"kind": 4096,
+										"flags": {},
+										"sources": [
+											{
+												"fileName": "policyCore/policyDef/context/types.ts",
+												"line": 50,
+												"character": 6,
+												"url": "https://github.com/LIT-Protocol/Vincent/blob/46a7999ef358981de990d808b7484f24731b23f9/packages/libs/tool-sdk/src/lib/policyCore/policyDef/context/types.ts#L50"
+											}
+										],
+										"parameters": [
+											{
+												"id": 177,
+												"name": "result",
+												"variant": "param",
+												"kind": 32768,
+												"flags": {},
+												"type": {
+													"type": "reference",
+													"target": {
+														"sourceFileName": "../../../node_modules/.pnpm/zod@3.25.64/node_modules/zod/dist/types/v3/types.d.ts",
+														"qualifiedName": "TypeOf"
+													},
+													"typeArguments": [
+														{
+															"type": "reference",
+															"target": 191,
+															"name": "DenySchema",
+															"package": "@lit-protocol/vincent-tool-sdk",
+															"qualifiedName": "PolicyContext.DenySchema",
+															"refersToTypeParameter": true
+														}
+													],
+													"name": "TypeOf",
+													"package": "zod"
+												}
+											},
+											{
+												"id": 178,
+												"name": "error",
+												"variant": "param",
+												"kind": 32768,
+												"flags": {
+													"isOptional": true
+												},
+												"type": {
+													"type": "intrinsic",
+													"name": "string"
+												}
+											}
+										],
+										"type": {
+											"type": "reference",
+											"target": {
+												"sourceFileName": "src/lib/policyCore/policyDef/context/types.ts",
+												"qualifiedName": "ContextDenyResponse"
+											},
+											"typeArguments": [
+												{
+													"type": "reference",
+													"target": {
+														"sourceFileName": "../../../node_modules/.pnpm/zod@3.25.64/node_modules/zod/dist/types/v3/types.d.ts",
+														"qualifiedName": "TypeOf"
+													},
+													"typeArguments": [
+														{
+															"type": "reference",
+															"target": 191,
+															"name": "DenySchema",
+															"package": "@lit-protocol/vincent-tool-sdk",
+															"qualifiedName": "PolicyContext.DenySchema",
+															"refersToTypeParameter": true
+														}
+													],
+													"name": "TypeOf",
+													"package": "zod"
+												}
+											],
+											"name": "ContextDenyResponse",
+											"package": "@lit-protocol/vincent-tool-sdk"
+										}
+									}
+								]
+							}
+						}
+					}
+				},
+				{
+					"id": 179,
+					"name": "toolIpfsCid",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isInherited": true
+					},
+					"sources": [
+						{
+							"fileName": "types.ts",
+							"line": 413,
+							"character": 2,
+							"url": "https://github.com/LIT-Protocol/Vincent/blob/46a7999ef358981de990d808b7484f24731b23f9/packages/libs/tool-sdk/src/lib/types.ts#L413"
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					},
+					"inheritedFrom": {
+						"type": "reference",
+						"target": -1,
+						"name": "BaseContext.toolIpfsCid"
+					}
+				},
+				{
+					"id": 180,
 					"name": "appId",
 					"variant": "declaration",
 					"kind": 1024,
@@ -23,9 +438,9 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 411,
+							"line": 414,
 							"character": 2,
-							"url": "https://github.com/LIT-Protocol/Vincent/blob/8e21b5da26217bce6eb8963c7b9c9ea95c6a2290/packages/libs/tool-sdk/src/lib/types.ts#L411"
+							"url": "https://github.com/LIT-Protocol/Vincent/blob/46a7999ef358981de990d808b7484f24731b23f9/packages/libs/tool-sdk/src/lib/types.ts#L414"
 						}
 					],
 					"type": {
@@ -39,7 +454,7 @@
 					}
 				},
 				{
-					"id": 227,
+					"id": 181,
 					"name": "appVersion",
 					"variant": "declaration",
 					"kind": 1024,
@@ -49,9 +464,9 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 412,
+							"line": 415,
 							"character": 2,
-							"url": "https://github.com/LIT-Protocol/Vincent/blob/8e21b5da26217bce6eb8963c7b9c9ea95c6a2290/packages/libs/tool-sdk/src/lib/types.ts#L412"
+							"url": "https://github.com/LIT-Protocol/Vincent/blob/46a7999ef358981de990d808b7484f24731b23f9/packages/libs/tool-sdk/src/lib/types.ts#L415"
 						}
 					],
 					"type": {
@@ -65,7 +480,7 @@
 					}
 				},
 				{
-					"id": 228,
+					"id": 182,
 					"name": "delegation",
 					"variant": "declaration",
 					"kind": 1024,
@@ -75,22 +490,22 @@
 					"sources": [
 						{
 							"fileName": "types.ts",
-							"line": 413,
+							"line": 416,
 							"character": 2,
-							"url": "https://github.com/LIT-Protocol/Vincent/blob/8e21b5da26217bce6eb8963c7b9c9ea95c6a2290/packages/libs/tool-sdk/src/lib/types.ts#L413"
+							"url": "https://github.com/LIT-Protocol/Vincent/blob/46a7999ef358981de990d808b7484f24731b23f9/packages/libs/tool-sdk/src/lib/types.ts#L416"
 						}
 					],
 					"type": {
 						"type": "reflection",
 						"declaration": {
-							"id": 229,
+							"id": 183,
 							"name": "__type",
 							"variant": "declaration",
 							"kind": 65536,
 							"flags": {},
 							"children": [
 								{
-									"id": 230,
+									"id": 184,
 									"name": "delegateeAddress",
 									"variant": "declaration",
 									"kind": 1024,
@@ -98,9 +513,9 @@
 									"sources": [
 										{
 											"fileName": "types.ts",
-											"line": 414,
+											"line": 417,
 											"character": 4,
-											"url": "https://github.com/LIT-Protocol/Vincent/blob/8e21b5da26217bce6eb8963c7b9c9ea95c6a2290/packages/libs/tool-sdk/src/lib/types.ts#L414"
+											"url": "https://github.com/LIT-Protocol/Vincent/blob/46a7999ef358981de990d808b7484f24731b23f9/packages/libs/tool-sdk/src/lib/types.ts#L417"
 										}
 									],
 									"type": {
@@ -109,7 +524,7 @@
 									}
 								},
 								{
-									"id": 231,
+									"id": 185,
 									"name": "delegatorPkpInfo",
 									"variant": "declaration",
 									"kind": 1024,
@@ -117,60 +532,22 @@
 									"sources": [
 										{
 											"fileName": "types.ts",
-											"line": 415,
+											"line": 418,
 											"character": 4,
-											"url": "https://github.com/LIT-Protocol/Vincent/blob/8e21b5da26217bce6eb8963c7b9c9ea95c6a2290/packages/libs/tool-sdk/src/lib/types.ts#L415"
+											"url": "https://github.com/LIT-Protocol/Vincent/blob/46a7999ef358981de990d808b7484f24731b23f9/packages/libs/tool-sdk/src/lib/types.ts#L418"
 										}
 									],
 									"type": {
 										"type": "reflection",
 										"declaration": {
-											"id": 232,
+											"id": 186,
 											"name": "__type",
 											"variant": "declaration",
 											"kind": 65536,
 											"flags": {},
 											"children": [
 												{
-													"id": 234,
-													"name": "ethAddress",
-													"variant": "declaration",
-													"kind": 1024,
-													"flags": {},
-													"sources": [
-														{
-															"fileName": "types.ts",
-															"line": 417,
-															"character": 6,
-															"url": "https://github.com/LIT-Protocol/Vincent/blob/8e21b5da26217bce6eb8963c7b9c9ea95c6a2290/packages/libs/tool-sdk/src/lib/types.ts#L417"
-														}
-													],
-													"type": {
-														"type": "intrinsic",
-														"name": "string"
-													}
-												},
-												{
-													"id": 235,
-													"name": "publicKey",
-													"variant": "declaration",
-													"kind": 1024,
-													"flags": {},
-													"sources": [
-														{
-															"fileName": "types.ts",
-															"line": 418,
-															"character": 6,
-															"url": "https://github.com/LIT-Protocol/Vincent/blob/8e21b5da26217bce6eb8963c7b9c9ea95c6a2290/packages/libs/tool-sdk/src/lib/types.ts#L418"
-														}
-													],
-													"type": {
-														"type": "intrinsic",
-														"name": "string"
-													}
-												},
-												{
-													"id": 233,
+													"id": 187,
 													"name": "tokenId",
 													"variant": "declaration",
 													"kind": 1024,
@@ -178,9 +555,47 @@
 													"sources": [
 														{
 															"fileName": "types.ts",
-															"line": 416,
+															"line": 419,
 															"character": 6,
-															"url": "https://github.com/LIT-Protocol/Vincent/blob/8e21b5da26217bce6eb8963c7b9c9ea95c6a2290/packages/libs/tool-sdk/src/lib/types.ts#L416"
+															"url": "https://github.com/LIT-Protocol/Vincent/blob/46a7999ef358981de990d808b7484f24731b23f9/packages/libs/tool-sdk/src/lib/types.ts#L419"
+														}
+													],
+													"type": {
+														"type": "intrinsic",
+														"name": "string"
+													}
+												},
+												{
+													"id": 188,
+													"name": "ethAddress",
+													"variant": "declaration",
+													"kind": 1024,
+													"flags": {},
+													"sources": [
+														{
+															"fileName": "types.ts",
+															"line": 420,
+															"character": 6,
+															"url": "https://github.com/LIT-Protocol/Vincent/blob/46a7999ef358981de990d808b7484f24731b23f9/packages/libs/tool-sdk/src/lib/types.ts#L420"
+														}
+													],
+													"type": {
+														"type": "intrinsic",
+														"name": "string"
+													}
+												},
+												{
+													"id": 189,
+													"name": "publicKey",
+													"variant": "declaration",
+													"kind": 1024,
+													"flags": {},
+													"sources": [
+														{
+															"fileName": "types.ts",
+															"line": 421,
+															"character": 6,
+															"url": "https://github.com/LIT-Protocol/Vincent/blob/46a7999ef358981de990d808b7484f24731b23f9/packages/libs/tool-sdk/src/lib/types.ts#L421"
 														}
 													],
 													"type": {
@@ -193,18 +608,18 @@
 												{
 													"title": "Properties",
 													"children": [
-														234,
-														235,
-														233
+														187,
+														188,
+														189
 													]
 												}
 											],
 											"sources": [
 												{
 													"fileName": "types.ts",
-													"line": 415,
+													"line": 418,
 													"character": 22,
-													"url": "https://github.com/LIT-Protocol/Vincent/blob/8e21b5da26217bce6eb8963c7b9c9ea95c6a2290/packages/libs/tool-sdk/src/lib/types.ts#L415"
+													"url": "https://github.com/LIT-Protocol/Vincent/blob/46a7999ef358981de990d808b7484f24731b23f9/packages/libs/tool-sdk/src/lib/types.ts#L418"
 												}
 											]
 										}
@@ -215,17 +630,17 @@
 								{
 									"title": "Properties",
 									"children": [
-										230,
-										231
+										184,
+										185
 									]
 								}
 							],
 							"sources": [
 								{
 									"fileName": "types.ts",
-									"line": 413,
+									"line": 416,
 									"character": 14,
-									"url": "https://github.com/LIT-Protocol/Vincent/blob/8e21b5da26217bce6eb8963c7b9c9ea95c6a2290/packages/libs/tool-sdk/src/lib/types.ts#L413"
+									"url": "https://github.com/LIT-Protocol/Vincent/blob/46a7999ef358981de990d808b7484f24731b23f9/packages/libs/tool-sdk/src/lib/types.ts#L416"
 								}
 							]
 						}
@@ -235,84 +650,83 @@
 						"target": -1,
 						"name": "BaseContext.delegation"
 					}
-				},
-				{
-					"id": 224,
-					"name": "policiesContext",
-					"variant": "declaration",
-					"kind": 1024,
-					"flags": {},
-					"sources": [
-						{
-							"fileName": "toolCore/toolDef/context/types.ts",
-							"line": 13,
-							"character": 2,
-							"url": "https://github.com/LIT-Protocol/Vincent/blob/8e21b5da26217bce6eb8963c7b9c9ea95c6a2290/packages/libs/tool-sdk/src/lib/toolCore/toolDef/context/types.ts#L13"
-						}
-					],
-					"type": {
-						"type": "reference",
-						"target": 236,
-						"name": "Policies",
-						"package": "@lit-protocol/vincent-tool-sdk",
-						"qualifiedName": "BaseToolContext.Policies",
-						"refersToTypeParameter": true
-					}
-				},
-				{
-					"id": 225,
-					"name": "toolIpfsCid",
-					"variant": "declaration",
-					"kind": 1024,
-					"flags": {
-						"isInherited": true
-					},
-					"sources": [
-						{
-							"fileName": "types.ts",
-							"line": 410,
-							"character": 2,
-							"url": "https://github.com/LIT-Protocol/Vincent/blob/8e21b5da26217bce6eb8963c7b9c9ea95c6a2290/packages/libs/tool-sdk/src/lib/types.ts#L410"
-						}
-					],
-					"type": {
-						"type": "intrinsic",
-						"name": "string"
-					},
-					"inheritedFrom": {
-						"type": "reference",
-						"target": -1,
-						"name": "BaseContext.toolIpfsCid"
-					}
 				}
 			],
 			"groups": [
 				{
 					"title": "Properties",
 					"children": [
-						226,
-						227,
-						228,
-						224,
-						225
+						165,
+						171,
+						179,
+						180,
+						181,
+						182
 					]
 				}
 			],
 			"sources": [
 				{
-					"fileName": "toolCore/toolDef/context/types.ts",
-					"line": 12,
+					"fileName": "policyCore/policyDef/context/types.ts",
+					"line": 40,
 					"character": 17,
-					"url": "https://github.com/LIT-Protocol/Vincent/blob/8e21b5da26217bce6eb8963c7b9c9ea95c6a2290/packages/libs/tool-sdk/src/lib/toolCore/toolDef/context/types.ts#L12"
+					"url": "https://github.com/LIT-Protocol/Vincent/blob/46a7999ef358981de990d808b7484f24731b23f9/packages/libs/tool-sdk/src/lib/policyCore/policyDef/context/types.ts#L40"
 				}
 			],
 			"typeParameters": [
 				{
-					"id": 236,
-					"name": "Policies",
+					"id": 190,
+					"name": "AllowSchema",
 					"variant": "typeParam",
 					"kind": 131072,
-					"flags": {}
+					"flags": {},
+					"type": {
+						"type": "reference",
+						"target": {
+							"sourceFileName": "../../../node_modules/.pnpm/zod@3.25.64/node_modules/zod/dist/types/v3/types.d.ts",
+							"qualifiedName": "ZodType"
+						},
+						"name": "z.ZodType",
+						"package": "zod",
+						"qualifiedName": "ZodType"
+					},
+					"default": {
+						"type": "reference",
+						"target": {
+							"sourceFileName": "../../../node_modules/.pnpm/zod@3.25.64/node_modules/zod/dist/types/v3/types.d.ts",
+							"qualifiedName": "ZodUndefined"
+						},
+						"name": "z.ZodUndefined",
+						"package": "zod",
+						"qualifiedName": "ZodUndefined"
+					}
+				},
+				{
+					"id": 191,
+					"name": "DenySchema",
+					"variant": "typeParam",
+					"kind": 131072,
+					"flags": {},
+					"type": {
+						"type": "reference",
+						"target": {
+							"sourceFileName": "../../../node_modules/.pnpm/zod@3.25.64/node_modules/zod/dist/types/v3/types.d.ts",
+							"qualifiedName": "ZodType"
+						},
+						"name": "z.ZodType",
+						"package": "zod",
+						"qualifiedName": "ZodType"
+					},
+					"default": {
+						"type": "reference",
+						"target": {
+							"sourceFileName": "../../../node_modules/.pnpm/zod@3.25.64/node_modules/zod/dist/types/v3/types.d.ts",
+							"qualifiedName": "ZodUndefined"
+						},
+						"name": "z.ZodUndefined",
+						"package": "zod",
+						"qualifiedName": "ZodUndefined"
+					}
 				}
 			],
 			"extendedTypes": [
@@ -325,2135 +739,267 @@
 			]
 		},
 		{
-			"id": 107,
-			"name": "BundledVincentPolicy",
+			"id": 144,
+			"name": "PolicyDefLifecycleFunction",
 			"variant": "declaration",
 			"kind": 2097152,
 			"flags": {},
 			"comment": {
 				"summary": [
 					{
+						"kind": "code",
+						"text": "`evaluate()`"
+					},
+					{
 						"kind": "text",
-						"text": "A VincentPolicy bundled with an IPFS CID and uniquely branded.\nThis ensures only correctly constructed objects are assignable."
+						"text": " and "
+					},
+					{
+						"kind": "code",
+						"text": "`precheck()`"
+					},
+					{
+						"kind": "text",
+						"text": " functions that you define when using "
+					},
+					{
+						"kind": "code",
+						"text": "`createVincentPolicy()`"
+					},
+					{
+						"kind": "text",
+						"text": " will match this function signature.\nNote that the arguments and return types are inferred based on the ZOD schemas that you pass to "
+					},
+					{
+						"kind": "code",
+						"text": "`createVincentPolicy`"
+					}
+				],
+				"blockTags": [
+					{
+						"tag": "@category",
+						"content": [
+							{
+								"kind": "text",
+								"text": "Interfaces"
+							}
+						]
 					}
 				]
 			},
 			"sources": [
 				{
-					"fileName": "policyCore/bundledPolicy/types.ts",
-					"line": 14,
+					"fileName": "policyCore/policyDef/types.ts",
+					"line": 16,
 					"character": 12,
-					"url": "https://github.com/LIT-Protocol/Vincent/blob/8e21b5da26217bce6eb8963c7b9c9ea95c6a2290/packages/libs/tool-sdk/src/lib/policyCore/bundledPolicy/types.ts#L14"
+					"url": "https://github.com/LIT-Protocol/Vincent/blob/46a7999ef358981de990d808b7484f24731b23f9/packages/libs/tool-sdk/src/lib/policyCore/policyDef/types.ts#L16"
 				}
 			],
 			"typeParameters": [
 				{
-					"id": 112,
-					"name": "VP",
+					"id": 152,
+					"name": "ToolParams",
 					"variant": "typeParam",
 					"kind": 131072,
 					"flags": {},
 					"type": {
 						"type": "reference",
 						"target": {
-							"sourceFileName": "src/lib/types.ts",
-							"qualifiedName": "VincentPolicy"
+							"sourceFileName": "../../../node_modules/.pnpm/zod@3.25.64/node_modules/zod/dist/types/v3/types.d.ts",
+							"qualifiedName": "ZodType"
 						},
-						"typeArguments": [
-							{
-								"type": "intrinsic",
-								"name": "any"
-							},
-							{
-								"type": "intrinsic",
-								"name": "any"
-							},
-							{
-								"type": "intrinsic",
-								"name": "any"
-							},
-							{
-								"type": "intrinsic",
-								"name": "any"
-							},
-							{
-								"type": "intrinsic",
-								"name": "any"
-							},
-							{
-								"type": "intrinsic",
-								"name": "any"
-							},
-							{
-								"type": "intrinsic",
-								"name": "any"
-							},
-							{
-								"type": "intrinsic",
-								"name": "any"
-							},
-							{
-								"type": "intrinsic",
-								"name": "any"
-							},
-							{
-								"type": "intrinsic",
-								"name": "any"
-							},
-							{
-								"type": "intrinsic",
-								"name": "any"
-							},
-							{
-								"type": "intrinsic",
-								"name": "any"
-							},
-							{
-								"type": "intrinsic",
-								"name": "any"
-							}
-						],
-						"name": "VincentPolicy",
-						"package": "@lit-protocol/vincent-tool-sdk"
+						"name": "z.ZodType",
+						"package": "zod",
+						"qualifiedName": "ZodType"
 					}
 				},
 				{
-					"id": 113,
-					"name": "IpfsCid",
-					"variant": "typeParam",
-					"kind": 131072,
-					"flags": {},
-					"type": {
-						"type": "intrinsic",
-						"name": "string"
-					},
-					"default": {
-						"type": "intrinsic",
-						"name": "string"
-					}
-				}
-			],
-			"type": {
-				"type": "reflection",
-				"declaration": {
-					"id": 108,
-					"name": "__type",
-					"variant": "declaration",
-					"kind": 65536,
-					"flags": {},
-					"children": [
-						{
-							"id": 109,
-							"name": "ipfsCid",
-							"variant": "declaration",
-							"kind": 1024,
-							"flags": {
-								"isReadonly": true
-							},
-							"sources": [
-								{
-									"fileName": "policyCore/bundledPolicy/types.ts",
-									"line": 18,
-									"character": 11,
-									"url": "https://github.com/LIT-Protocol/Vincent/blob/8e21b5da26217bce6eb8963c7b9c9ea95c6a2290/packages/libs/tool-sdk/src/lib/policyCore/bundledPolicy/types.ts#L18"
-								}
-							],
-							"type": {
-								"type": "reference",
-								"target": 113,
-								"name": "IpfsCid",
-								"package": "@lit-protocol/vincent-tool-sdk",
-								"refersToTypeParameter": true
-							}
-						},
-						{
-							"id": 110,
-							"name": "vincentPolicy",
-							"variant": "declaration",
-							"kind": 1024,
-							"flags": {
-								"isReadonly": true
-							},
-							"sources": [
-								{
-									"fileName": "policyCore/bundledPolicy/types.ts",
-									"line": 19,
-									"character": 11,
-									"url": "https://github.com/LIT-Protocol/Vincent/blob/8e21b5da26217bce6eb8963c7b9c9ea95c6a2290/packages/libs/tool-sdk/src/lib/policyCore/bundledPolicy/types.ts#L19"
-								}
-							],
-							"type": {
-								"type": "reference",
-								"target": 112,
-								"name": "VP",
-								"package": "@lit-protocol/vincent-tool-sdk",
-								"refersToTypeParameter": true
-							}
-						}
-					],
-					"groups": [
-						{
-							"title": "Properties",
-							"children": [
-								109,
-								110
-							]
-						}
-					],
-					"sources": [
-						{
-							"fileName": "policyCore/bundledPolicy/types.ts",
-							"line": 17,
-							"character": 4,
-							"url": "https://github.com/LIT-Protocol/Vincent/blob/8e21b5da26217bce6eb8963c7b9c9ea95c6a2290/packages/libs/tool-sdk/src/lib/policyCore/bundledPolicy/types.ts#L17"
-						}
-					]
-				}
-			}
-		},
-		{
-			"id": 114,
-			"name": "BundledVincentTool",
-			"variant": "declaration",
-			"kind": 2097152,
-			"flags": {},
-			"comment": {
-				"summary": [
-					{
-						"kind": "text",
-						"text": "A VincentTool bundled with an IPFS CID and uniquely branded.\nThis ensures only correctly constructed objects are assignable."
-					}
-				]
-			},
-			"sources": [
-				{
-					"fileName": "toolCore/bundledTool/types.ts",
-					"line": 14,
-					"character": 12,
-					"url": "https://github.com/LIT-Protocol/Vincent/blob/8e21b5da26217bce6eb8963c7b9c9ea95c6a2290/packages/libs/tool-sdk/src/lib/toolCore/bundledTool/types.ts#L14"
-				}
-			],
-			"typeParameters": [
-				{
-					"id": 119,
-					"name": "VT",
-					"variant": "typeParam",
-					"kind": 131072,
-					"flags": {},
-					"type": {
-						"type": "reference",
-						"target": 195,
-						"typeArguments": [
-							{
-								"type": "intrinsic",
-								"name": "any"
-							},
-							{
-								"type": "intrinsic",
-								"name": "any"
-							},
-							{
-								"type": "intrinsic",
-								"name": "any"
-							},
-							{
-								"type": "intrinsic",
-								"name": "any"
-							},
-							{
-								"type": "intrinsic",
-								"name": "any"
-							},
-							{
-								"type": "intrinsic",
-								"name": "any"
-							},
-							{
-								"type": "intrinsic",
-								"name": "any"
-							},
-							{
-								"type": "intrinsic",
-								"name": "any"
-							},
-							{
-								"type": "intrinsic",
-								"name": "any"
-							},
-							{
-								"type": "intrinsic",
-								"name": "any"
-							}
-						],
-						"name": "VincentTool",
-						"package": "@lit-protocol/vincent-tool-sdk"
-					}
-				},
-				{
-					"id": 120,
-					"name": "IpfsCid",
-					"variant": "typeParam",
-					"kind": 131072,
-					"flags": {},
-					"type": {
-						"type": "intrinsic",
-						"name": "string"
-					},
-					"default": {
-						"type": "intrinsic",
-						"name": "string"
-					}
-				}
-			],
-			"type": {
-				"type": "reflection",
-				"declaration": {
-					"id": 115,
-					"name": "__type",
-					"variant": "declaration",
-					"kind": 65536,
-					"flags": {},
-					"children": [
-						{
-							"id": 116,
-							"name": "ipfsCid",
-							"variant": "declaration",
-							"kind": 1024,
-							"flags": {
-								"isReadonly": true
-							},
-							"sources": [
-								{
-									"fileName": "toolCore/bundledTool/types.ts",
-									"line": 18,
-									"character": 11,
-									"url": "https://github.com/LIT-Protocol/Vincent/blob/8e21b5da26217bce6eb8963c7b9c9ea95c6a2290/packages/libs/tool-sdk/src/lib/toolCore/bundledTool/types.ts#L18"
-								}
-							],
-							"type": {
-								"type": "reference",
-								"target": 120,
-								"name": "IpfsCid",
-								"package": "@lit-protocol/vincent-tool-sdk",
-								"refersToTypeParameter": true
-							}
-						},
-						{
-							"id": 117,
-							"name": "vincentTool",
-							"variant": "declaration",
-							"kind": 1024,
-							"flags": {
-								"isReadonly": true
-							},
-							"sources": [
-								{
-									"fileName": "toolCore/bundledTool/types.ts",
-									"line": 19,
-									"character": 11,
-									"url": "https://github.com/LIT-Protocol/Vincent/blob/8e21b5da26217bce6eb8963c7b9c9ea95c6a2290/packages/libs/tool-sdk/src/lib/toolCore/bundledTool/types.ts#L19"
-								}
-							],
-							"type": {
-								"type": "reference",
-								"target": 119,
-								"name": "VT",
-								"package": "@lit-protocol/vincent-tool-sdk",
-								"refersToTypeParameter": true
-							}
-						}
-					],
-					"groups": [
-						{
-							"title": "Properties",
-							"children": [
-								116,
-								117
-							]
-						}
-					],
-					"sources": [
-						{
-							"fileName": "toolCore/bundledTool/types.ts",
-							"line": 17,
-							"character": 4,
-							"url": "https://github.com/LIT-Protocol/Vincent/blob/8e21b5da26217bce6eb8963c7b9c9ea95c6a2290/packages/libs/tool-sdk/src/lib/toolCore/bundledTool/types.ts#L17"
-						}
-					]
-				}
-			}
-		},
-		{
-			"id": 156,
-			"name": "PolicyEvaluationResultContext",
-			"variant": "declaration",
-			"kind": 2097152,
-			"flags": {},
-			"sources": [
-				{
-					"fileName": "types.ts",
-					"line": 158,
-					"character": 12,
-					"url": "https://github.com/LIT-Protocol/Vincent/blob/8e21b5da26217bce6eb8963c7b9c9ea95c6a2290/packages/libs/tool-sdk/src/lib/types.ts#L158"
-				}
-			],
-			"typeParameters": [
-				{
-					"id": 182,
-					"name": "Policies",
+					"id": 153,
+					"name": "UserParams",
 					"variant": "typeParam",
 					"kind": 131072,
 					"flags": {},
 					"type": {
 						"type": "reference",
 						"target": {
-							"sourceFileName": "../../../node_modules/.pnpm/typescript@5.8.3/node_modules/typescript/lib/lib.es5.d.ts",
-							"qualifiedName": "Record"
+							"sourceFileName": "../../../node_modules/.pnpm/zod@3.25.64/node_modules/zod/dist/types/v3/types.d.ts",
+							"qualifiedName": "ZodType"
 						},
-						"typeArguments": [
-							{
-								"type": "intrinsic",
-								"name": "string"
-							},
-							{
-								"type": "reflection",
-								"declaration": {
-									"id": 183,
-									"name": "__type",
-									"variant": "declaration",
-									"kind": 65536,
-									"flags": {},
-									"children": [
-										{
-											"id": 184,
-											"name": "vincentPolicy",
-											"variant": "declaration",
-											"kind": 1024,
-											"flags": {},
-											"sources": [
-												{
-													"fileName": "types.ts",
-													"line": 162,
-													"character": 6,
-													"url": "https://github.com/LIT-Protocol/Vincent/blob/8e21b5da26217bce6eb8963c7b9c9ea95c6a2290/packages/libs/tool-sdk/src/lib/types.ts#L162"
-												}
-											],
-											"type": {
-												"type": "reference",
-												"target": {
-													"sourceFileName": "src/lib/types.ts",
-													"qualifiedName": "VincentPolicy"
-												},
-												"typeArguments": [
-													{
-														"type": "intrinsic",
-														"name": "any"
-													},
-													{
-														"type": "intrinsic",
-														"name": "any"
-													},
-													{
-														"type": "intrinsic",
-														"name": "any"
-													},
-													{
-														"type": "intrinsic",
-														"name": "any"
-													},
-													{
-														"type": "intrinsic",
-														"name": "any"
-													},
-													{
-														"type": "intrinsic",
-														"name": "any"
-													},
-													{
-														"type": "intrinsic",
-														"name": "any"
-													},
-													{
-														"type": "intrinsic",
-														"name": "any"
-													},
-													{
-														"type": "intrinsic",
-														"name": "any"
-													},
-													{
-														"type": "intrinsic",
-														"name": "any"
-													}
-												],
-												"name": "VincentPolicy",
-												"package": "@lit-protocol/vincent-tool-sdk"
-											}
-										}
-									],
-									"groups": [
-										{
-											"title": "Properties",
-											"children": [
-												184
-											]
-										}
-									],
-									"sources": [
-										{
-											"fileName": "types.ts",
-											"line": 161,
-											"character": 4,
-											"url": "https://github.com/LIT-Protocol/Vincent/blob/8e21b5da26217bce6eb8963c7b9c9ea95c6a2290/packages/libs/tool-sdk/src/lib/types.ts#L161"
-										}
-									]
-								}
-							}
-						],
-						"name": "Record",
-						"package": "typescript"
+						"name": "z.ZodType",
+						"package": "zod",
+						"qualifiedName": "ZodType"
+					},
+					"default": {
+						"type": "reference",
+						"target": {
+							"sourceFileName": "../../../node_modules/.pnpm/zod@3.25.64/node_modules/zod/dist/types/v3/types.d.ts",
+							"qualifiedName": "ZodUndefined"
+						},
+						"name": "z.ZodUndefined",
+						"package": "zod",
+						"qualifiedName": "ZodUndefined"
+					}
+				},
+				{
+					"id": 154,
+					"name": "AllowResult",
+					"variant": "typeParam",
+					"kind": 131072,
+					"flags": {},
+					"type": {
+						"type": "reference",
+						"target": {
+							"sourceFileName": "../../../node_modules/.pnpm/zod@3.25.64/node_modules/zod/dist/types/v3/types.d.ts",
+							"qualifiedName": "ZodType"
+						},
+						"name": "z.ZodType",
+						"package": "zod",
+						"qualifiedName": "ZodType"
+					},
+					"default": {
+						"type": "reference",
+						"target": {
+							"sourceFileName": "../../../node_modules/.pnpm/zod@3.25.64/node_modules/zod/dist/types/v3/types.d.ts",
+							"qualifiedName": "ZodUndefined"
+						},
+						"name": "z.ZodUndefined",
+						"package": "zod",
+						"qualifiedName": "ZodUndefined"
+					}
+				},
+				{
+					"id": 155,
+					"name": "DenyResult",
+					"variant": "typeParam",
+					"kind": 131072,
+					"flags": {},
+					"type": {
+						"type": "reference",
+						"target": {
+							"sourceFileName": "../../../node_modules/.pnpm/zod@3.25.64/node_modules/zod/dist/types/v3/types.d.ts",
+							"qualifiedName": "ZodType"
+						},
+						"name": "z.ZodType",
+						"package": "zod",
+						"qualifiedName": "ZodType"
+					},
+					"default": {
+						"type": "reference",
+						"target": {
+							"sourceFileName": "../../../node_modules/.pnpm/zod@3.25.64/node_modules/zod/dist/types/v3/types.d.ts",
+							"qualifiedName": "ZodUndefined"
+						},
+						"name": "z.ZodUndefined",
+						"package": "zod",
+						"qualifiedName": "ZodUndefined"
 					}
 				}
 			],
 			"type": {
-				"type": "intersection",
-				"types": [
-					{
-						"type": "reflection",
-						"declaration": {
-							"id": 157,
+				"type": "reflection",
+				"declaration": {
+					"id": 145,
+					"name": "__type",
+					"variant": "declaration",
+					"kind": 65536,
+					"flags": {},
+					"sources": [
+						{
+							"fileName": "policyCore/policyDef/types.ts",
+							"line": 21,
+							"character": 4,
+							"url": "https://github.com/LIT-Protocol/Vincent/blob/46a7999ef358981de990d808b7484f24731b23f9/packages/libs/tool-sdk/src/lib/policyCore/policyDef/types.ts#L21"
+						}
+					],
+					"signatures": [
+						{
+							"id": 146,
 							"name": "__type",
-							"variant": "declaration",
-							"kind": 65536,
+							"variant": "signature",
+							"kind": 4096,
 							"flags": {},
-							"children": [
+							"parameters": [
 								{
-									"id": 158,
-									"name": "evaluatedPolicies",
-									"variant": "declaration",
-									"kind": 1024,
+									"id": 147,
+									"name": "args",
+									"variant": "param",
+									"kind": 32768,
 									"flags": {},
-									"sources": [
-										{
-											"fileName": "types.ts",
-											"line": 177,
-											"character": 2,
-											"url": "https://github.com/LIT-Protocol/Vincent/blob/8e21b5da26217bce6eb8963c7b9c9ea95c6a2290/packages/libs/tool-sdk/src/lib/types.ts#L177"
-										}
-									],
 									"type": {
-										"type": "array",
-										"elementType": {
-											"type": "typeOperator",
-											"operator": "keyof",
-											"target": {
-												"type": "reference",
-												"target": 182,
-												"name": "Policies",
-												"package": "@lit-protocol/vincent-tool-sdk",
-												"refersToTypeParameter": true
-											}
-										}
-									}
-								}
-							],
-							"groups": [
-								{
-									"title": "Properties",
-									"children": [
-										158
-									]
-								}
-							],
-							"sources": [
-								{
-									"fileName": "types.ts",
-									"line": 176,
-									"character": 4,
-									"url": "https://github.com/LIT-Protocol/Vincent/blob/8e21b5da26217bce6eb8963c7b9c9ea95c6a2290/packages/libs/tool-sdk/src/lib/types.ts#L176"
-								}
-							]
-						}
-					},
-					{
-						"type": "union",
-						"types": [
-							{
-								"type": "reflection",
-								"declaration": {
-									"id": 159,
-									"name": "__type",
-									"variant": "declaration",
-									"kind": 65536,
-									"flags": {},
-									"children": [
-										{
-											"id": 160,
-											"name": "allow",
-											"variant": "declaration",
-											"kind": 1024,
-											"flags": {},
-											"sources": [
-												{
-													"fileName": "types.ts",
-													"line": 180,
-													"character": 6,
-													"url": "https://github.com/LIT-Protocol/Vincent/blob/8e21b5da26217bce6eb8963c7b9c9ea95c6a2290/packages/libs/tool-sdk/src/lib/types.ts#L180"
-												}
-											],
-											"type": {
-												"type": "literal",
-												"value": true
-											}
-										},
-										{
-											"id": 161,
-											"name": "allowedPolicies",
-											"variant": "declaration",
-											"kind": 1024,
-											"flags": {},
-											"sources": [
-												{
-													"fileName": "types.ts",
-													"line": 181,
-													"character": 6,
-													"url": "https://github.com/LIT-Protocol/Vincent/blob/8e21b5da26217bce6eb8963c7b9c9ea95c6a2290/packages/libs/tool-sdk/src/lib/types.ts#L181"
-												}
-											],
-											"type": {
-												"type": "mapped",
-												"parameter": "PolicyKey",
-												"parameterType": {
-													"type": "typeOperator",
-													"operator": "keyof",
-													"target": {
-														"type": "reference",
-														"target": 182,
-														"name": "Policies",
-														"package": "@lit-protocol/vincent-tool-sdk",
-														"refersToTypeParameter": true
-													}
-												},
-												"templateType": {
-													"type": "reflection",
-													"declaration": {
-														"id": 162,
-														"name": "__type",
-														"variant": "declaration",
-														"kind": 65536,
-														"flags": {},
-														"children": [
-															{
-																"id": 163,
-																"name": "result",
-																"variant": "declaration",
-																"kind": 1024,
-																"flags": {},
-																"sources": [
-																	{
-																		"fileName": "types.ts",
-																		"line": 183,
-																		"character": 10,
-																		"url": "https://github.com/LIT-Protocol/Vincent/blob/8e21b5da26217bce6eb8963c7b9c9ea95c6a2290/packages/libs/tool-sdk/src/lib/types.ts#L183"
-																	}
-																],
-																"type": {
-																	"type": "conditional",
-																	"checkType": {
-																		"type": "indexedAccess",
-																		"indexType": {
-																			"type": "literal",
-																			"value": "__schemaTypes"
-																		},
-																		"objectType": {
-																			"type": "indexedAccess",
-																			"indexType": {
-																				"type": "reference",
-																				"target": {
-																					"sourceFileName": "src/lib/types.ts",
-																					"qualifiedName": "PolicyKey"
-																				},
-																				"name": "PolicyKey",
-																				"package": "@lit-protocol/vincent-tool-sdk",
-																				"refersToTypeParameter": true
-																			},
-																			"objectType": {
-																				"type": "reference",
-																				"target": 182,
-																				"name": "Policies",
-																				"package": "@lit-protocol/vincent-tool-sdk",
-																				"refersToTypeParameter": true
-																			}
-																		}
-																	},
-																	"extendsType": {
-																		"type": "reflection",
-																		"declaration": {
-																			"id": 164,
-																			"name": "__type",
-																			"variant": "declaration",
-																			"kind": 65536,
-																			"flags": {},
-																			"children": [
-																				{
-																					"id": 165,
-																					"name": "evalAllowResultSchema",
-																					"variant": "declaration",
-																					"kind": 1024,
-																					"flags": {},
-																					"sources": [
-																						{
-																							"fileName": "types.ts",
-																							"line": 184,
-																							"character": 12,
-																							"url": "https://github.com/LIT-Protocol/Vincent/blob/8e21b5da26217bce6eb8963c7b9c9ea95c6a2290/packages/libs/tool-sdk/src/lib/types.ts#L184"
-																						}
-																					],
-																					"type": {
-																						"type": "inferred",
-																						"name": "Schema"
-																					}
-																				}
-																			],
-																			"groups": [
-																				{
-																					"title": "Properties",
-																					"children": [
-																						165
-																					]
-																				}
-																			],
-																			"sources": [
-																				{
-																					"fileName": "types.ts",
-																					"line": 183,
-																					"character": 63,
-																					"url": "https://github.com/LIT-Protocol/Vincent/blob/8e21b5da26217bce6eb8963c7b9c9ea95c6a2290/packages/libs/tool-sdk/src/lib/types.ts#L183"
-																				}
-																			]
-																		}
-																	},
-																	"trueType": {
-																		"type": "conditional",
-																		"checkType": {
-																			"type": "reference",
-																			"target": {
-																				"sourceFileName": "src/lib/types.ts",
-																				"qualifiedName": "Schema"
-																			},
-																			"name": "Schema",
-																			"package": "@lit-protocol/vincent-tool-sdk",
-																			"refersToTypeParameter": true
-																		},
-																		"extendsType": {
-																			"type": "reference",
-																			"target": {
-																				"sourceFileName": "../../../node_modules/.pnpm/zod@3.25.64/node_modules/zod/dist/types/v3/types.d.ts",
-																				"qualifiedName": "ZodType"
-																			},
-																			"name": "z.ZodType",
-																			"package": "zod",
-																			"qualifiedName": "ZodType"
-																		},
-																		"trueType": {
-																			"type": "reference",
-																			"target": {
-																				"sourceFileName": "../../../node_modules/.pnpm/zod@3.25.64/node_modules/zod/dist/types/v3/types.d.ts",
-																				"qualifiedName": "TypeOf"
-																			},
-																			"typeArguments": [
-																				{
-																					"type": "reference",
-																					"target": {
-																						"sourceFileName": "src/lib/types.ts",
-																						"qualifiedName": "Schema"
-																					},
-																					"name": "Schema",
-																					"package": "@lit-protocol/vincent-tool-sdk",
-																					"refersToTypeParameter": true
-																				}
-																			],
-																			"name": "z.infer",
-																			"package": "zod",
-																			"qualifiedName": "TypeOf"
-																		},
-																		"falseType": {
-																			"type": "intrinsic",
-																			"name": "never"
-																		}
-																	},
-																	"falseType": {
-																		"type": "intrinsic",
-																		"name": "never"
-																	}
-																}
-															}
-														],
-														"groups": [
-															{
-																"title": "Properties",
-																"children": [
-																	163
-																]
-															}
-														],
-														"sources": [
-															{
-																"fileName": "types.ts",
-																"line": 182,
-																"character": 40,
-																"url": "https://github.com/LIT-Protocol/Vincent/blob/8e21b5da26217bce6eb8963c7b9c9ea95c6a2290/packages/libs/tool-sdk/src/lib/types.ts#L182"
-															}
-														]
-													}
-												},
-												"optionalModifier": "+"
-											}
-										},
-										{
-											"id": 166,
-											"name": "deniedPolicy",
-											"variant": "declaration",
-											"kind": 1024,
-											"flags": {
-												"isOptional": true
-											},
-											"sources": [
-												{
-													"fileName": "types.ts",
-													"line": 192,
-													"character": 6,
-													"url": "https://github.com/LIT-Protocol/Vincent/blob/8e21b5da26217bce6eb8963c7b9c9ea95c6a2290/packages/libs/tool-sdk/src/lib/types.ts#L192"
-												}
-											],
-											"type": {
-												"type": "intrinsic",
-												"name": "never"
-											}
-										}
-									],
-									"groups": [
-										{
-											"title": "Properties",
-											"children": [
-												160,
-												161,
-												166
-											]
-										}
-									],
-									"sources": [
-										{
-											"fileName": "types.ts",
-											"line": 179,
-											"character": 4,
-											"url": "https://github.com/LIT-Protocol/Vincent/blob/8e21b5da26217bce6eb8963c7b9c9ea95c6a2290/packages/libs/tool-sdk/src/lib/types.ts#L179"
-										}
-									]
-								}
-							},
-							{
-								"type": "reflection",
-								"declaration": {
-									"id": 167,
-									"name": "__type",
-									"variant": "declaration",
-									"kind": 65536,
-									"flags": {},
-									"children": [
-										{
-											"id": 168,
-											"name": "allow",
-											"variant": "declaration",
-											"kind": 1024,
-											"flags": {},
-											"sources": [
-												{
-													"fileName": "types.ts",
-													"line": 195,
-													"character": 6,
-													"url": "https://github.com/LIT-Protocol/Vincent/blob/8e21b5da26217bce6eb8963c7b9c9ea95c6a2290/packages/libs/tool-sdk/src/lib/types.ts#L195"
-												}
-											],
-											"type": {
-												"type": "literal",
-												"value": false
-											}
-										},
-										{
-											"id": 177,
-											"name": "allowedPolicies",
-											"variant": "declaration",
-											"kind": 1024,
-											"flags": {
-												"isOptional": true
-											},
-											"sources": [
-												{
-													"fileName": "types.ts",
-													"line": 208,
-													"character": 6,
-													"url": "https://github.com/LIT-Protocol/Vincent/blob/8e21b5da26217bce6eb8963c7b9c9ea95c6a2290/packages/libs/tool-sdk/src/lib/types.ts#L208"
-												}
-											],
-											"type": {
-												"type": "mapped",
-												"parameter": "PolicyKey",
-												"parameterType": {
-													"type": "typeOperator",
-													"operator": "keyof",
-													"target": {
-														"type": "reference",
-														"target": 182,
-														"name": "Policies",
-														"package": "@lit-protocol/vincent-tool-sdk",
-														"refersToTypeParameter": true
-													}
-												},
-												"templateType": {
-													"type": "reflection",
-													"declaration": {
-														"id": 178,
-														"name": "__type",
-														"variant": "declaration",
-														"kind": 65536,
-														"flags": {},
-														"children": [
-															{
-																"id": 179,
-																"name": "result",
-																"variant": "declaration",
-																"kind": 1024,
-																"flags": {},
-																"sources": [
-																	{
-																		"fileName": "types.ts",
-																		"line": 210,
-																		"character": 10,
-																		"url": "https://github.com/LIT-Protocol/Vincent/blob/8e21b5da26217bce6eb8963c7b9c9ea95c6a2290/packages/libs/tool-sdk/src/lib/types.ts#L210"
-																	}
-																],
-																"type": {
-																	"type": "conditional",
-																	"checkType": {
-																		"type": "indexedAccess",
-																		"indexType": {
-																			"type": "literal",
-																			"value": "__schemaTypes"
-																		},
-																		"objectType": {
-																			"type": "indexedAccess",
-																			"indexType": {
-																				"type": "reference",
-																				"target": {
-																					"sourceFileName": "src/lib/types.ts",
-																					"qualifiedName": "PolicyKey"
-																				},
-																				"name": "PolicyKey",
-																				"package": "@lit-protocol/vincent-tool-sdk",
-																				"refersToTypeParameter": true
-																			},
-																			"objectType": {
-																				"type": "reference",
-																				"target": 182,
-																				"name": "Policies",
-																				"package": "@lit-protocol/vincent-tool-sdk",
-																				"refersToTypeParameter": true
-																			}
-																		}
-																	},
-																	"extendsType": {
-																		"type": "reflection",
-																		"declaration": {
-																			"id": 180,
-																			"name": "__type",
-																			"variant": "declaration",
-																			"kind": 65536,
-																			"flags": {},
-																			"children": [
-																				{
-																					"id": 181,
-																					"name": "evalAllowResultSchema",
-																					"variant": "declaration",
-																					"kind": 1024,
-																					"flags": {},
-																					"sources": [
-																						{
-																							"fileName": "types.ts",
-																							"line": 211,
-																							"character": 12,
-																							"url": "https://github.com/LIT-Protocol/Vincent/blob/8e21b5da26217bce6eb8963c7b9c9ea95c6a2290/packages/libs/tool-sdk/src/lib/types.ts#L211"
-																						}
-																					],
-																					"type": {
-																						"type": "inferred",
-																						"name": "Schema"
-																					}
-																				}
-																			],
-																			"groups": [
-																				{
-																					"title": "Properties",
-																					"children": [
-																						181
-																					]
-																				}
-																			],
-																			"sources": [
-																				{
-																					"fileName": "types.ts",
-																					"line": 210,
-																					"character": 63,
-																					"url": "https://github.com/LIT-Protocol/Vincent/blob/8e21b5da26217bce6eb8963c7b9c9ea95c6a2290/packages/libs/tool-sdk/src/lib/types.ts#L210"
-																				}
-																			]
-																		}
-																	},
-																	"trueType": {
-																		"type": "conditional",
-																		"checkType": {
-																			"type": "reference",
-																			"target": {
-																				"sourceFileName": "src/lib/types.ts",
-																				"qualifiedName": "Schema"
-																			},
-																			"name": "Schema",
-																			"package": "@lit-protocol/vincent-tool-sdk",
-																			"refersToTypeParameter": true
-																		},
-																		"extendsType": {
-																			"type": "reference",
-																			"target": {
-																				"sourceFileName": "../../../node_modules/.pnpm/zod@3.25.64/node_modules/zod/dist/types/v3/types.d.ts",
-																				"qualifiedName": "ZodType"
-																			},
-																			"name": "z.ZodType",
-																			"package": "zod",
-																			"qualifiedName": "ZodType"
-																		},
-																		"trueType": {
-																			"type": "reference",
-																			"target": {
-																				"sourceFileName": "../../../node_modules/.pnpm/zod@3.25.64/node_modules/zod/dist/types/v3/types.d.ts",
-																				"qualifiedName": "TypeOf"
-																			},
-																			"typeArguments": [
-																				{
-																					"type": "reference",
-																					"target": {
-																						"sourceFileName": "src/lib/types.ts",
-																						"qualifiedName": "Schema"
-																					},
-																					"name": "Schema",
-																					"package": "@lit-protocol/vincent-tool-sdk",
-																					"refersToTypeParameter": true
-																				}
-																			],
-																			"name": "z.infer",
-																			"package": "zod",
-																			"qualifiedName": "TypeOf"
-																		},
-																		"falseType": {
-																			"type": "intrinsic",
-																			"name": "never"
-																		}
-																	},
-																	"falseType": {
-																		"type": "intrinsic",
-																		"name": "never"
-																	}
-																}
-															}
-														],
-														"groups": [
-															{
-																"title": "Properties",
-																"children": [
-																	179
-																]
-															}
-														],
-														"sources": [
-															{
-																"fileName": "types.ts",
-																"line": 209,
-																"character": 40,
-																"url": "https://github.com/LIT-Protocol/Vincent/blob/8e21b5da26217bce6eb8963c7b9c9ea95c6a2290/packages/libs/tool-sdk/src/lib/types.ts#L209"
-															}
-														]
-													}
-												},
-												"optionalModifier": "+"
-											}
-										},
-										{
-											"id": 169,
-											"name": "deniedPolicy",
-											"variant": "declaration",
-											"kind": 1024,
-											"flags": {},
-											"sources": [
-												{
-													"fileName": "types.ts",
-													"line": 196,
-													"character": 6,
-													"url": "https://github.com/LIT-Protocol/Vincent/blob/8e21b5da26217bce6eb8963c7b9c9ea95c6a2290/packages/libs/tool-sdk/src/lib/types.ts#L196"
-												}
-											],
-											"type": {
-												"type": "reflection",
-												"declaration": {
-													"id": 170,
-													"name": "__type",
-													"variant": "declaration",
-													"kind": 65536,
-													"flags": {},
-													"children": [
-														{
-															"id": 171,
-															"name": "packageName",
-															"variant": "declaration",
-															"kind": 1024,
-															"flags": {},
-															"sources": [
-																{
-																	"fileName": "types.ts",
-																	"line": 197,
-																	"character": 8,
-																	"url": "https://github.com/LIT-Protocol/Vincent/blob/8e21b5da26217bce6eb8963c7b9c9ea95c6a2290/packages/libs/tool-sdk/src/lib/types.ts#L197"
-																}
-															],
-															"type": {
-																"type": "typeOperator",
-																"operator": "keyof",
-																"target": {
-																	"type": "reference",
-																	"target": 182,
-																	"name": "Policies",
-																	"package": "@lit-protocol/vincent-tool-sdk",
-																	"refersToTypeParameter": true
-																}
-															}
-														},
-														{
-															"id": 172,
-															"name": "result",
-															"variant": "declaration",
-															"kind": 1024,
-															"flags": {},
-															"sources": [
-																{
-																	"fileName": "types.ts",
-																	"line": 198,
-																	"character": 8,
-																	"url": "https://github.com/LIT-Protocol/Vincent/blob/8e21b5da26217bce6eb8963c7b9c9ea95c6a2290/packages/libs/tool-sdk/src/lib/types.ts#L198"
-																}
-															],
-															"type": {
-																"type": "intersection",
-																"types": [
-																	{
-																		"type": "reflection",
-																		"declaration": {
-																			"id": 173,
-																			"name": "__type",
-																			"variant": "declaration",
-																			"kind": 65536,
-																			"flags": {},
-																			"children": [
-																				{
-																					"id": 174,
-																					"name": "error",
-																					"variant": "declaration",
-																					"kind": 1024,
-																					"flags": {
-																						"isOptional": true
-																					},
-																					"sources": [
-																						{
-																							"fileName": "types.ts",
-																							"line": 199,
-																							"character": 10,
-																							"url": "https://github.com/LIT-Protocol/Vincent/blob/8e21b5da26217bce6eb8963c7b9c9ea95c6a2290/packages/libs/tool-sdk/src/lib/types.ts#L199"
-																						}
-																					],
-																					"type": {
-																						"type": "intrinsic",
-																						"name": "string"
-																					}
-																				}
-																			],
-																			"groups": [
-																				{
-																					"title": "Properties",
-																					"children": [
-																						174
-																					]
-																				}
-																			],
-																			"sources": [
-																				{
-																					"fileName": "types.ts",
-																					"line": 198,
-																					"character": 16,
-																					"url": "https://github.com/LIT-Protocol/Vincent/blob/8e21b5da26217bce6eb8963c7b9c9ea95c6a2290/packages/libs/tool-sdk/src/lib/types.ts#L198"
-																				}
-																			]
-																		}
-																	},
-																	{
-																		"type": "conditional",
-																		"checkType": {
-																			"type": "indexedAccess",
-																			"indexType": {
-																				"type": "literal",
-																				"value": "__schemaTypes"
-																			},
-																			"objectType": {
-																				"type": "indexedAccess",
-																				"indexType": {
-																					"type": "reference",
-																					"target": {
-																						"sourceFileName": "../../../node_modules/.pnpm/typescript@5.8.3/node_modules/typescript/lib/lib.es5.d.ts",
-																						"qualifiedName": "Extract"
-																					},
-																					"typeArguments": [
-																						{
-																							"type": "unknown",
-																							"name": "..."
-																						},
-																						{
-																							"type": "unknown",
-																							"name": "..."
-																						}
-																					],
-																					"name": "Extract",
-																					"package": "typescript"
-																				},
-																				"objectType": {
-																					"type": "reference",
-																					"target": 182,
-																					"name": "Policies",
-																					"package": "@lit-protocol/vincent-tool-sdk",
-																					"refersToTypeParameter": true
-																				}
-																			}
-																		},
-																		"extendsType": {
-																			"type": "reflection",
-																			"declaration": {
-																				"id": 175,
-																				"name": "__type",
-																				"variant": "declaration",
-																				"kind": 65536,
-																				"flags": {},
-																				"children": [
-																					{
-																						"id": 176,
-																						"name": "evalDenyResultSchema",
-																						"variant": "declaration",
-																						"kind": 1024,
-																						"flags": {},
-																						"sources": [
-																							{
-																								"fileName": "types.ts",
-																								"line": 201,
-																								"character": 10,
-																								"url": "https://github.com/LIT-Protocol/Vincent/blob/8e21b5da26217bce6eb8963c7b9c9ea95c6a2290/packages/libs/tool-sdk/src/lib/types.ts#L201"
-																							}
-																						],
-																						"type": {
-																							"type": "inferred",
-																							"name": "Schema"
-																						}
-																					}
-																				],
-																				"groups": [
-																					{
-																						"title": "Properties",
-																						"children": [
-																							176
-																						]
-																					}
-																				],
-																				"sources": [
-																					{
-																						"fileName": "types.ts",
-																						"line": 200,
-																						"character": 80,
-																						"url": "https://github.com/LIT-Protocol/Vincent/blob/8e21b5da26217bce6eb8963c7b9c9ea95c6a2290/packages/libs/tool-sdk/src/lib/types.ts#L200"
-																					}
-																				]
-																			}
-																		},
-																		"trueType": {
-																			"type": "conditional",
-																			"checkType": {
-																				"type": "reference",
-																				"target": {
-																					"sourceFileName": "src/lib/types.ts",
-																					"qualifiedName": "Schema"
-																				},
-																				"name": "Schema",
-																				"package": "@lit-protocol/vincent-tool-sdk",
-																				"refersToTypeParameter": true
-																			},
-																			"extendsType": {
-																				"type": "reference",
-																				"target": {
-																					"sourceFileName": "../../../node_modules/.pnpm/zod@3.25.64/node_modules/zod/dist/types/v3/types.d.ts",
-																					"qualifiedName": "ZodType"
-																				},
-																				"name": "z.ZodType",
-																				"package": "zod",
-																				"qualifiedName": "ZodType"
-																			},
-																			"trueType": {
-																				"type": "reference",
-																				"target": {
-																					"sourceFileName": "../../../node_modules/.pnpm/zod@3.25.64/node_modules/zod/dist/types/v3/types.d.ts",
-																					"qualifiedName": "TypeOf"
-																				},
-																				"typeArguments": [
-																					{
-																						"type": "reference",
-																						"target": {
-																							"sourceFileName": "src/lib/types.ts",
-																							"qualifiedName": "Schema"
-																						},
-																						"name": "Schema",
-																						"package": "@lit-protocol/vincent-tool-sdk",
-																						"refersToTypeParameter": true
-																					}
-																				],
-																				"name": "z.infer",
-																				"package": "zod",
-																				"qualifiedName": "TypeOf"
-																			},
-																			"falseType": {
-																				"type": "intrinsic",
-																				"name": "undefined"
-																			}
-																		},
-																		"falseType": {
-																			"type": "intrinsic",
-																			"name": "undefined"
-																		}
-																	}
-																]
-															}
-														}
-													],
-													"groups": [
-														{
-															"title": "Properties",
-															"children": [
-																171,
-																172
-															]
-														}
-													],
-													"sources": [
-														{
-															"fileName": "types.ts",
-															"line": 196,
-															"character": 20,
-															"url": "https://github.com/LIT-Protocol/Vincent/blob/8e21b5da26217bce6eb8963c7b9c9ea95c6a2290/packages/libs/tool-sdk/src/lib/types.ts#L196"
-														}
-													]
-												}
-											}
-										}
-									],
-									"groups": [
-										{
-											"title": "Properties",
-											"children": [
-												168,
-												177,
-												169
-											]
-										}
-									],
-									"sources": [
-										{
-											"fileName": "types.ts",
-											"line": 194,
-											"character": 4,
-											"url": "https://github.com/LIT-Protocol/Vincent/blob/8e21b5da26217bce6eb8963c7b9c9ea95c6a2290/packages/libs/tool-sdk/src/lib/types.ts#L194"
-										}
-									]
-								}
-							}
-						]
-					}
-				]
-			}
-		},
-		{
-			"id": 195,
-			"name": "VincentTool",
-			"variant": "declaration",
-			"kind": 2097152,
-			"flags": {},
-			"sources": [
-				{
-					"fileName": "types.ts",
-					"line": 357,
-					"character": 12,
-					"url": "https://github.com/LIT-Protocol/Vincent/blob/8e21b5da26217bce6eb8963c7b9c9ea95c6a2290/packages/libs/tool-sdk/src/lib/types.ts#L357"
-				}
-			],
-			"typeParameters": [
-				{
-					"id": 208,
-					"name": "ToolParamsSchema",
-					"variant": "typeParam",
-					"kind": 131072,
-					"flags": {},
-					"type": {
-						"type": "reference",
-						"target": {
-							"sourceFileName": "../../../node_modules/.pnpm/zod@3.25.64/node_modules/zod/dist/types/v3/types.d.ts",
-							"qualifiedName": "ZodType"
-						},
-						"name": "z.ZodType",
-						"package": "zod",
-						"qualifiedName": "ZodType"
-					}
-				},
-				{
-					"id": 209,
-					"name": "PkgNames",
-					"variant": "typeParam",
-					"kind": 131072,
-					"flags": {},
-					"type": {
-						"type": "intrinsic",
-						"name": "string"
-					}
-				},
-				{
-					"id": 210,
-					"name": "PolicyMap",
-					"variant": "typeParam",
-					"kind": 131072,
-					"flags": {},
-					"type": {
-						"type": "reference",
-						"target": {
-							"sourceFileName": "src/lib/toolCore/helpers/supportedPoliciesForTool.ts",
-							"qualifiedName": "ToolPolicyMap"
-						},
-						"typeArguments": [
-							{
-								"type": "intrinsic",
-								"name": "any"
-							},
-							{
-								"type": "reference",
-								"target": 209,
-								"name": "PkgNames",
-								"package": "@lit-protocol/vincent-tool-sdk",
-								"refersToTypeParameter": true
-							}
-						],
-						"name": "ToolPolicyMap",
-						"package": "@lit-protocol/vincent-tool-sdk"
-					}
-				},
-				{
-					"id": 211,
-					"name": "PoliciesByPackageName",
-					"variant": "typeParam",
-					"kind": 131072,
-					"flags": {},
-					"type": {
-						"type": "indexedAccess",
-						"indexType": {
-							"type": "literal",
-							"value": "policyByPackageName"
-						},
-						"objectType": {
-							"type": "reference",
-							"target": 210,
-							"name": "PolicyMap",
-							"package": "@lit-protocol/vincent-tool-sdk",
-							"refersToTypeParameter": true
-						}
-					}
-				},
-				{
-					"id": 212,
-					"name": "ExecuteSuccessSchema",
-					"variant": "typeParam",
-					"kind": 131072,
-					"flags": {},
-					"type": {
-						"type": "union",
-						"types": [
-							{
-								"type": "reference",
-								"target": {
-									"sourceFileName": "../../../node_modules/.pnpm/zod@3.25.64/node_modules/zod/dist/types/v3/types.d.ts",
-									"qualifiedName": "ZodType"
-								},
-								"name": "z.ZodType",
-								"package": "zod",
-								"qualifiedName": "ZodType"
-							},
-							{
-								"type": "intrinsic",
-								"name": "undefined"
-							}
-						]
-					},
-					"default": {
-						"type": "intrinsic",
-						"name": "undefined"
-					}
-				},
-				{
-					"id": 213,
-					"name": "ExecuteFailSchema",
-					"variant": "typeParam",
-					"kind": 131072,
-					"flags": {},
-					"type": {
-						"type": "union",
-						"types": [
-							{
-								"type": "reference",
-								"target": {
-									"sourceFileName": "../../../node_modules/.pnpm/zod@3.25.64/node_modules/zod/dist/types/v3/types.d.ts",
-									"qualifiedName": "ZodType"
-								},
-								"name": "z.ZodType",
-								"package": "zod",
-								"qualifiedName": "ZodType"
-							},
-							{
-								"type": "intrinsic",
-								"name": "undefined"
-							}
-						]
-					},
-					"default": {
-						"type": "intrinsic",
-						"name": "undefined"
-					}
-				},
-				{
-					"id": 214,
-					"name": "PrecheckSuccessSchema",
-					"variant": "typeParam",
-					"kind": 131072,
-					"flags": {},
-					"type": {
-						"type": "union",
-						"types": [
-							{
-								"type": "reference",
-								"target": {
-									"sourceFileName": "../../../node_modules/.pnpm/zod@3.25.64/node_modules/zod/dist/types/v3/types.d.ts",
-									"qualifiedName": "ZodType"
-								},
-								"name": "z.ZodType",
-								"package": "zod",
-								"qualifiedName": "ZodType"
-							},
-							{
-								"type": "intrinsic",
-								"name": "undefined"
-							}
-						]
-					},
-					"default": {
-						"type": "intrinsic",
-						"name": "undefined"
-					}
-				},
-				{
-					"id": 215,
-					"name": "PrecheckFailSchema",
-					"variant": "typeParam",
-					"kind": 131072,
-					"flags": {},
-					"type": {
-						"type": "union",
-						"types": [
-							{
-								"type": "reference",
-								"target": {
-									"sourceFileName": "../../../node_modules/.pnpm/zod@3.25.64/node_modules/zod/dist/types/v3/types.d.ts",
-									"qualifiedName": "ZodType"
-								},
-								"name": "z.ZodType",
-								"package": "zod",
-								"qualifiedName": "ZodType"
-							},
-							{
-								"type": "intrinsic",
-								"name": "undefined"
-							}
-						]
-					},
-					"default": {
-						"type": "intrinsic",
-						"name": "undefined"
-					}
-				},
-				{
-					"id": 216,
-					"name": "ExecuteFn",
-					"variant": "typeParam",
-					"kind": 131072,
-					"flags": {},
-					"default": {
-						"type": "reference",
-						"target": {
-							"sourceFileName": "src/lib/types.ts",
-							"qualifiedName": "ToolLifecycleFunction"
-						},
-						"typeArguments": [
-							{
-								"type": "reference",
-								"target": 208,
-								"name": "ToolParamsSchema",
-								"package": "@lit-protocol/vincent-tool-sdk",
-								"refersToTypeParameter": true
-							},
-							{
-								"type": "reference",
-								"target": {
-									"sourceFileName": "src/lib/types.ts",
-									"qualifiedName": "ToolExecutionPolicyContext"
-								},
-								"typeArguments": [
-									{
-										"type": "reference",
-										"target": 211,
-										"name": "PoliciesByPackageName",
-										"package": "@lit-protocol/vincent-tool-sdk",
-										"refersToTypeParameter": true
-									}
-								],
-								"name": "ToolExecutionPolicyContext",
-								"package": "@lit-protocol/vincent-tool-sdk"
-							},
-							{
-								"type": "reference",
-								"target": 212,
-								"name": "ExecuteSuccessSchema",
-								"package": "@lit-protocol/vincent-tool-sdk",
-								"refersToTypeParameter": true
-							},
-							{
-								"type": "reference",
-								"target": 213,
-								"name": "ExecuteFailSchema",
-								"package": "@lit-protocol/vincent-tool-sdk",
-								"refersToTypeParameter": true
-							}
-						],
-						"name": "ToolLifecycleFunction",
-						"package": "@lit-protocol/vincent-tool-sdk"
-					}
-				},
-				{
-					"id": 217,
-					"name": "PrecheckFn",
-					"variant": "typeParam",
-					"kind": 131072,
-					"flags": {},
-					"default": {
-						"type": "union",
-						"types": [
-							{
-								"type": "intrinsic",
-								"name": "undefined"
-							},
-							{
-								"type": "reference",
-								"target": {
-									"sourceFileName": "src/lib/types.ts",
-									"qualifiedName": "ToolLifecycleFunction"
-								},
-								"typeArguments": [
-									{
-										"type": "reference",
-										"target": 208,
-										"name": "ToolParamsSchema",
-										"package": "@lit-protocol/vincent-tool-sdk",
-										"refersToTypeParameter": true
-									},
-									{
-										"type": "reference",
-										"target": 156,
-										"typeArguments": [
-											{
-												"type": "reference",
-												"target": 211,
-												"name": "PoliciesByPackageName",
-												"package": "@lit-protocol/vincent-tool-sdk",
-												"refersToTypeParameter": true
-											}
-										],
-										"name": "PolicyEvaluationResultContext",
-										"package": "@lit-protocol/vincent-tool-sdk"
-									},
-									{
-										"type": "reference",
-										"target": 214,
-										"name": "PrecheckSuccessSchema",
-										"package": "@lit-protocol/vincent-tool-sdk",
-										"refersToTypeParameter": true
-									},
-									{
-										"type": "reference",
-										"target": 215,
-										"name": "PrecheckFailSchema",
-										"package": "@lit-protocol/vincent-tool-sdk",
-										"refersToTypeParameter": true
-									}
-								],
-								"name": "ToolLifecycleFunction",
-								"package": "@lit-protocol/vincent-tool-sdk"
-							}
-						]
-					}
-				}
-			],
-			"type": {
-				"type": "reflection",
-				"declaration": {
-					"id": 196,
-					"name": "__type",
-					"variant": "declaration",
-					"kind": 65536,
-					"flags": {},
-					"children": [
-						{
-							"id": 199,
-							"name": "execute",
-							"variant": "declaration",
-							"kind": 1024,
-							"flags": {},
-							"sources": [
-								{
-									"fileName": "types.ts",
-									"line": 385,
-									"character": 2,
-									"url": "https://github.com/LIT-Protocol/Vincent/blob/8e21b5da26217bce6eb8963c7b9c9ea95c6a2290/packages/libs/tool-sdk/src/lib/types.ts#L385"
-								}
-							],
-							"type": {
-								"type": "reference",
-								"target": 216,
-								"name": "ExecuteFn",
-								"package": "@lit-protocol/vincent-tool-sdk",
-								"refersToTypeParameter": true
-							}
-						},
-						{
-							"id": 197,
-							"name": "packageName",
-							"variant": "declaration",
-							"kind": 1024,
-							"flags": {},
-							"sources": [
-								{
-									"fileName": "types.ts",
-									"line": 383,
-									"character": 2,
-									"url": "https://github.com/LIT-Protocol/Vincent/blob/8e21b5da26217bce6eb8963c7b9c9ea95c6a2290/packages/libs/tool-sdk/src/lib/types.ts#L383"
-								}
-							],
-							"type": {
-								"type": "intrinsic",
-								"name": "string"
-							}
-						},
-						{
-							"id": 198,
-							"name": "precheck",
-							"variant": "declaration",
-							"kind": 1024,
-							"flags": {
-								"isOptional": true
-							},
-							"sources": [
-								{
-									"fileName": "types.ts",
-									"line": 384,
-									"character": 2,
-									"url": "https://github.com/LIT-Protocol/Vincent/blob/8e21b5da26217bce6eb8963c7b9c9ea95c6a2290/packages/libs/tool-sdk/src/lib/types.ts#L384"
-								}
-							],
-							"type": {
-								"type": "reference",
-								"target": 217,
-								"name": "PrecheckFn",
-								"package": "@lit-protocol/vincent-tool-sdk",
-								"refersToTypeParameter": true
-							}
-						},
-						{
-							"id": 201,
-							"name": "supportedPolicies",
-							"variant": "declaration",
-							"kind": 1024,
-							"flags": {},
-							"sources": [
-								{
-									"fileName": "types.ts",
-									"line": 387,
-									"character": 2,
-									"url": "https://github.com/LIT-Protocol/Vincent/blob/8e21b5da26217bce6eb8963c7b9c9ea95c6a2290/packages/libs/tool-sdk/src/lib/types.ts#L387"
-								}
-							],
-							"type": {
-								"type": "reference",
-								"target": 210,
-								"name": "PolicyMap",
-								"package": "@lit-protocol/vincent-tool-sdk",
-								"refersToTypeParameter": true
-							}
-						},
-						{
-							"id": 200,
-							"name": "toolParamsSchema",
-							"variant": "declaration",
-							"kind": 1024,
-							"flags": {},
-							"sources": [
-								{
-									"fileName": "types.ts",
-									"line": 386,
-									"character": 2,
-									"url": "https://github.com/LIT-Protocol/Vincent/blob/8e21b5da26217bce6eb8963c7b9c9ea95c6a2290/packages/libs/tool-sdk/src/lib/types.ts#L386"
-								}
-							],
-							"type": {
-								"type": "reference",
-								"target": 208,
-								"name": "ToolParamsSchema",
-								"package": "@lit-protocol/vincent-tool-sdk",
-								"refersToTypeParameter": true
-							}
-						}
-					],
-					"groups": [
-						{
-							"title": "Properties",
-							"children": [
-								199,
-								197,
-								198,
-								201,
-								200
-							]
-						}
-					],
-					"sources": [
-						{
-							"fileName": "types.ts",
-							"line": 382,
-							"character": 4,
-							"url": "https://github.com/LIT-Protocol/Vincent/blob/8e21b5da26217bce6eb8963c7b9c9ea95c6a2290/packages/libs/tool-sdk/src/lib/types.ts#L382"
-						}
-					]
-				}
-			}
-		},
-		{
-			"id": 121,
-			"name": "VincentToolPolicy",
-			"variant": "declaration",
-			"kind": 2097152,
-			"flags": {},
-			"sources": [
-				{
-					"fileName": "types.ts",
-					"line": 74,
-					"character": 12,
-					"url": "https://github.com/LIT-Protocol/Vincent/blob/8e21b5da26217bce6eb8963c7b9c9ea95c6a2290/packages/libs/tool-sdk/src/lib/types.ts#L74"
-				}
-			],
-			"typeParameters": [
-				{
-					"id": 140,
-					"name": "ToolParamsSchema",
-					"variant": "typeParam",
-					"kind": 131072,
-					"flags": {},
-					"type": {
-						"type": "reference",
-						"target": {
-							"sourceFileName": "../../../node_modules/.pnpm/zod@3.25.64/node_modules/zod/dist/types/v3/types.d.ts",
-							"qualifiedName": "ZodType"
-						},
-						"name": "z.ZodType",
-						"package": "zod",
-						"qualifiedName": "ZodType"
-					}
-				},
-				{
-					"id": 141,
-					"name": "VP",
-					"variant": "typeParam",
-					"kind": 131072,
-					"flags": {},
-					"type": {
-						"type": "reference",
-						"target": {
-							"sourceFileName": "src/lib/types.ts",
-							"qualifiedName": "VincentPolicy"
-						},
-						"typeArguments": [
-							{
-								"type": "intrinsic",
-								"name": "any"
-							},
-							{
-								"type": "intrinsic",
-								"name": "any"
-							},
-							{
-								"type": "intrinsic",
-								"name": "any"
-							},
-							{
-								"type": "intrinsic",
-								"name": "any"
-							},
-							{
-								"type": "intrinsic",
-								"name": "any"
-							},
-							{
-								"type": "intrinsic",
-								"name": "any"
-							},
-							{
-								"type": "intrinsic",
-								"name": "any"
-							},
-							{
-								"type": "intrinsic",
-								"name": "any"
-							},
-							{
-								"type": "intrinsic",
-								"name": "any"
-							},
-							{
-								"type": "intrinsic",
-								"name": "any"
-							}
-						],
-						"name": "VincentPolicy",
-						"package": "@lit-protocol/vincent-tool-sdk"
-					}
-				},
-				{
-					"id": 142,
-					"name": "PackageName",
-					"variant": "typeParam",
-					"kind": 131072,
-					"flags": {},
-					"type": {
-						"type": "intrinsic",
-						"name": "string"
-					},
-					"default": {
-						"type": "intrinsic",
-						"name": "string"
-					}
-				},
-				{
-					"id": 143,
-					"name": "IpfsCid",
-					"variant": "typeParam",
-					"kind": 131072,
-					"flags": {},
-					"type": {
-						"type": "intrinsic",
-						"name": "string"
-					},
-					"default": {
-						"type": "intrinsic",
-						"name": "string"
-					}
-				}
-			],
-			"type": {
-				"type": "reflection",
-				"declaration": {
-					"id": 122,
-					"name": "__type",
-					"variant": "declaration",
-					"kind": 65536,
-					"flags": {},
-					"children": [
-						{
-							"id": 123,
-							"name": "ipfsCid",
-							"variant": "declaration",
-							"kind": 1024,
-							"flags": {},
-							"sources": [
-								{
-									"fileName": "types.ts",
-									"line": 80,
-									"character": 2,
-									"url": "https://github.com/LIT-Protocol/Vincent/blob/8e21b5da26217bce6eb8963c7b9c9ea95c6a2290/packages/libs/tool-sdk/src/lib/types.ts#L80"
-								}
-							],
-							"type": {
-								"type": "reference",
-								"target": 143,
-								"name": "IpfsCid",
-								"package": "@lit-protocol/vincent-tool-sdk",
-								"refersToTypeParameter": true
-							}
-						},
-						{
-							"id": 127,
-							"name": "toolParameterMappings",
-							"variant": "declaration",
-							"kind": 1024,
-							"flags": {},
-							"sources": [
-								{
-									"fileName": "types.ts",
-									"line": 82,
-									"character": 2,
-									"url": "https://github.com/LIT-Protocol/Vincent/blob/8e21b5da26217bce6eb8963c7b9c9ea95c6a2290/packages/libs/tool-sdk/src/lib/types.ts#L82"
-								}
-							],
-							"type": {
-								"type": "reference",
-								"target": {
-									"sourceFileName": "../../../node_modules/.pnpm/typescript@5.8.3/node_modules/typescript/lib/lib.es5.d.ts",
-									"qualifiedName": "Partial"
-								},
-								"typeArguments": [
-									{
-										"type": "mapped",
-										"parameter": "K",
-										"parameterType": {
-											"type": "typeOperator",
-											"operator": "keyof",
-											"target": {
-												"type": "reference",
-												"target": {
-													"sourceFileName": "../../../node_modules/.pnpm/zod@3.25.64/node_modules/zod/dist/types/v3/types.d.ts",
-													"qualifiedName": "TypeOf"
-												},
-												"typeArguments": [
-													{
-														"type": "reference",
-														"target": 140,
-														"name": "ToolParamsSchema",
-														"package": "@lit-protocol/vincent-tool-sdk",
-														"refersToTypeParameter": true
-													}
-												],
-												"name": "z.infer",
-												"package": "zod",
-												"qualifiedName": "TypeOf"
-											}
-										},
-										"templateType": {
-											"type": "typeOperator",
-											"operator": "keyof",
-											"target": {
-												"type": "reference",
-												"target": {
-													"sourceFileName": "../../../node_modules/.pnpm/zod@3.25.64/node_modules/zod/dist/types/v3/types.d.ts",
-													"qualifiedName": "TypeOf"
-												},
-												"typeArguments": [
-													{
-														"type": "indexedAccess",
-														"indexType": {
-															"type": "literal",
-															"value": "toolParamsSchema"
-														},
-														"objectType": {
-															"type": "reference",
-															"target": 141,
-															"name": "VP",
-															"package": "@lit-protocol/vincent-tool-sdk",
-															"refersToTypeParameter": true
-														}
-													}
-												],
-												"name": "z.infer",
-												"package": "zod",
-												"qualifiedName": "TypeOf"
-											}
-										}
-									}
-								],
-								"name": "Partial",
-								"package": "typescript"
-							}
-						},
-						{
-							"id": 124,
-							"name": "vincentPolicy",
-							"variant": "declaration",
-							"kind": 1024,
-							"flags": {},
-							"sources": [
-								{
-									"fileName": "types.ts",
-									"line": 81,
-									"character": 2,
-									"url": "https://github.com/LIT-Protocol/Vincent/blob/8e21b5da26217bce6eb8963c7b9c9ea95c6a2290/packages/libs/tool-sdk/src/lib/types.ts#L81"
-								}
-							],
-							"type": {
-								"type": "intersection",
-								"types": [
-									{
-										"type": "reference",
-										"target": 141,
-										"name": "VP",
-										"package": "@lit-protocol/vincent-tool-sdk",
-										"refersToTypeParameter": true
-									},
-									{
 										"type": "reflection",
 										"declaration": {
-											"id": 125,
+											"id": 148,
 											"name": "__type",
 											"variant": "declaration",
 											"kind": 65536,
 											"flags": {},
 											"children": [
 												{
-													"id": 126,
-													"name": "packageName",
+													"id": 149,
+													"name": "toolParams",
 													"variant": "declaration",
 													"kind": 1024,
 													"flags": {},
 													"sources": [
 														{
-															"fileName": "types.ts",
-															"line": 81,
-															"character": 24,
-															"url": "https://github.com/LIT-Protocol/Vincent/blob/8e21b5da26217bce6eb8963c7b9c9ea95c6a2290/packages/libs/tool-sdk/src/lib/types.ts#L81"
+															"fileName": "policyCore/policyDef/types.ts",
+															"line": 23,
+															"character": 4,
+															"url": "https://github.com/LIT-Protocol/Vincent/blob/46a7999ef358981de990d808b7484f24731b23f9/packages/libs/tool-sdk/src/lib/policyCore/policyDef/types.ts#L23"
 														}
 													],
 													"type": {
 														"type": "reference",
-														"target": 142,
-														"name": "PackageName",
-														"package": "@lit-protocol/vincent-tool-sdk",
-														"refersToTypeParameter": true
+														"target": {
+															"sourceFileName": "../../../node_modules/.pnpm/zod@3.25.64/node_modules/zod/dist/types/v3/types.d.ts",
+															"qualifiedName": "TypeOf"
+														},
+														"typeArguments": [
+															{
+																"type": "reference",
+																"target": 152,
+																"name": "ToolParams",
+																"package": "@lit-protocol/vincent-tool-sdk",
+																"refersToTypeParameter": true
+															}
+														],
+														"name": "z.infer",
+														"package": "zod",
+														"qualifiedName": "TypeOf"
+													}
+												},
+												{
+													"id": 150,
+													"name": "userParams",
+													"variant": "declaration",
+													"kind": 1024,
+													"flags": {},
+													"sources": [
+														{
+															"fileName": "policyCore/policyDef/types.ts",
+															"line": 24,
+															"character": 4,
+															"url": "https://github.com/LIT-Protocol/Vincent/blob/46a7999ef358981de990d808b7484f24731b23f9/packages/libs/tool-sdk/src/lib/policyCore/policyDef/types.ts#L24"
+														}
+													],
+													"type": {
+														"type": "reference",
+														"target": {
+															"sourceFileName": "../../../node_modules/.pnpm/zod@3.25.64/node_modules/zod/dist/types/v3/types.d.ts",
+															"qualifiedName": "TypeOf"
+														},
+														"typeArguments": [
+															{
+																"type": "reference",
+																"target": 153,
+																"name": "UserParams",
+																"package": "@lit-protocol/vincent-tool-sdk",
+																"refersToTypeParameter": true
+															}
+														],
+														"name": "z.infer",
+														"package": "zod",
+														"qualifiedName": "TypeOf"
 													}
 												}
 											],
@@ -2461,371 +1007,611 @@
 												{
 													"title": "Properties",
 													"children": [
-														126
+														149,
+														150
 													]
 												}
 											],
 											"sources": [
 												{
-													"fileName": "types.ts",
-													"line": 81,
-													"character": 22,
-													"url": "https://github.com/LIT-Protocol/Vincent/blob/8e21b5da26217bce6eb8963c7b9c9ea95c6a2290/packages/libs/tool-sdk/src/lib/types.ts#L81"
+													"fileName": "policyCore/policyDef/types.ts",
+													"line": 22,
+													"character": 8,
+													"url": "https://github.com/LIT-Protocol/Vincent/blob/46a7999ef358981de990d808b7484f24731b23f9/packages/libs/tool-sdk/src/lib/policyCore/policyDef/types.ts#L22"
 												}
 											]
 										}
 									}
-								]
+								},
+								{
+									"id": 151,
+									"name": "ctx",
+									"variant": "param",
+									"kind": 32768,
+									"flags": {},
+									"type": {
+										"type": "reference",
+										"target": 164,
+										"typeArguments": [
+											{
+												"type": "reference",
+												"target": 154,
+												"name": "AllowResult",
+												"package": "@lit-protocol/vincent-tool-sdk",
+												"refersToTypeParameter": true
+											},
+											{
+												"type": "reference",
+												"target": 155,
+												"name": "DenyResult",
+												"package": "@lit-protocol/vincent-tool-sdk",
+												"refersToTypeParameter": true
+											}
+										],
+										"name": "PolicyContext",
+										"package": "@lit-protocol/vincent-tool-sdk"
+									}
+								}
+							],
+							"type": {
+								"type": "reference",
+								"target": {
+									"sourceFileName": "../../../node_modules/.pnpm/typescript@5.8.3/node_modules/typescript/lib/lib.es5.d.ts",
+									"qualifiedName": "Promise"
+								},
+								"typeArguments": [
+									{
+										"type": "reference",
+										"target": {
+											"sourceFileName": "src/lib/policyCore/policyDef/context/types.ts",
+											"qualifiedName": "EnforcePolicyResponse"
+										},
+										"typeArguments": [
+											{
+												"type": "union",
+												"types": [
+													{
+														"type": "conditional",
+														"checkType": {
+															"type": "reference",
+															"target": 154,
+															"name": "AllowResult",
+															"package": "@lit-protocol/vincent-tool-sdk",
+															"refersToTypeParameter": true
+														},
+														"extendsType": {
+															"type": "reference",
+															"target": {
+																"sourceFileName": "../../../node_modules/.pnpm/zod@3.25.64/node_modules/zod/dist/types/v3/types.d.ts",
+																"qualifiedName": "ZodUndefined"
+															},
+															"name": "z.ZodUndefined",
+															"package": "zod",
+															"qualifiedName": "ZodUndefined"
+														},
+														"trueType": {
+															"type": "reference",
+															"target": {
+																"sourceFileName": "src/lib/policyCore/policyDef/context/types.ts",
+																"qualifiedName": "ContextAllowResponseNoResult"
+															},
+															"name": "ContextAllowResponseNoResult",
+															"package": "@lit-protocol/vincent-tool-sdk"
+														},
+														"falseType": {
+															"type": "reference",
+															"target": {
+																"sourceFileName": "src/lib/policyCore/policyDef/context/types.ts",
+																"qualifiedName": "ContextAllowResponse"
+															},
+															"typeArguments": [
+																{
+																	"type": "reference",
+																	"target": {
+																		"sourceFileName": "../../../node_modules/.pnpm/zod@3.25.64/node_modules/zod/dist/types/v3/types.d.ts",
+																		"qualifiedName": "TypeOf"
+																	},
+																	"typeArguments": [
+																		{
+																			"type": "reference",
+																			"target": 154,
+																			"name": "AllowResult",
+																			"package": "@lit-protocol/vincent-tool-sdk",
+																			"refersToTypeParameter": true
+																		}
+																	],
+																	"name": "z.infer",
+																	"package": "zod",
+																	"qualifiedName": "TypeOf"
+																}
+															],
+															"name": "ContextAllowResponse",
+															"package": "@lit-protocol/vincent-tool-sdk"
+														}
+													},
+													{
+														"type": "conditional",
+														"checkType": {
+															"type": "reference",
+															"target": 155,
+															"name": "DenyResult",
+															"package": "@lit-protocol/vincent-tool-sdk",
+															"refersToTypeParameter": true
+														},
+														"extendsType": {
+															"type": "reference",
+															"target": {
+																"sourceFileName": "../../../node_modules/.pnpm/zod@3.25.64/node_modules/zod/dist/types/v3/types.d.ts",
+																"qualifiedName": "ZodUndefined"
+															},
+															"name": "z.ZodUndefined",
+															"package": "zod",
+															"qualifiedName": "ZodUndefined"
+														},
+														"trueType": {
+															"type": "reference",
+															"target": {
+																"sourceFileName": "src/lib/policyCore/policyDef/context/types.ts",
+																"qualifiedName": "ContextDenyResponseNoResult"
+															},
+															"name": "ContextDenyResponseNoResult",
+															"package": "@lit-protocol/vincent-tool-sdk"
+														},
+														"falseType": {
+															"type": "reference",
+															"target": {
+																"sourceFileName": "src/lib/policyCore/policyDef/context/types.ts",
+																"qualifiedName": "ContextDenyResponse"
+															},
+															"typeArguments": [
+																{
+																	"type": "reference",
+																	"target": {
+																		"sourceFileName": "../../../node_modules/.pnpm/zod@3.25.64/node_modules/zod/dist/types/v3/types.d.ts",
+																		"qualifiedName": "TypeOf"
+																	},
+																	"typeArguments": [
+																		{
+																			"type": "reference",
+																			"target": 155,
+																			"name": "DenyResult",
+																			"package": "@lit-protocol/vincent-tool-sdk",
+																			"refersToTypeParameter": true
+																		}
+																	],
+																	"name": "z.infer",
+																	"package": "zod",
+																	"qualifiedName": "TypeOf"
+																}
+															],
+															"name": "ContextDenyResponse",
+															"package": "@lit-protocol/vincent-tool-sdk"
+														}
+													}
+												]
+											}
+										],
+										"name": "EnforcePolicyResponse",
+										"package": "@lit-protocol/vincent-tool-sdk"
+									}
+								],
+								"name": "Promise",
+								"package": "typescript"
 							}
-						}
-					],
-					"groups": [
-						{
-							"title": "Properties",
-							"children": [
-								123,
-								127,
-								124
-							]
-						}
-					],
-					"sources": [
-						{
-							"fileName": "types.ts",
-							"line": 79,
-							"character": 4,
-							"url": "https://github.com/LIT-Protocol/Vincent/blob/8e21b5da26217bce6eb8963c7b9c9ea95c6a2290/packages/libs/tool-sdk/src/lib/types.ts#L79"
 						}
 					]
 				}
 			}
 		},
 		{
-			"id": 91,
-			"name": "asBundledVincentPolicy",
+			"id": 156,
+			"name": "PolicyDefCommitFunction",
 			"variant": "declaration",
-			"kind": 64,
+			"kind": 2097152,
 			"flags": {},
+			"comment": {
+				"summary": [
+					{
+						"kind": "text",
+						"text": "Unlike "
+					},
+					{
+						"kind": "code",
+						"text": "`evaluate()`"
+					},
+					{
+						"kind": "text",
+						"text": " and "
+					},
+					{
+						"kind": "code",
+						"text": "`precheck()`"
+					},
+					{
+						"kind": "text",
+						"text": ", commit receives specific arguments provided by the tool during its "
+					},
+					{
+						"kind": "code",
+						"text": "`execute()`"
+					},
+					{
+						"kind": "text",
+						"text": " phase\ninstead of than "
+					},
+					{
+						"kind": "code",
+						"text": "`toolParams`"
+					},
+					{
+						"kind": "text",
+						"text": " and "
+					},
+					{
+						"kind": "code",
+						"text": "`userParams`"
+					},
+					{
+						"kind": "text",
+						"text": " that the tool was called with."
+					}
+				],
+				"blockTags": [
+					{
+						"tag": "@category",
+						"content": [
+							{
+								"kind": "text",
+								"text": "Interfaces"
+							}
+						]
+					}
+				]
+			},
 			"sources": [
 				{
-					"fileName": "policyCore/bundledPolicy/bundledPolicy.ts",
-					"line": 6,
-					"character": 16,
-					"url": "https://github.com/LIT-Protocol/Vincent/blob/8e21b5da26217bce6eb8963c7b9c9ea95c6a2290/packages/libs/tool-sdk/src/lib/policyCore/bundledPolicy/bundledPolicy.ts#L6"
+					"fileName": "policyCore/policyDef/types.ts",
+					"line": 43,
+					"character": 12,
+					"url": "https://github.com/LIT-Protocol/Vincent/blob/46a7999ef358981de990d808b7484f24731b23f9/packages/libs/tool-sdk/src/lib/policyCore/policyDef/types.ts#L43"
 				}
 			],
-			"signatures": [
+			"typeParameters": [
 				{
-					"id": 92,
-					"name": "asBundledVincentPolicy",
-					"variant": "signature",
-					"kind": 4096,
+					"id": 161,
+					"name": "CommitParams",
+					"variant": "typeParam",
+					"kind": 131072,
+					"flags": {},
+					"type": {
+						"type": "reference",
+						"target": {
+							"sourceFileName": "../../../node_modules/.pnpm/zod@3.25.64/node_modules/zod/dist/types/v3/types.d.ts",
+							"qualifiedName": "ZodType"
+						},
+						"name": "z.ZodType",
+						"package": "zod",
+						"qualifiedName": "ZodType"
+					},
+					"default": {
+						"type": "reference",
+						"target": {
+							"sourceFileName": "../../../node_modules/.pnpm/zod@3.25.64/node_modules/zod/dist/types/v3/types.d.ts",
+							"qualifiedName": "ZodUndefined"
+						},
+						"name": "z.ZodUndefined",
+						"package": "zod",
+						"qualifiedName": "ZodUndefined"
+					}
+				},
+				{
+					"id": 162,
+					"name": "CommitAllowResult",
+					"variant": "typeParam",
+					"kind": 131072,
+					"flags": {},
+					"type": {
+						"type": "reference",
+						"target": {
+							"sourceFileName": "../../../node_modules/.pnpm/zod@3.25.64/node_modules/zod/dist/types/v3/types.d.ts",
+							"qualifiedName": "ZodType"
+						},
+						"name": "z.ZodType",
+						"package": "zod",
+						"qualifiedName": "ZodType"
+					},
+					"default": {
+						"type": "reference",
+						"target": {
+							"sourceFileName": "../../../node_modules/.pnpm/zod@3.25.64/node_modules/zod/dist/types/v3/types.d.ts",
+							"qualifiedName": "ZodUndefined"
+						},
+						"name": "z.ZodUndefined",
+						"package": "zod",
+						"qualifiedName": "ZodUndefined"
+					}
+				},
+				{
+					"id": 163,
+					"name": "CommitDenyResult",
+					"variant": "typeParam",
+					"kind": 131072,
+					"flags": {},
+					"type": {
+						"type": "reference",
+						"target": {
+							"sourceFileName": "../../../node_modules/.pnpm/zod@3.25.64/node_modules/zod/dist/types/v3/types.d.ts",
+							"qualifiedName": "ZodType"
+						},
+						"name": "z.ZodType",
+						"package": "zod",
+						"qualifiedName": "ZodType"
+					},
+					"default": {
+						"type": "reference",
+						"target": {
+							"sourceFileName": "../../../node_modules/.pnpm/zod@3.25.64/node_modules/zod/dist/types/v3/types.d.ts",
+							"qualifiedName": "ZodUndefined"
+						},
+						"name": "z.ZodUndefined",
+						"package": "zod",
+						"qualifiedName": "ZodUndefined"
+					}
+				}
+			],
+			"type": {
+				"type": "reflection",
+				"declaration": {
+					"id": 157,
+					"name": "__type",
+					"variant": "declaration",
+					"kind": 65536,
 					"flags": {},
 					"sources": [
 						{
-							"fileName": "policyCore/bundledPolicy/bundledPolicy.ts",
-							"line": 6,
-							"character": 16,
-							"url": "https://github.com/LIT-Protocol/Vincent/blob/8e21b5da26217bce6eb8963c7b9c9ea95c6a2290/packages/libs/tool-sdk/src/lib/policyCore/bundledPolicy/bundledPolicy.ts#L6"
+							"fileName": "policyCore/policyDef/types.ts",
+							"line": 47,
+							"character": 4,
+							"url": "https://github.com/LIT-Protocol/Vincent/blob/46a7999ef358981de990d808b7484f24731b23f9/packages/libs/tool-sdk/src/lib/policyCore/policyDef/types.ts#L47"
 						}
 					],
-					"typeParameters": [
+					"signatures": [
 						{
-							"id": 93,
-							"name": "VP",
-							"variant": "typeParam",
-							"kind": 131072,
-							"flags": {
-								"isConst": true
-							},
+							"id": 158,
+							"name": "__type",
+							"variant": "signature",
+							"kind": 4096,
+							"flags": {},
+							"parameters": [
+								{
+									"id": 159,
+									"name": "args",
+									"variant": "param",
+									"kind": 32768,
+									"flags": {},
+									"type": {
+										"type": "conditional",
+										"checkType": {
+											"type": "reference",
+											"target": 161,
+											"name": "CommitParams",
+											"package": "@lit-protocol/vincent-tool-sdk",
+											"refersToTypeParameter": true
+										},
+										"extendsType": {
+											"type": "reference",
+											"target": {
+												"sourceFileName": "../../../node_modules/.pnpm/zod@3.25.64/node_modules/zod/dist/types/v3/types.d.ts",
+												"qualifiedName": "ZodType"
+											},
+											"name": "z.ZodType",
+											"package": "zod",
+											"qualifiedName": "ZodType"
+										},
+										"trueType": {
+											"type": "reference",
+											"target": {
+												"sourceFileName": "../../../node_modules/.pnpm/zod@3.25.64/node_modules/zod/dist/types/v3/types.d.ts",
+												"qualifiedName": "TypeOf"
+											},
+											"typeArguments": [
+												{
+													"type": "reference",
+													"target": 161,
+													"name": "CommitParams",
+													"package": "@lit-protocol/vincent-tool-sdk",
+													"refersToTypeParameter": true
+												}
+											],
+											"name": "z.infer",
+											"package": "zod",
+											"qualifiedName": "TypeOf"
+										},
+										"falseType": {
+											"type": "intrinsic",
+											"name": "undefined"
+										}
+									}
+								},
+								{
+									"id": 160,
+									"name": "context",
+									"variant": "param",
+									"kind": 32768,
+									"flags": {},
+									"type": {
+										"type": "reference",
+										"target": 164,
+										"typeArguments": [
+											{
+												"type": "reference",
+												"target": 162,
+												"name": "CommitAllowResult",
+												"package": "@lit-protocol/vincent-tool-sdk",
+												"refersToTypeParameter": true
+											},
+											{
+												"type": "reference",
+												"target": 163,
+												"name": "CommitDenyResult",
+												"package": "@lit-protocol/vincent-tool-sdk",
+												"refersToTypeParameter": true
+											}
+										],
+										"name": "PolicyContext",
+										"package": "@lit-protocol/vincent-tool-sdk"
+									}
+								}
+							],
 							"type": {
 								"type": "reference",
 								"target": {
-									"sourceFileName": "src/lib/types.ts",
-									"qualifiedName": "VincentPolicy"
+									"sourceFileName": "../../../node_modules/.pnpm/typescript@5.8.3/node_modules/typescript/lib/lib.es5.d.ts",
+									"qualifiedName": "Promise"
 								},
 								"typeArguments": [
 									{
-										"type": "intrinsic",
-										"name": "any"
-									},
-									{
-										"type": "intrinsic",
-										"name": "any"
-									},
-									{
-										"type": "intrinsic",
-										"name": "any"
-									},
-									{
-										"type": "intrinsic",
-										"name": "any"
-									},
-									{
-										"type": "intrinsic",
-										"name": "any"
-									},
-									{
-										"type": "intrinsic",
-										"name": "any"
-									},
-									{
-										"type": "intrinsic",
-										"name": "any"
-									},
-									{
-										"type": "intrinsic",
-										"name": "any"
-									},
-									{
-										"type": "intrinsic",
-										"name": "any"
-									},
-									{
-										"type": "intrinsic",
-										"name": "any"
-									},
-									{
-										"type": "intrinsic",
-										"name": "any"
-									},
-									{
-										"type": "intrinsic",
-										"name": "any"
-									},
-									{
-										"type": "intrinsic",
-										"name": "any"
+										"type": "reference",
+										"target": {
+											"sourceFileName": "src/lib/policyCore/policyDef/context/types.ts",
+											"qualifiedName": "EnforcePolicyResponse"
+										},
+										"typeArguments": [
+											{
+												"type": "union",
+												"types": [
+													{
+														"type": "conditional",
+														"checkType": {
+															"type": "reference",
+															"target": 162,
+															"name": "CommitAllowResult",
+															"package": "@lit-protocol/vincent-tool-sdk",
+															"refersToTypeParameter": true
+														},
+														"extendsType": {
+															"type": "reference",
+															"target": {
+																"sourceFileName": "../../../node_modules/.pnpm/zod@3.25.64/node_modules/zod/dist/types/v3/types.d.ts",
+																"qualifiedName": "ZodUndefined"
+															},
+															"name": "z.ZodUndefined",
+															"package": "zod",
+															"qualifiedName": "ZodUndefined"
+														},
+														"trueType": {
+															"type": "reference",
+															"target": {
+																"sourceFileName": "src/lib/policyCore/policyDef/context/types.ts",
+																"qualifiedName": "ContextAllowResponseNoResult"
+															},
+															"name": "ContextAllowResponseNoResult",
+															"package": "@lit-protocol/vincent-tool-sdk"
+														},
+														"falseType": {
+															"type": "reference",
+															"target": {
+																"sourceFileName": "src/lib/policyCore/policyDef/context/types.ts",
+																"qualifiedName": "ContextAllowResponse"
+															},
+															"typeArguments": [
+																{
+																	"type": "reference",
+																	"target": {
+																		"sourceFileName": "../../../node_modules/.pnpm/zod@3.25.64/node_modules/zod/dist/types/v3/types.d.ts",
+																		"qualifiedName": "TypeOf"
+																	},
+																	"typeArguments": [
+																		{
+																			"type": "reference",
+																			"target": 162,
+																			"name": "CommitAllowResult",
+																			"package": "@lit-protocol/vincent-tool-sdk",
+																			"refersToTypeParameter": true
+																		}
+																	],
+																	"name": "z.infer",
+																	"package": "zod",
+																	"qualifiedName": "TypeOf"
+																}
+															],
+															"name": "ContextAllowResponse",
+															"package": "@lit-protocol/vincent-tool-sdk"
+														}
+													},
+													{
+														"type": "conditional",
+														"checkType": {
+															"type": "reference",
+															"target": 163,
+															"name": "CommitDenyResult",
+															"package": "@lit-protocol/vincent-tool-sdk",
+															"refersToTypeParameter": true
+														},
+														"extendsType": {
+															"type": "reference",
+															"target": {
+																"sourceFileName": "../../../node_modules/.pnpm/zod@3.25.64/node_modules/zod/dist/types/v3/types.d.ts",
+																"qualifiedName": "ZodUndefined"
+															},
+															"name": "z.ZodUndefined",
+															"package": "zod",
+															"qualifiedName": "ZodUndefined"
+														},
+														"trueType": {
+															"type": "reference",
+															"target": {
+																"sourceFileName": "src/lib/policyCore/policyDef/context/types.ts",
+																"qualifiedName": "ContextDenyResponseNoResult"
+															},
+															"name": "ContextDenyResponseNoResult",
+															"package": "@lit-protocol/vincent-tool-sdk"
+														},
+														"falseType": {
+															"type": "reference",
+															"target": {
+																"sourceFileName": "src/lib/policyCore/policyDef/context/types.ts",
+																"qualifiedName": "ContextDenyResponse"
+															},
+															"typeArguments": [
+																{
+																	"type": "reference",
+																	"target": {
+																		"sourceFileName": "../../../node_modules/.pnpm/zod@3.25.64/node_modules/zod/dist/types/v3/types.d.ts",
+																		"qualifiedName": "TypeOf"
+																	},
+																	"typeArguments": [
+																		{
+																			"type": "reference",
+																			"target": 163,
+																			"name": "CommitDenyResult",
+																			"package": "@lit-protocol/vincent-tool-sdk",
+																			"refersToTypeParameter": true
+																		}
+																	],
+																	"name": "z.infer",
+																	"package": "zod",
+																	"qualifiedName": "TypeOf"
+																}
+															],
+															"name": "ContextDenyResponse",
+															"package": "@lit-protocol/vincent-tool-sdk"
+														}
+													}
+												]
+											}
+										],
+										"name": "EnforcePolicyResponse",
+										"package": "@lit-protocol/vincent-tool-sdk"
 									}
 								],
-								"name": "VincentPolicy",
-								"package": "@lit-protocol/vincent-tool-sdk"
-							}
-						},
-						{
-							"id": 94,
-							"name": "IpfsCid",
-							"variant": "typeParam",
-							"kind": 131072,
-							"flags": {
-								"isConst": true
-							},
-							"type": {
-								"type": "intrinsic",
-								"name": "string"
+								"name": "Promise",
+								"package": "typescript"
 							}
 						}
-					],
-					"parameters": [
-						{
-							"id": 95,
-							"name": "vincentPolicy",
-							"variant": "param",
-							"kind": 32768,
-							"flags": {},
-							"type": {
-								"type": "reference",
-								"target": 93,
-								"name": "VP",
-								"package": "@lit-protocol/vincent-tool-sdk",
-								"refersToTypeParameter": true
-							}
-						},
-						{
-							"id": 96,
-							"name": "ipfsCid",
-							"variant": "param",
-							"kind": 32768,
-							"flags": {},
-							"type": {
-								"type": "reference",
-								"target": 94,
-								"name": "IpfsCid",
-								"package": "@lit-protocol/vincent-tool-sdk",
-								"refersToTypeParameter": true
-							}
-						}
-					],
-					"type": {
-						"type": "reference",
-						"target": 107,
-						"typeArguments": [
-							{
-								"type": "reference",
-								"target": 93,
-								"name": "VP",
-								"package": "@lit-protocol/vincent-tool-sdk",
-								"refersToTypeParameter": true
-							},
-							{
-								"type": "reference",
-								"target": 94,
-								"name": "IpfsCid",
-								"package": "@lit-protocol/vincent-tool-sdk",
-								"refersToTypeParameter": true
-							}
-						],
-						"name": "BundledVincentPolicy",
-						"package": "@lit-protocol/vincent-tool-sdk"
-					}
+					]
 				}
-			]
-		},
-		{
-			"id": 85,
-			"name": "asBundledVincentTool",
-			"variant": "declaration",
-			"kind": 64,
-			"flags": {},
-			"sources": [
-				{
-					"fileName": "toolCore/bundledTool/bundledTool.ts",
-					"line": 6,
-					"character": 16,
-					"url": "https://github.com/LIT-Protocol/Vincent/blob/8e21b5da26217bce6eb8963c7b9c9ea95c6a2290/packages/libs/tool-sdk/src/lib/toolCore/bundledTool/bundledTool.ts#L6"
-				}
-			],
-			"signatures": [
-				{
-					"id": 86,
-					"name": "asBundledVincentTool",
-					"variant": "signature",
-					"kind": 4096,
-					"flags": {},
-					"sources": [
-						{
-							"fileName": "toolCore/bundledTool/bundledTool.ts",
-							"line": 6,
-							"character": 16,
-							"url": "https://github.com/LIT-Protocol/Vincent/blob/8e21b5da26217bce6eb8963c7b9c9ea95c6a2290/packages/libs/tool-sdk/src/lib/toolCore/bundledTool/bundledTool.ts#L6"
-						}
-					],
-					"typeParameters": [
-						{
-							"id": 87,
-							"name": "VT",
-							"variant": "typeParam",
-							"kind": 131072,
-							"flags": {
-								"isConst": true
-							},
-							"type": {
-								"type": "reference",
-								"target": 195,
-								"typeArguments": [
-									{
-										"type": "intrinsic",
-										"name": "any"
-									},
-									{
-										"type": "intrinsic",
-										"name": "any"
-									},
-									{
-										"type": "intrinsic",
-										"name": "any"
-									},
-									{
-										"type": "intrinsic",
-										"name": "any"
-									},
-									{
-										"type": "intrinsic",
-										"name": "any"
-									},
-									{
-										"type": "intrinsic",
-										"name": "any"
-									},
-									{
-										"type": "intrinsic",
-										"name": "any"
-									},
-									{
-										"type": "intrinsic",
-										"name": "any"
-									},
-									{
-										"type": "intrinsic",
-										"name": "any"
-									},
-									{
-										"type": "intrinsic",
-										"name": "any"
-									}
-								],
-								"name": "VincentTool",
-								"package": "@lit-protocol/vincent-tool-sdk"
-							}
-						},
-						{
-							"id": 88,
-							"name": "IpfsCid",
-							"variant": "typeParam",
-							"kind": 131072,
-							"flags": {
-								"isConst": true
-							},
-							"type": {
-								"type": "intrinsic",
-								"name": "string"
-							}
-						}
-					],
-					"parameters": [
-						{
-							"id": 89,
-							"name": "vincentTool",
-							"variant": "param",
-							"kind": 32768,
-							"flags": {},
-							"type": {
-								"type": "reference",
-								"target": 87,
-								"name": "VT",
-								"package": "@lit-protocol/vincent-tool-sdk",
-								"refersToTypeParameter": true
-							}
-						},
-						{
-							"id": 90,
-							"name": "ipfsCid",
-							"variant": "param",
-							"kind": 32768,
-							"flags": {},
-							"type": {
-								"type": "reference",
-								"target": 88,
-								"name": "IpfsCid",
-								"package": "@lit-protocol/vincent-tool-sdk",
-								"refersToTypeParameter": true
-							}
-						}
-					],
-					"type": {
-						"type": "reference",
-						"target": 114,
-						"typeArguments": [
-							{
-								"type": "reference",
-								"target": 87,
-								"name": "VT",
-								"package": "@lit-protocol/vincent-tool-sdk",
-								"refersToTypeParameter": true
-							},
-							{
-								"type": "reference",
-								"target": 88,
-								"name": "IpfsCid",
-								"package": "@lit-protocol/vincent-tool-sdk",
-								"refersToTypeParameter": true
-							}
-						],
-						"name": "BundledVincentTool",
-						"package": "@lit-protocol/vincent-tool-sdk"
-					}
-				}
-			]
+			}
 		},
 		{
 			"id": 1,
@@ -2836,9 +1622,9 @@
 			"sources": [
 				{
 					"fileName": "policyCore/vincentPolicy.ts",
-					"line": 35,
+					"line": 36,
 					"character": 16,
-					"url": "https://github.com/LIT-Protocol/Vincent/blob/8e21b5da26217bce6eb8963c7b9c9ea95c6a2290/packages/libs/tool-sdk/src/lib/policyCore/vincentPolicy.ts#L35"
+					"url": "https://github.com/LIT-Protocol/Vincent/blob/46a7999ef358981de990d808b7484f24731b23f9/packages/libs/tool-sdk/src/lib/policyCore/vincentPolicy.ts#L36"
 				}
 			],
 			"signatures": [
@@ -2852,56 +1638,35 @@
 						"summary": [
 							{
 								"kind": "text",
-								"text": "Wraps a raw VincentPolicyDef with internal logic and returns a fully typed\npolicy object, preserving inference for all lifecycle methods ("
+								"text": "The "
 							},
 							{
 								"kind": "code",
-								"text": "`evaluate`"
+								"text": "`createVincentPolicy()`"
 							},
 							{
 								"kind": "text",
-								"text": ", "
-							},
+								"text": " method is used to define a policy's lifecycle methods and ensure that arguments provided to the tool's\nlifecycle methods, as well as their return values, are validated and fully type-safe by defining ZOD schemas for them."
+							}
+						],
+						"blockTags": [
 							{
-								"kind": "code",
-								"text": "`precheck`"
-							},
-							{
-								"kind": "text",
-								"text": ", "
-							},
-							{
-								"kind": "code",
-								"text": "`commit`"
-							},
-							{
-								"kind": "text",
-								"text": ")\nand providing metadata such as "
-							},
-							{
-								"kind": "code",
-								"text": "`ipfsCid`"
-							},
-							{
-								"kind": "text",
-								"text": " and "
-							},
-							{
-								"kind": "code",
-								"text": "`packageName`"
-							},
-							{
-								"kind": "text",
-								"text": "."
+								"tag": "@category",
+								"content": [
+									{
+										"kind": "text",
+										"text": "API Methods"
+									}
+								]
 							}
 						]
 					},
 					"sources": [
 						{
 							"fileName": "policyCore/vincentPolicy.ts",
-							"line": 35,
+							"line": 36,
 							"character": 16,
-							"url": "https://github.com/LIT-Protocol/Vincent/blob/8e21b5da26217bce6eb8963c7b9c9ea95c6a2290/packages/libs/tool-sdk/src/lib/policyCore/vincentPolicy.ts#L35"
+							"url": "https://github.com/LIT-Protocol/Vincent/blob/46a7999ef358981de990d808b7484f24731b23f9/packages/libs/tool-sdk/src/lib/policyCore/vincentPolicy.ts#L36"
 						}
 					],
 					"typeParameters": [
@@ -3312,195 +2077,400 @@
 							"kind": 32768,
 							"flags": {},
 							"type": {
-								"type": "reference",
-								"target": {
-									"sourceFileName": "src/lib/policyCore/policyDef/types.ts",
-									"qualifiedName": "VincentPolicyDef"
-								},
-								"typeArguments": [
-									{
-										"type": "reference",
-										"target": 3,
-										"name": "PackageName",
-										"package": "@lit-protocol/vincent-tool-sdk",
-										"refersToTypeParameter": true
-									},
-									{
-										"type": "reference",
-										"target": 4,
-										"name": "PolicyToolParams",
-										"package": "@lit-protocol/vincent-tool-sdk",
-										"refersToTypeParameter": true
-									},
-									{
-										"type": "reference",
-										"target": 5,
-										"name": "UserParams",
-										"package": "@lit-protocol/vincent-tool-sdk",
-										"refersToTypeParameter": true
-									},
-									{
-										"type": "reference",
-										"target": 6,
-										"name": "PrecheckAllowResult",
-										"package": "@lit-protocol/vincent-tool-sdk",
-										"refersToTypeParameter": true
-									},
-									{
-										"type": "reference",
-										"target": 7,
-										"name": "PrecheckDenyResult",
-										"package": "@lit-protocol/vincent-tool-sdk",
-										"refersToTypeParameter": true
-									},
-									{
-										"type": "reference",
-										"target": 8,
-										"name": "EvalAllowResult",
-										"package": "@lit-protocol/vincent-tool-sdk",
-										"refersToTypeParameter": true
-									},
-									{
-										"type": "reference",
-										"target": 9,
-										"name": "EvalDenyResult",
-										"package": "@lit-protocol/vincent-tool-sdk",
-										"refersToTypeParameter": true
-									},
-									{
-										"type": "reference",
-										"target": 10,
-										"name": "CommitParams",
-										"package": "@lit-protocol/vincent-tool-sdk",
-										"refersToTypeParameter": true
-									},
-									{
-										"type": "reference",
-										"target": 11,
-										"name": "CommitAllowResult",
-										"package": "@lit-protocol/vincent-tool-sdk",
-										"refersToTypeParameter": true
-									},
-									{
-										"type": "reference",
-										"target": 12,
-										"name": "CommitDenyResult",
-										"package": "@lit-protocol/vincent-tool-sdk",
-										"refersToTypeParameter": true
-									},
-									{
-										"type": "reference",
-										"target": {
-											"sourceFileName": "src/lib/policyCore/policyDef/types.ts",
-											"qualifiedName": "PolicyDefLifecycleFunction"
+								"type": "reflection",
+								"declaration": {
+									"id": 14,
+									"name": "__type",
+									"variant": "declaration",
+									"kind": 65536,
+									"flags": {},
+									"children": [
+										{
+											"id": 15,
+											"name": "packageName",
+											"variant": "declaration",
+											"kind": 1024,
+											"flags": {},
+											"sources": [
+												{
+													"fileName": "policyCore/policyDef/types.ts",
+													"line": 89,
+													"character": 2,
+													"url": "https://github.com/LIT-Protocol/Vincent/blob/46a7999ef358981de990d808b7484f24731b23f9/packages/libs/tool-sdk/src/lib/policyCore/policyDef/types.ts#L89"
+												}
+											],
+											"type": {
+												"type": "reference",
+												"target": 3,
+												"name": "PackageName",
+												"package": "@lit-protocol/vincent-tool-sdk",
+												"refersToTypeParameter": true
+											}
 										},
-										"typeArguments": [
-											{
+										{
+											"id": 16,
+											"name": "toolParamsSchema",
+											"variant": "declaration",
+											"kind": 1024,
+											"flags": {},
+											"sources": [
+												{
+													"fileName": "policyCore/policyDef/types.ts",
+													"line": 90,
+													"character": 2,
+													"url": "https://github.com/LIT-Protocol/Vincent/blob/46a7999ef358981de990d808b7484f24731b23f9/packages/libs/tool-sdk/src/lib/policyCore/policyDef/types.ts#L90"
+												}
+											],
+											"type": {
 												"type": "reference",
 												"target": 4,
 												"name": "PolicyToolParams",
 												"package": "@lit-protocol/vincent-tool-sdk",
 												"refersToTypeParameter": true
+											}
+										},
+										{
+											"id": 17,
+											"name": "userParamsSchema",
+											"variant": "declaration",
+											"kind": 1024,
+											"flags": {
+												"isOptional": true
 											},
-											{
+											"sources": [
+												{
+													"fileName": "policyCore/policyDef/types.ts",
+													"line": 91,
+													"character": 2,
+													"url": "https://github.com/LIT-Protocol/Vincent/blob/46a7999ef358981de990d808b7484f24731b23f9/packages/libs/tool-sdk/src/lib/policyCore/policyDef/types.ts#L91"
+												}
+											],
+											"type": {
 												"type": "reference",
 												"target": 5,
 												"name": "UserParams",
 												"package": "@lit-protocol/vincent-tool-sdk",
 												"refersToTypeParameter": true
+											}
+										},
+										{
+											"id": 18,
+											"name": "evalAllowResultSchema",
+											"variant": "declaration",
+											"kind": 1024,
+											"flags": {
+												"isOptional": true
 											},
-											{
+											"sources": [
+												{
+													"fileName": "policyCore/policyDef/types.ts",
+													"line": 92,
+													"character": 2,
+													"url": "https://github.com/LIT-Protocol/Vincent/blob/46a7999ef358981de990d808b7484f24731b23f9/packages/libs/tool-sdk/src/lib/policyCore/policyDef/types.ts#L92"
+												}
+											],
+											"type": {
 												"type": "reference",
 												"target": 8,
 												"name": "EvalAllowResult",
 												"package": "@lit-protocol/vincent-tool-sdk",
 												"refersToTypeParameter": true
+											}
+										},
+										{
+											"id": 19,
+											"name": "evalDenyResultSchema",
+											"variant": "declaration",
+											"kind": 1024,
+											"flags": {
+												"isOptional": true
 											},
-											{
+											"sources": [
+												{
+													"fileName": "policyCore/policyDef/types.ts",
+													"line": 93,
+													"character": 2,
+													"url": "https://github.com/LIT-Protocol/Vincent/blob/46a7999ef358981de990d808b7484f24731b23f9/packages/libs/tool-sdk/src/lib/policyCore/policyDef/types.ts#L93"
+												}
+											],
+											"type": {
 												"type": "reference",
 												"target": 9,
 												"name": "EvalDenyResult",
 												"package": "@lit-protocol/vincent-tool-sdk",
 												"refersToTypeParameter": true
 											}
-										],
-										"name": "PolicyDefLifecycleFunction",
-										"package": "@lit-protocol/vincent-tool-sdk"
-									},
-									{
-										"type": "reference",
-										"target": {
-											"sourceFileName": "src/lib/policyCore/policyDef/types.ts",
-											"qualifiedName": "PolicyDefLifecycleFunction"
 										},
-										"typeArguments": [
-											{
-												"type": "reference",
-												"target": 4,
-												"name": "PolicyToolParams",
-												"package": "@lit-protocol/vincent-tool-sdk",
-												"refersToTypeParameter": true
+										{
+											"id": 20,
+											"name": "precheckAllowResultSchema",
+											"variant": "declaration",
+											"kind": 1024,
+											"flags": {
+												"isOptional": true
 											},
-											{
-												"type": "reference",
-												"target": 5,
-												"name": "UserParams",
-												"package": "@lit-protocol/vincent-tool-sdk",
-												"refersToTypeParameter": true
-											},
-											{
+											"sources": [
+												{
+													"fileName": "policyCore/policyDef/types.ts",
+													"line": 94,
+													"character": 2,
+													"url": "https://github.com/LIT-Protocol/Vincent/blob/46a7999ef358981de990d808b7484f24731b23f9/packages/libs/tool-sdk/src/lib/policyCore/policyDef/types.ts#L94"
+												}
+											],
+											"type": {
 												"type": "reference",
 												"target": 6,
 												"name": "PrecheckAllowResult",
 												"package": "@lit-protocol/vincent-tool-sdk",
 												"refersToTypeParameter": true
+											}
+										},
+										{
+											"id": 21,
+											"name": "precheckDenyResultSchema",
+											"variant": "declaration",
+											"kind": 1024,
+											"flags": {
+												"isOptional": true
 											},
-											{
+											"sources": [
+												{
+													"fileName": "policyCore/policyDef/types.ts",
+													"line": 95,
+													"character": 2,
+													"url": "https://github.com/LIT-Protocol/Vincent/blob/46a7999ef358981de990d808b7484f24731b23f9/packages/libs/tool-sdk/src/lib/policyCore/policyDef/types.ts#L95"
+												}
+											],
+											"type": {
 												"type": "reference",
 												"target": 7,
 												"name": "PrecheckDenyResult",
 												"package": "@lit-protocol/vincent-tool-sdk",
 												"refersToTypeParameter": true
 											}
-										],
-										"name": "PolicyDefLifecycleFunction",
-										"package": "@lit-protocol/vincent-tool-sdk"
-									},
-									{
-										"type": "reference",
-										"target": {
-											"sourceFileName": "src/lib/policyCore/policyDef/types.ts",
-											"qualifiedName": "PolicyDefCommitFunction"
 										},
-										"typeArguments": [
-											{
+										{
+											"id": 22,
+											"name": "commitParamsSchema",
+											"variant": "declaration",
+											"kind": 1024,
+											"flags": {
+												"isOptional": true
+											},
+											"sources": [
+												{
+													"fileName": "policyCore/policyDef/types.ts",
+													"line": 96,
+													"character": 2,
+													"url": "https://github.com/LIT-Protocol/Vincent/blob/46a7999ef358981de990d808b7484f24731b23f9/packages/libs/tool-sdk/src/lib/policyCore/policyDef/types.ts#L96"
+												}
+											],
+											"type": {
 												"type": "reference",
 												"target": 10,
 												"name": "CommitParams",
 												"package": "@lit-protocol/vincent-tool-sdk",
 												"refersToTypeParameter": true
+											}
+										},
+										{
+											"id": 23,
+											"name": "commitAllowResultSchema",
+											"variant": "declaration",
+											"kind": 1024,
+											"flags": {
+												"isOptional": true
 											},
-											{
+											"sources": [
+												{
+													"fileName": "policyCore/policyDef/types.ts",
+													"line": 97,
+													"character": 2,
+													"url": "https://github.com/LIT-Protocol/Vincent/blob/46a7999ef358981de990d808b7484f24731b23f9/packages/libs/tool-sdk/src/lib/policyCore/policyDef/types.ts#L97"
+												}
+											],
+											"type": {
 												"type": "reference",
 												"target": 11,
 												"name": "CommitAllowResult",
 												"package": "@lit-protocol/vincent-tool-sdk",
 												"refersToTypeParameter": true
+											}
+										},
+										{
+											"id": 24,
+											"name": "commitDenyResultSchema",
+											"variant": "declaration",
+											"kind": 1024,
+											"flags": {
+												"isOptional": true
 											},
-											{
+											"sources": [
+												{
+													"fileName": "policyCore/policyDef/types.ts",
+													"line": 98,
+													"character": 2,
+													"url": "https://github.com/LIT-Protocol/Vincent/blob/46a7999ef358981de990d808b7484f24731b23f9/packages/libs/tool-sdk/src/lib/policyCore/policyDef/types.ts#L98"
+												}
+											],
+											"type": {
 												"type": "reference",
 												"target": 12,
 												"name": "CommitDenyResult",
 												"package": "@lit-protocol/vincent-tool-sdk",
 												"refersToTypeParameter": true
 											}
-										],
-										"name": "PolicyDefCommitFunction",
-										"package": "@lit-protocol/vincent-tool-sdk"
-									}
-								],
-								"name": "VincentPolicyDef",
-								"package": "@lit-protocol/vincent-tool-sdk"
+										},
+										{
+											"id": 25,
+											"name": "evaluate",
+											"variant": "declaration",
+											"kind": 1024,
+											"flags": {},
+											"sources": [
+												{
+													"fileName": "policyCore/policyDef/types.ts",
+													"line": 101,
+													"character": 2,
+													"url": "https://github.com/LIT-Protocol/Vincent/blob/46a7999ef358981de990d808b7484f24731b23f9/packages/libs/tool-sdk/src/lib/policyCore/policyDef/types.ts#L101"
+												}
+											],
+											"type": {
+												"type": "reference",
+												"target": 144,
+												"name": "PolicyDefLifecycleFunction",
+												"package": "@lit-protocol/vincent-tool-sdk"
+											}
+										},
+										{
+											"id": 26,
+											"name": "precheck",
+											"variant": "declaration",
+											"kind": 1024,
+											"flags": {
+												"isOptional": true
+											},
+											"sources": [
+												{
+													"fileName": "policyCore/policyDef/types.ts",
+													"line": 102,
+													"character": 2,
+													"url": "https://github.com/LIT-Protocol/Vincent/blob/46a7999ef358981de990d808b7484f24731b23f9/packages/libs/tool-sdk/src/lib/policyCore/policyDef/types.ts#L102"
+												}
+											],
+											"type": {
+												"type": "reference",
+												"target": 144,
+												"typeArguments": [
+													{
+														"type": "reference",
+														"target": 4,
+														"name": "PolicyToolParams",
+														"package": "@lit-protocol/vincent-tool-sdk",
+														"refersToTypeParameter": true
+													},
+													{
+														"type": "reference",
+														"target": 5,
+														"name": "UserParams",
+														"package": "@lit-protocol/vincent-tool-sdk",
+														"refersToTypeParameter": true
+													},
+													{
+														"type": "reference",
+														"target": 6,
+														"name": "PrecheckAllowResult",
+														"package": "@lit-protocol/vincent-tool-sdk",
+														"refersToTypeParameter": true
+													},
+													{
+														"type": "reference",
+														"target": 7,
+														"name": "PrecheckDenyResult",
+														"package": "@lit-protocol/vincent-tool-sdk",
+														"refersToTypeParameter": true
+													}
+												],
+												"name": "PolicyDefLifecycleFunction",
+												"package": "@lit-protocol/vincent-tool-sdk"
+											}
+										},
+										{
+											"id": 27,
+											"name": "commit",
+											"variant": "declaration",
+											"kind": 1024,
+											"flags": {
+												"isOptional": true
+											},
+											"sources": [
+												{
+													"fileName": "policyCore/policyDef/types.ts",
+													"line": 103,
+													"character": 2,
+													"url": "https://github.com/LIT-Protocol/Vincent/blob/46a7999ef358981de990d808b7484f24731b23f9/packages/libs/tool-sdk/src/lib/policyCore/policyDef/types.ts#L103"
+												}
+											],
+											"type": {
+												"type": "reference",
+												"target": 156,
+												"typeArguments": [
+													{
+														"type": "reference",
+														"target": 10,
+														"name": "CommitParams",
+														"package": "@lit-protocol/vincent-tool-sdk",
+														"refersToTypeParameter": true
+													},
+													{
+														"type": "reference",
+														"target": 11,
+														"name": "CommitAllowResult",
+														"package": "@lit-protocol/vincent-tool-sdk",
+														"refersToTypeParameter": true
+													},
+													{
+														"type": "reference",
+														"target": 12,
+														"name": "CommitDenyResult",
+														"package": "@lit-protocol/vincent-tool-sdk",
+														"refersToTypeParameter": true
+													}
+												],
+												"name": "PolicyDefCommitFunction",
+												"package": "@lit-protocol/vincent-tool-sdk"
+											}
+										}
+									],
+									"groups": [
+										{
+											"title": "Properties",
+											"children": [
+												15,
+												16,
+												17,
+												18,
+												19,
+												20,
+												21,
+												22,
+												23,
+												24,
+												25,
+												26,
+												27
+											]
+										}
+									],
+									"sources": [
+										{
+											"fileName": "policyCore/policyDef/types.ts",
+											"line": 88,
+											"character": 4,
+											"url": "https://github.com/LIT-Protocol/Vincent/blob/46a7999ef358981de990d808b7484f24731b23f9/packages/libs/tool-sdk/src/lib/policyCore/policyDef/types.ts#L88"
+										}
+									]
+								}
 							}
 						}
 					],
@@ -3699,576 +2669,7 @@
 			]
 		},
 		{
-			"id": 49,
-			"name": "createVincentTool",
-			"variant": "declaration",
-			"kind": 64,
-			"flags": {},
-			"sources": [
-				{
-					"fileName": "toolCore/vincentTool.ts",
-					"line": 28,
-					"character": 16,
-					"url": "https://github.com/LIT-Protocol/Vincent/blob/8e21b5da26217bce6eb8963c7b9c9ea95c6a2290/packages/libs/tool-sdk/src/lib/toolCore/vincentTool.ts#L28"
-				}
-			],
-			"signatures": [
-				{
-					"id": 50,
-					"name": "createVincentTool",
-					"variant": "signature",
-					"kind": 4096,
-					"flags": {},
-					"comment": {
-						"summary": [
-							{
-								"kind": "text",
-								"text": "Wraps a VincentToolDef object and returns a fully typed tool with\nstandard lifecycle entrypoints ("
-							},
-							{
-								"kind": "code",
-								"text": "`precheck`"
-							},
-							{
-								"kind": "text",
-								"text": ", "
-							},
-							{
-								"kind": "code",
-								"text": "`execute`"
-							},
-							{
-								"kind": "text",
-								"text": ") and strong inference\nbased on schemas and supported policies."
-							}
-						]
-					},
-					"sources": [
-						{
-							"fileName": "toolCore/vincentTool.ts",
-							"line": 28,
-							"character": 16,
-							"url": "https://github.com/LIT-Protocol/Vincent/blob/8e21b5da26217bce6eb8963c7b9c9ea95c6a2290/packages/libs/tool-sdk/src/lib/toolCore/vincentTool.ts#L28"
-						}
-					],
-					"typeParameters": [
-						{
-							"id": 51,
-							"name": "ToolParamsSchema",
-							"variant": "typeParam",
-							"kind": 131072,
-							"flags": {},
-							"type": {
-								"type": "reference",
-								"target": {
-									"sourceFileName": "../../../node_modules/.pnpm/zod@3.25.64/node_modules/zod/dist/types/v3/types.d.ts",
-									"qualifiedName": "ZodType"
-								},
-								"typeArguments": [
-									{
-										"type": "intrinsic",
-										"name": "any"
-									},
-									{
-										"type": "reference",
-										"target": {
-											"sourceFileName": "../../../node_modules/.pnpm/zod@3.25.64/node_modules/zod/dist/types/v3/types.d.ts",
-											"qualifiedName": "ZodTypeDef"
-										},
-										"name": "ZodTypeDef",
-										"package": "zod"
-									},
-									{
-										"type": "intrinsic",
-										"name": "any"
-									}
-								],
-								"name": "ZodType",
-								"package": "zod"
-							}
-						},
-						{
-							"id": 52,
-							"name": "PkgNames",
-							"variant": "typeParam",
-							"kind": 131072,
-							"flags": {
-								"isConst": true
-							},
-							"type": {
-								"type": "intrinsic",
-								"name": "string"
-							}
-						},
-						{
-							"id": 53,
-							"name": "PolicyMap",
-							"variant": "typeParam",
-							"kind": 131072,
-							"flags": {
-								"isConst": true
-							},
-							"type": {
-								"type": "reference",
-								"target": {
-									"sourceFileName": "src/lib/toolCore/helpers/supportedPoliciesForTool.ts",
-									"qualifiedName": "ToolPolicyMap"
-								},
-								"typeArguments": [
-									{
-										"type": "intrinsic",
-										"name": "any"
-									},
-									{
-										"type": "reference",
-										"target": 52,
-										"name": "PkgNames",
-										"package": "@lit-protocol/vincent-tool-sdk",
-										"refersToTypeParameter": true
-									}
-								],
-								"name": "ToolPolicyMap",
-								"package": "@lit-protocol/vincent-tool-sdk"
-							}
-						},
-						{
-							"id": 54,
-							"name": "PolicyMapByPackageName",
-							"variant": "typeParam",
-							"kind": 131072,
-							"flags": {},
-							"type": {
-								"type": "mapped",
-								"parameter": "K",
-								"parameterType": {
-									"type": "intrinsic",
-									"name": "string"
-								},
-								"templateType": {
-									"type": "intrinsic",
-									"name": "any"
-								}
-							}
-						},
-						{
-							"id": 55,
-							"name": "PrecheckSuccessSchema",
-							"variant": "typeParam",
-							"kind": 131072,
-							"flags": {},
-							"type": {
-								"type": "reference",
-								"target": {
-									"sourceFileName": "../../../node_modules/.pnpm/zod@3.25.64/node_modules/zod/dist/types/v3/types.d.ts",
-									"qualifiedName": "ZodType"
-								},
-								"typeArguments": [
-									{
-										"type": "intrinsic",
-										"name": "any"
-									},
-									{
-										"type": "reference",
-										"target": {
-											"sourceFileName": "../../../node_modules/.pnpm/zod@3.25.64/node_modules/zod/dist/types/v3/types.d.ts",
-											"qualifiedName": "ZodTypeDef"
-										},
-										"name": "ZodTypeDef",
-										"package": "zod"
-									},
-									{
-										"type": "intrinsic",
-										"name": "any"
-									}
-								],
-								"name": "ZodType",
-								"package": "zod"
-							},
-							"default": {
-								"type": "reference",
-								"target": {
-									"sourceFileName": "../../../node_modules/.pnpm/zod@3.25.64/node_modules/zod/dist/types/v3/types.d.ts",
-									"qualifiedName": "ZodUndefined"
-								},
-								"name": "ZodUndefined",
-								"package": "zod"
-							}
-						},
-						{
-							"id": 56,
-							"name": "PrecheckFailSchema",
-							"variant": "typeParam",
-							"kind": 131072,
-							"flags": {},
-							"type": {
-								"type": "reference",
-								"target": {
-									"sourceFileName": "../../../node_modules/.pnpm/zod@3.25.64/node_modules/zod/dist/types/v3/types.d.ts",
-									"qualifiedName": "ZodType"
-								},
-								"typeArguments": [
-									{
-										"type": "intrinsic",
-										"name": "any"
-									},
-									{
-										"type": "reference",
-										"target": {
-											"sourceFileName": "../../../node_modules/.pnpm/zod@3.25.64/node_modules/zod/dist/types/v3/types.d.ts",
-											"qualifiedName": "ZodTypeDef"
-										},
-										"name": "ZodTypeDef",
-										"package": "zod"
-									},
-									{
-										"type": "intrinsic",
-										"name": "any"
-									}
-								],
-								"name": "ZodType",
-								"package": "zod"
-							},
-							"default": {
-								"type": "reference",
-								"target": {
-									"sourceFileName": "../../../node_modules/.pnpm/zod@3.25.64/node_modules/zod/dist/types/v3/types.d.ts",
-									"qualifiedName": "ZodUndefined"
-								},
-								"name": "ZodUndefined",
-								"package": "zod"
-							}
-						},
-						{
-							"id": 57,
-							"name": "ExecuteSuccessSchema",
-							"variant": "typeParam",
-							"kind": 131072,
-							"flags": {},
-							"type": {
-								"type": "reference",
-								"target": {
-									"sourceFileName": "../../../node_modules/.pnpm/zod@3.25.64/node_modules/zod/dist/types/v3/types.d.ts",
-									"qualifiedName": "ZodType"
-								},
-								"typeArguments": [
-									{
-										"type": "intrinsic",
-										"name": "any"
-									},
-									{
-										"type": "reference",
-										"target": {
-											"sourceFileName": "../../../node_modules/.pnpm/zod@3.25.64/node_modules/zod/dist/types/v3/types.d.ts",
-											"qualifiedName": "ZodTypeDef"
-										},
-										"name": "ZodTypeDef",
-										"package": "zod"
-									},
-									{
-										"type": "intrinsic",
-										"name": "any"
-									}
-								],
-								"name": "ZodType",
-								"package": "zod"
-							},
-							"default": {
-								"type": "reference",
-								"target": {
-									"sourceFileName": "../../../node_modules/.pnpm/zod@3.25.64/node_modules/zod/dist/types/v3/types.d.ts",
-									"qualifiedName": "ZodUndefined"
-								},
-								"name": "ZodUndefined",
-								"package": "zod"
-							}
-						},
-						{
-							"id": 58,
-							"name": "ExecuteFailSchema",
-							"variant": "typeParam",
-							"kind": 131072,
-							"flags": {},
-							"type": {
-								"type": "reference",
-								"target": {
-									"sourceFileName": "../../../node_modules/.pnpm/zod@3.25.64/node_modules/zod/dist/types/v3/types.d.ts",
-									"qualifiedName": "ZodType"
-								},
-								"typeArguments": [
-									{
-										"type": "intrinsic",
-										"name": "any"
-									},
-									{
-										"type": "reference",
-										"target": {
-											"sourceFileName": "../../../node_modules/.pnpm/zod@3.25.64/node_modules/zod/dist/types/v3/types.d.ts",
-											"qualifiedName": "ZodTypeDef"
-										},
-										"name": "ZodTypeDef",
-										"package": "zod"
-									},
-									{
-										"type": "intrinsic",
-										"name": "any"
-									}
-								],
-								"name": "ZodType",
-								"package": "zod"
-							},
-							"default": {
-								"type": "reference",
-								"target": {
-									"sourceFileName": "../../../node_modules/.pnpm/zod@3.25.64/node_modules/zod/dist/types/v3/types.d.ts",
-									"qualifiedName": "ZodUndefined"
-								},
-								"name": "ZodUndefined",
-								"package": "zod"
-							}
-						}
-					],
-					"parameters": [
-						{
-							"id": 59,
-							"name": "toolDef",
-							"variant": "param",
-							"kind": 32768,
-							"flags": {},
-							"type": {
-								"type": "reference",
-								"target": {
-									"sourceFileName": "src/lib/toolCore/toolDef/types.ts",
-									"qualifiedName": "VincentToolDef"
-								},
-								"typeArguments": [
-									{
-										"type": "reference",
-										"target": 51,
-										"name": "ToolParamsSchema",
-										"package": "@lit-protocol/vincent-tool-sdk",
-										"refersToTypeParameter": true
-									},
-									{
-										"type": "reference",
-										"target": 52,
-										"name": "PkgNames",
-										"package": "@lit-protocol/vincent-tool-sdk",
-										"refersToTypeParameter": true
-									},
-									{
-										"type": "reference",
-										"target": 53,
-										"name": "PolicyMap",
-										"package": "@lit-protocol/vincent-tool-sdk",
-										"refersToTypeParameter": true
-									},
-									{
-										"type": "reference",
-										"target": 54,
-										"name": "PolicyMapByPackageName",
-										"package": "@lit-protocol/vincent-tool-sdk",
-										"refersToTypeParameter": true
-									},
-									{
-										"type": "reference",
-										"target": 55,
-										"name": "PrecheckSuccessSchema",
-										"package": "@lit-protocol/vincent-tool-sdk",
-										"refersToTypeParameter": true
-									},
-									{
-										"type": "reference",
-										"target": 56,
-										"name": "PrecheckFailSchema",
-										"package": "@lit-protocol/vincent-tool-sdk",
-										"refersToTypeParameter": true
-									},
-									{
-										"type": "reference",
-										"target": 57,
-										"name": "ExecuteSuccessSchema",
-										"package": "@lit-protocol/vincent-tool-sdk",
-										"refersToTypeParameter": true
-									},
-									{
-										"type": "reference",
-										"target": 58,
-										"name": "ExecuteFailSchema",
-										"package": "@lit-protocol/vincent-tool-sdk",
-										"refersToTypeParameter": true
-									},
-									{
-										"type": "reference",
-										"target": {
-											"sourceFileName": "src/lib/toolCore/toolDef/types.ts",
-											"qualifiedName": "ToolDefLifecycleFunction"
-										},
-										"typeArguments": [
-											{
-												"type": "reference",
-												"target": 51,
-												"name": "ToolParamsSchema",
-												"package": "@lit-protocol/vincent-tool-sdk",
-												"refersToTypeParameter": true
-											},
-											{
-												"type": "reference",
-												"target": 156,
-												"typeArguments": [
-													{
-														"type": "reference",
-														"target": 54,
-														"name": "PolicyMapByPackageName",
-														"package": "@lit-protocol/vincent-tool-sdk",
-														"refersToTypeParameter": true
-													}
-												],
-												"name": "PolicyEvaluationResultContext",
-												"package": "@lit-protocol/vincent-tool-sdk"
-											},
-											{
-												"type": "reference",
-												"target": 55,
-												"name": "PrecheckSuccessSchema",
-												"package": "@lit-protocol/vincent-tool-sdk",
-												"refersToTypeParameter": true
-											},
-											{
-												"type": "reference",
-												"target": 56,
-												"name": "PrecheckFailSchema",
-												"package": "@lit-protocol/vincent-tool-sdk",
-												"refersToTypeParameter": true
-											}
-										],
-										"name": "ToolDefLifecycleFunction",
-										"package": "@lit-protocol/vincent-tool-sdk"
-									},
-									{
-										"type": "reference",
-										"target": {
-											"sourceFileName": "src/lib/toolCore/toolDef/types.ts",
-											"qualifiedName": "ToolDefLifecycleFunction"
-										},
-										"typeArguments": [
-											{
-												"type": "reference",
-												"target": 51,
-												"name": "ToolParamsSchema",
-												"package": "@lit-protocol/vincent-tool-sdk",
-												"refersToTypeParameter": true
-											},
-											{
-												"type": "reference",
-												"target": {
-													"sourceFileName": "src/lib/types.ts",
-													"qualifiedName": "ToolExecutionPolicyContext"
-												},
-												"typeArguments": [
-													{
-														"type": "reference",
-														"target": 54,
-														"name": "PolicyMapByPackageName",
-														"package": "@lit-protocol/vincent-tool-sdk",
-														"refersToTypeParameter": true
-													}
-												],
-												"name": "ToolExecutionPolicyContext",
-												"package": "@lit-protocol/vincent-tool-sdk"
-											},
-											{
-												"type": "reference",
-												"target": 57,
-												"name": "ExecuteSuccessSchema",
-												"package": "@lit-protocol/vincent-tool-sdk",
-												"refersToTypeParameter": true
-											},
-											{
-												"type": "reference",
-												"target": 58,
-												"name": "ExecuteFailSchema",
-												"package": "@lit-protocol/vincent-tool-sdk",
-												"refersToTypeParameter": true
-											}
-										],
-										"name": "ToolDefLifecycleFunction",
-										"package": "@lit-protocol/vincent-tool-sdk"
-									}
-								],
-								"name": "VincentToolDef",
-								"package": "@lit-protocol/vincent-tool-sdk"
-							}
-						}
-					],
-					"type": {
-						"type": "reference",
-						"target": 195,
-						"typeArguments": [
-							{
-								"type": "reference",
-								"target": 51,
-								"name": "ToolParamsSchema",
-								"package": "@lit-protocol/vincent-tool-sdk",
-								"refersToTypeParameter": true
-							},
-							{
-								"type": "reference",
-								"target": 52,
-								"name": "PkgNames",
-								"package": "@lit-protocol/vincent-tool-sdk",
-								"refersToTypeParameter": true
-							},
-							{
-								"type": "reference",
-								"target": 53,
-								"name": "PolicyMap",
-								"package": "@lit-protocol/vincent-tool-sdk",
-								"refersToTypeParameter": true
-							},
-							{
-								"type": "reference",
-								"target": 54,
-								"name": "PolicyMapByPackageName",
-								"package": "@lit-protocol/vincent-tool-sdk",
-								"refersToTypeParameter": true
-							},
-							{
-								"type": "reference",
-								"target": 57,
-								"name": "ExecuteSuccessSchema",
-								"package": "@lit-protocol/vincent-tool-sdk",
-								"refersToTypeParameter": true
-							},
-							{
-								"type": "reference",
-								"target": 58,
-								"name": "ExecuteFailSchema",
-								"package": "@lit-protocol/vincent-tool-sdk",
-								"refersToTypeParameter": true
-							},
-							{
-								"type": "reference",
-								"target": 55,
-								"name": "PrecheckSuccessSchema",
-								"package": "@lit-protocol/vincent-tool-sdk",
-								"refersToTypeParameter": true
-							},
-							{
-								"type": "reference",
-								"target": 56,
-								"name": "PrecheckFailSchema",
-								"package": "@lit-protocol/vincent-tool-sdk",
-								"refersToTypeParameter": true
-							}
-						],
-						"name": "VincentTool",
-						"package": "@lit-protocol/vincent-tool-sdk"
-					}
-				}
-			]
-		},
-		{
-			"id": 14,
+			"id": 28,
 			"name": "createVincentToolPolicy",
 			"variant": "declaration",
 			"kind": 64,
@@ -4276,14 +2677,14 @@
 			"sources": [
 				{
 					"fileName": "policyCore/vincentPolicy.ts",
-					"line": 302,
+					"line": 325,
 					"character": 16,
-					"url": "https://github.com/LIT-Protocol/Vincent/blob/8e21b5da26217bce6eb8963c7b9c9ea95c6a2290/packages/libs/tool-sdk/src/lib/policyCore/vincentPolicy.ts#L302"
+					"url": "https://github.com/LIT-Protocol/Vincent/blob/46a7999ef358981de990d808b7484f24731b23f9/packages/libs/tool-sdk/src/lib/policyCore/vincentPolicy.ts#L325"
 				}
 			],
 			"signatures": [
 				{
-					"id": 15,
+					"id": 29,
 					"name": "createVincentToolPolicy",
 					"variant": "signature",
 					"kind": 4096,
@@ -4291,22 +2692,73 @@
 					"comment": {
 						"summary": [
 							{
+								"kind": "code",
+								"text": "`createVincentToolPolicy()`"
+							},
+							{
 								"kind": "text",
-								"text": "Adapts a single policy to a specific tool by applying parameter mappings.\nThis allows the policy's schema-defined params to be inferred and automatically\nextracted from the tool's input params. Also attaches schema metadata for result typing."
+								"text": " is used to bind a policy to a specific tool. You must provide a "
+							},
+							{
+								"kind": "code",
+								"text": "`toolParameterMappings`"
+							},
+							{
+								"kind": "text",
+								"text": " argument\nwhich instructs the tool which of its toolParams should be passed to the Vincent Policy during evaluation, and\ndefines what the argument passed to the tool should be.\n\nFor example, a Tool might receive an argument called "
+							},
+							{
+								"kind": "code",
+								"text": "`tokenInAmount`"
+							},
+							{
+								"kind": "text",
+								"text": ", but it may need to pass that as "
+							},
+							{
+								"kind": "code",
+								"text": "`buyAmount`"
+							},
+							{
+								"kind": "text",
+								"text": " to a\npolicy that uses the "
+							},
+							{
+								"kind": "code",
+								"text": "`tokenInAmount`"
+							},
+							{
+								"kind": "text",
+								"text": " for its own purposes.\n\n"
+							},
+							{
+								"kind": "code",
+								"text": "```typescript\nimport { bundledVincentPolicy } from '@lit-protocol/vincent-policy-spending-limit';\n\nconst SpendingLimitPolicy = createVincentToolPolicy({\n  toolParamsSchema,\n  bundledVincentPolicy,\n  toolParameterMappings: {\n    rpcUrlForUniswap: 'rpcUrlForUniswap',\n    chainIdForUniswap: 'chainIdForUniswap',\n    ethRpcUrl: 'ethRpcUrl',\n    tokenInAddress: 'tokenAddress',\n    tokenInDecimals: 'tokenDecimals',\n    tokenInAmount: 'buyAmount',\n  },\n});\n```"
+							}
+						],
+						"blockTags": [
+							{
+								"tag": "@category",
+								"content": [
+									{
+										"kind": "text",
+										"text": "API Methods"
+									}
+								]
 							}
 						]
 					},
 					"sources": [
 						{
 							"fileName": "policyCore/vincentPolicy.ts",
-							"line": 302,
+							"line": 325,
 							"character": 16,
-							"url": "https://github.com/LIT-Protocol/Vincent/blob/8e21b5da26217bce6eb8963c7b9c9ea95c6a2290/packages/libs/tool-sdk/src/lib/policyCore/vincentPolicy.ts#L302"
+							"url": "https://github.com/LIT-Protocol/Vincent/blob/46a7999ef358981de990d808b7484f24731b23f9/packages/libs/tool-sdk/src/lib/policyCore/vincentPolicy.ts#L325"
 						}
 					],
 					"typeParameters": [
 						{
-							"id": 16,
+							"id": 30,
 							"name": "PackageName",
 							"variant": "typeParam",
 							"kind": 131072,
@@ -4319,7 +2771,7 @@
 							}
 						},
 						{
-							"id": 17,
+							"id": 31,
 							"name": "IpfsCid",
 							"variant": "typeParam",
 							"kind": 131072,
@@ -4332,7 +2784,7 @@
 							}
 						},
 						{
-							"id": 18,
+							"id": 32,
 							"name": "ToolParamsSchema",
 							"variant": "typeParam",
 							"kind": 131072,
@@ -4367,7 +2819,7 @@
 							}
 						},
 						{
-							"id": 19,
+							"id": 33,
 							"name": "PolicyToolParams",
 							"variant": "typeParam",
 							"kind": 131072,
@@ -4402,7 +2854,7 @@
 							}
 						},
 						{
-							"id": 20,
+							"id": 34,
 							"name": "UserParams",
 							"variant": "typeParam",
 							"kind": 131072,
@@ -4446,7 +2898,7 @@
 							}
 						},
 						{
-							"id": 21,
+							"id": 35,
 							"name": "PrecheckAllowResult",
 							"variant": "typeParam",
 							"kind": 131072,
@@ -4490,7 +2942,7 @@
 							}
 						},
 						{
-							"id": 22,
+							"id": 36,
 							"name": "PrecheckDenyResult",
 							"variant": "typeParam",
 							"kind": 131072,
@@ -4534,7 +2986,7 @@
 							}
 						},
 						{
-							"id": 23,
+							"id": 37,
 							"name": "EvalAllowResult",
 							"variant": "typeParam",
 							"kind": 131072,
@@ -4578,7 +3030,7 @@
 							}
 						},
 						{
-							"id": 24,
+							"id": 38,
 							"name": "EvalDenyResult",
 							"variant": "typeParam",
 							"kind": 131072,
@@ -4622,7 +3074,7 @@
 							}
 						},
 						{
-							"id": 25,
+							"id": 39,
 							"name": "CommitParams",
 							"variant": "typeParam",
 							"kind": 131072,
@@ -4666,7 +3118,7 @@
 							}
 						},
 						{
-							"id": 26,
+							"id": 40,
 							"name": "CommitAllowResult",
 							"variant": "typeParam",
 							"kind": 131072,
@@ -4710,7 +3162,7 @@
 							}
 						},
 						{
-							"id": 27,
+							"id": 41,
 							"name": "CommitDenyResult",
 							"variant": "typeParam",
 							"kind": 131072,
@@ -4756,7 +3208,7 @@
 					],
 					"parameters": [
 						{
-							"id": 28,
+							"id": 42,
 							"name": "config",
 							"variant": "param",
 							"kind": 32768,
@@ -4764,14 +3216,36 @@
 							"type": {
 								"type": "reflection",
 								"declaration": {
-									"id": 29,
+									"id": 43,
 									"name": "__type",
 									"variant": "declaration",
 									"kind": 65536,
 									"flags": {},
 									"children": [
 										{
-											"id": 31,
+											"id": 44,
+											"name": "toolParamsSchema",
+											"variant": "declaration",
+											"kind": 1024,
+											"flags": {},
+											"sources": [
+												{
+													"fileName": "policyCore/vincentPolicy.ts",
+													"line": 339,
+													"character": 2,
+													"url": "https://github.com/LIT-Protocol/Vincent/blob/46a7999ef358981de990d808b7484f24731b23f9/packages/libs/tool-sdk/src/lib/policyCore/vincentPolicy.ts#L339"
+												}
+											],
+											"type": {
+												"type": "reference",
+												"target": 32,
+												"name": "ToolParamsSchema",
+												"package": "@lit-protocol/vincent-tool-sdk",
+												"refersToTypeParameter": true
+											}
+										},
+										{
+											"id": 45,
 											"name": "bundledVincentPolicy",
 											"variant": "declaration",
 											"kind": 1024,
@@ -4779,14 +3253,14 @@
 											"sources": [
 												{
 													"fileName": "policyCore/vincentPolicy.ts",
-													"line": 317,
+													"line": 340,
 													"character": 2,
-													"url": "https://github.com/LIT-Protocol/Vincent/blob/8e21b5da26217bce6eb8963c7b9c9ea95c6a2290/packages/libs/tool-sdk/src/lib/policyCore/vincentPolicy.ts#L317"
+													"url": "https://github.com/LIT-Protocol/Vincent/blob/46a7999ef358981de990d808b7484f24731b23f9/packages/libs/tool-sdk/src/lib/policyCore/vincentPolicy.ts#L340"
 												}
 											],
 											"type": {
 												"type": "reference",
-												"target": 107,
+												"target": -1,
 												"typeArguments": [
 													{
 														"type": "reference",
@@ -4797,70 +3271,70 @@
 														"typeArguments": [
 															{
 																"type": "reference",
-																"target": 16,
+																"target": 30,
 																"name": "PackageName",
 																"package": "@lit-protocol/vincent-tool-sdk",
 																"refersToTypeParameter": true
 															},
 															{
 																"type": "reference",
-																"target": 19,
+																"target": 33,
 																"name": "PolicyToolParams",
 																"package": "@lit-protocol/vincent-tool-sdk",
 																"refersToTypeParameter": true
 															},
 															{
 																"type": "reference",
-																"target": 20,
+																"target": 34,
 																"name": "UserParams",
 																"package": "@lit-protocol/vincent-tool-sdk",
 																"refersToTypeParameter": true
 															},
 															{
 																"type": "reference",
-																"target": 21,
+																"target": 35,
 																"name": "PrecheckAllowResult",
 																"package": "@lit-protocol/vincent-tool-sdk",
 																"refersToTypeParameter": true
 															},
 															{
 																"type": "reference",
-																"target": 22,
+																"target": 36,
 																"name": "PrecheckDenyResult",
 																"package": "@lit-protocol/vincent-tool-sdk",
 																"refersToTypeParameter": true
 															},
 															{
 																"type": "reference",
-																"target": 23,
+																"target": 37,
 																"name": "EvalAllowResult",
 																"package": "@lit-protocol/vincent-tool-sdk",
 																"refersToTypeParameter": true
 															},
 															{
 																"type": "reference",
-																"target": 24,
+																"target": 38,
 																"name": "EvalDenyResult",
 																"package": "@lit-protocol/vincent-tool-sdk",
 																"refersToTypeParameter": true
 															},
 															{
 																"type": "reference",
-																"target": 25,
+																"target": 39,
 																"name": "CommitParams",
 																"package": "@lit-protocol/vincent-tool-sdk",
 																"refersToTypeParameter": true
 															},
 															{
 																"type": "reference",
-																"target": 26,
+																"target": 40,
 																"name": "CommitAllowResult",
 																"package": "@lit-protocol/vincent-tool-sdk",
 																"refersToTypeParameter": true
 															},
 															{
 																"type": "reference",
-																"target": 27,
+																"target": 41,
 																"name": "CommitDenyResult",
 																"package": "@lit-protocol/vincent-tool-sdk",
 																"refersToTypeParameter": true
@@ -4874,28 +3348,28 @@
 																"typeArguments": [
 																	{
 																		"type": "reference",
-																		"target": 19,
+																		"target": 33,
 																		"name": "PolicyToolParams",
 																		"package": "@lit-protocol/vincent-tool-sdk",
 																		"refersToTypeParameter": true
 																	},
 																	{
 																		"type": "reference",
-																		"target": 20,
+																		"target": 34,
 																		"name": "UserParams",
 																		"package": "@lit-protocol/vincent-tool-sdk",
 																		"refersToTypeParameter": true
 																	},
 																	{
 																		"type": "reference",
-																		"target": 23,
+																		"target": 37,
 																		"name": "EvalAllowResult",
 																		"package": "@lit-protocol/vincent-tool-sdk",
 																		"refersToTypeParameter": true
 																	},
 																	{
 																		"type": "reference",
-																		"target": 24,
+																		"target": 38,
 																		"name": "EvalDenyResult",
 																		"package": "@lit-protocol/vincent-tool-sdk",
 																		"refersToTypeParameter": true
@@ -4913,28 +3387,28 @@
 																"typeArguments": [
 																	{
 																		"type": "reference",
-																		"target": 19,
+																		"target": 33,
 																		"name": "PolicyToolParams",
 																		"package": "@lit-protocol/vincent-tool-sdk",
 																		"refersToTypeParameter": true
 																	},
 																	{
 																		"type": "reference",
-																		"target": 20,
+																		"target": 34,
 																		"name": "UserParams",
 																		"package": "@lit-protocol/vincent-tool-sdk",
 																		"refersToTypeParameter": true
 																	},
 																	{
 																		"type": "reference",
-																		"target": 21,
+																		"target": 35,
 																		"name": "PrecheckAllowResult",
 																		"package": "@lit-protocol/vincent-tool-sdk",
 																		"refersToTypeParameter": true
 																	},
 																	{
 																		"type": "reference",
-																		"target": 22,
+																		"target": 36,
 																		"name": "PrecheckDenyResult",
 																		"package": "@lit-protocol/vincent-tool-sdk",
 																		"refersToTypeParameter": true
@@ -4952,21 +3426,21 @@
 																"typeArguments": [
 																	{
 																		"type": "reference",
-																		"target": 25,
+																		"target": 39,
 																		"name": "CommitParams",
 																		"package": "@lit-protocol/vincent-tool-sdk",
 																		"refersToTypeParameter": true
 																	},
 																	{
 																		"type": "reference",
-																		"target": 26,
+																		"target": 40,
 																		"name": "CommitAllowResult",
 																		"package": "@lit-protocol/vincent-tool-sdk",
 																		"refersToTypeParameter": true
 																	},
 																	{
 																		"type": "reference",
-																		"target": 27,
+																		"target": 41,
 																		"name": "CommitDenyResult",
 																		"package": "@lit-protocol/vincent-tool-sdk",
 																		"refersToTypeParameter": true
@@ -4981,7 +3455,7 @@
 													},
 													{
 														"type": "reference",
-														"target": 17,
+														"target": 31,
 														"name": "IpfsCid",
 														"package": "@lit-protocol/vincent-tool-sdk",
 														"refersToTypeParameter": true
@@ -4992,7 +3466,7 @@
 											}
 										},
 										{
-											"id": 32,
+											"id": 46,
 											"name": "toolParameterMappings",
 											"variant": "declaration",
 											"kind": 1024,
@@ -5000,9 +3474,9 @@
 											"sources": [
 												{
 													"fileName": "policyCore/vincentPolicy.ts",
-													"line": 340,
+													"line": 363,
 													"character": 2,
-													"url": "https://github.com/LIT-Protocol/Vincent/blob/8e21b5da26217bce6eb8963c7b9c9ea95c6a2290/packages/libs/tool-sdk/src/lib/policyCore/vincentPolicy.ts#L340"
+													"url": "https://github.com/LIT-Protocol/Vincent/blob/46a7999ef358981de990d808b7484f24731b23f9/packages/libs/tool-sdk/src/lib/policyCore/vincentPolicy.ts#L363"
 												}
 											],
 											"type": {
@@ -5044,7 +3518,7 @@
 																"typeArguments": [
 																	{
 																		"type": "reference",
-																		"target": 19,
+																		"target": 33,
 																		"name": "PolicyToolParams",
 																		"package": "@lit-protocol/vincent-tool-sdk",
 																		"refersToTypeParameter": true
@@ -5059,46 +3533,24 @@
 												"name": "Partial",
 												"package": "typescript"
 											}
-										},
-										{
-											"id": 30,
-											"name": "toolParamsSchema",
-											"variant": "declaration",
-											"kind": 1024,
-											"flags": {},
-											"sources": [
-												{
-													"fileName": "policyCore/vincentPolicy.ts",
-													"line": 316,
-													"character": 2,
-													"url": "https://github.com/LIT-Protocol/Vincent/blob/8e21b5da26217bce6eb8963c7b9c9ea95c6a2290/packages/libs/tool-sdk/src/lib/policyCore/vincentPolicy.ts#L316"
-												}
-											],
-											"type": {
-												"type": "reference",
-												"target": 18,
-												"name": "ToolParamsSchema",
-												"package": "@lit-protocol/vincent-tool-sdk",
-												"refersToTypeParameter": true
-											}
 										}
 									],
 									"groups": [
 										{
 											"title": "Properties",
 											"children": [
-												31,
-												32,
-												30
+												44,
+												45,
+												46
 											]
 										}
 									],
 									"sources": [
 										{
 											"fileName": "policyCore/vincentPolicy.ts",
-											"line": 315,
+											"line": 338,
 											"character": 10,
-											"url": "https://github.com/LIT-Protocol/Vincent/blob/8e21b5da26217bce6eb8963c7b9c9ea95c6a2290/packages/libs/tool-sdk/src/lib/policyCore/vincentPolicy.ts#L315"
+											"url": "https://github.com/LIT-Protocol/Vincent/blob/46a7999ef358981de990d808b7484f24731b23f9/packages/libs/tool-sdk/src/lib/policyCore/vincentPolicy.ts#L338"
 										}
 									]
 								}
@@ -5108,393 +3560,220 @@
 					"type": {
 						"type": "reflection",
 						"declaration": {
-							"id": 33,
+							"id": 47,
 							"name": "__type",
 							"variant": "declaration",
 							"kind": 65536,
 							"flags": {},
 							"children": [
 								{
-									"id": 37,
-									"name": "__schemaTypes",
+									"id": 48,
+									"name": "vincentPolicy",
 									"variant": "declaration",
 									"kind": 1024,
 									"flags": {},
 									"sources": [
 										{
 											"fileName": "policyCore/vincentPolicy.ts",
-											"line": 373,
+											"line": 394,
 											"character": 4,
-											"url": "https://github.com/LIT-Protocol/Vincent/blob/8e21b5da26217bce6eb8963c7b9c9ea95c6a2290/packages/libs/tool-sdk/src/lib/policyCore/vincentPolicy.ts#L373"
+											"url": "https://github.com/LIT-Protocol/Vincent/blob/46a7999ef358981de990d808b7484f24731b23f9/packages/libs/tool-sdk/src/lib/policyCore/vincentPolicy.ts#L394"
 										}
 									],
 									"type": {
-										"type": "reflection",
-										"declaration": {
-											"id": 38,
-											"name": "__type",
-											"variant": "declaration",
-											"kind": 65536,
-											"flags": {},
-											"children": [
-												{
-													"id": 48,
-													"name": "commit",
-													"variant": "declaration",
-													"kind": 1024,
-													"flags": {},
-													"sources": [
-														{
-															"fileName": "policyCore/vincentPolicy.ts",
-															"line": 384,
-															"character": 6,
-															"url": "https://github.com/LIT-Protocol/Vincent/blob/8e21b5da26217bce6eb8963c7b9c9ea95c6a2290/packages/libs/tool-sdk/src/lib/policyCore/vincentPolicy.ts#L384"
-														}
-													],
-													"type": {
-														"type": "union",
-														"types": [
-															{
-																"type": "intrinsic",
-																"name": "undefined"
-															},
-															{
-																"type": "reference",
-																"target": {
-																	"sourceFileName": "src/lib/types.ts",
-																	"qualifiedName": "CommitLifecycleFunction"
-																},
-																"typeArguments": [
-																	{
-																		"type": "reference",
-																		"target": 25,
-																		"name": "CommitParams",
-																		"package": "@lit-protocol/vincent-tool-sdk",
-																		"refersToTypeParameter": true
-																	},
-																	{
-																		"type": "reference",
-																		"target": 26,
-																		"name": "CommitAllowResult",
-																		"package": "@lit-protocol/vincent-tool-sdk",
-																		"refersToTypeParameter": true
-																	},
-																	{
-																		"type": "reference",
-																		"target": 27,
-																		"name": "CommitDenyResult",
-																		"package": "@lit-protocol/vincent-tool-sdk",
-																		"refersToTypeParameter": true
-																	}
-																],
-																"name": "CommitLifecycleFunction",
-																"package": "@lit-protocol/vincent-tool-sdk"
-															}
-														]
-													}
+										"type": "reference",
+										"target": {
+											"sourceFileName": "src/lib/types.ts",
+											"qualifiedName": "VincentPolicy"
+										},
+										"typeArguments": [
+											{
+												"type": "reference",
+												"target": 30,
+												"name": "PackageName",
+												"package": "@lit-protocol/vincent-tool-sdk",
+												"refersToTypeParameter": true
+											},
+											{
+												"type": "reference",
+												"target": 33,
+												"name": "PolicyToolParams",
+												"package": "@lit-protocol/vincent-tool-sdk",
+												"refersToTypeParameter": true
+											},
+											{
+												"type": "reference",
+												"target": 34,
+												"name": "UserParams",
+												"package": "@lit-protocol/vincent-tool-sdk",
+												"refersToTypeParameter": true
+											},
+											{
+												"type": "reference",
+												"target": 35,
+												"name": "PrecheckAllowResult",
+												"package": "@lit-protocol/vincent-tool-sdk",
+												"refersToTypeParameter": true
+											},
+											{
+												"type": "reference",
+												"target": 36,
+												"name": "PrecheckDenyResult",
+												"package": "@lit-protocol/vincent-tool-sdk",
+												"refersToTypeParameter": true
+											},
+											{
+												"type": "reference",
+												"target": 37,
+												"name": "EvalAllowResult",
+												"package": "@lit-protocol/vincent-tool-sdk",
+												"refersToTypeParameter": true
+											},
+											{
+												"type": "reference",
+												"target": 38,
+												"name": "EvalDenyResult",
+												"package": "@lit-protocol/vincent-tool-sdk",
+												"refersToTypeParameter": true
+											},
+											{
+												"type": "reference",
+												"target": 39,
+												"name": "CommitParams",
+												"package": "@lit-protocol/vincent-tool-sdk",
+												"refersToTypeParameter": true
+											},
+											{
+												"type": "reference",
+												"target": 40,
+												"name": "CommitAllowResult",
+												"package": "@lit-protocol/vincent-tool-sdk",
+												"refersToTypeParameter": true
+											},
+											{
+												"type": "reference",
+												"target": 41,
+												"name": "CommitDenyResult",
+												"package": "@lit-protocol/vincent-tool-sdk",
+												"refersToTypeParameter": true
+											},
+											{
+												"type": "reference",
+												"target": {
+													"sourceFileName": "src/lib/types.ts",
+													"qualifiedName": "PolicyLifecycleFunction"
 												},
-												{
-													"id": 44,
-													"name": "commitAllowResultSchema",
-													"variant": "declaration",
-													"kind": 1024,
-													"flags": {},
-													"sources": [
-														{
-															"fileName": "policyCore/vincentPolicy.ts",
-															"line": 379,
-															"character": 6,
-															"url": "https://github.com/LIT-Protocol/Vincent/blob/8e21b5da26217bce6eb8963c7b9c9ea95c6a2290/packages/libs/tool-sdk/src/lib/policyCore/vincentPolicy.ts#L379"
-														}
-													],
-													"type": {
+												"typeArguments": [
+													{
 														"type": "reference",
-														"target": 26,
-														"name": "CommitAllowResult",
+														"target": 33,
+														"name": "PolicyToolParams",
 														"package": "@lit-protocol/vincent-tool-sdk",
 														"refersToTypeParameter": true
-													}
-												},
-												{
-													"id": 45,
-													"name": "commitDenyResultSchema",
-													"variant": "declaration",
-													"kind": 1024,
-													"flags": {},
-													"sources": [
-														{
-															"fileName": "policyCore/vincentPolicy.ts",
-															"line": 380,
-															"character": 6,
-															"url": "https://github.com/LIT-Protocol/Vincent/blob/8e21b5da26217bce6eb8963c7b9c9ea95c6a2290/packages/libs/tool-sdk/src/lib/policyCore/vincentPolicy.ts#L380"
-														}
-													],
-													"type": {
+													},
+													{
 														"type": "reference",
-														"target": 27,
-														"name": "CommitDenyResult",
+														"target": 34,
+														"name": "UserParams",
 														"package": "@lit-protocol/vincent-tool-sdk",
 														"refersToTypeParameter": true
-													}
-												},
-												{
-													"id": 43,
-													"name": "commitParamsSchema",
-													"variant": "declaration",
-													"kind": 1024,
-													"flags": {},
-													"sources": [
-														{
-															"fileName": "policyCore/vincentPolicy.ts",
-															"line": 378,
-															"character": 6,
-															"url": "https://github.com/LIT-Protocol/Vincent/blob/8e21b5da26217bce6eb8963c7b9c9ea95c6a2290/packages/libs/tool-sdk/src/lib/policyCore/vincentPolicy.ts#L378"
-														}
-													],
-													"type": {
+													},
+													{
 														"type": "reference",
-														"target": 25,
-														"name": "CommitParams",
-														"package": "@lit-protocol/vincent-tool-sdk",
-														"refersToTypeParameter": true
-													}
-												},
-												{
-													"id": 39,
-													"name": "evalAllowResultSchema",
-													"variant": "declaration",
-													"kind": 1024,
-													"flags": {},
-													"sources": [
-														{
-															"fileName": "policyCore/vincentPolicy.ts",
-															"line": 374,
-															"character": 6,
-															"url": "https://github.com/LIT-Protocol/Vincent/blob/8e21b5da26217bce6eb8963c7b9c9ea95c6a2290/packages/libs/tool-sdk/src/lib/policyCore/vincentPolicy.ts#L374"
-														}
-													],
-													"type": {
-														"type": "reference",
-														"target": 23,
+														"target": 37,
 														"name": "EvalAllowResult",
 														"package": "@lit-protocol/vincent-tool-sdk",
 														"refersToTypeParameter": true
-													}
-												},
-												{
-													"id": 40,
-													"name": "evalDenyResultSchema",
-													"variant": "declaration",
-													"kind": 1024,
-													"flags": {},
-													"sources": [
-														{
-															"fileName": "policyCore/vincentPolicy.ts",
-															"line": 375,
-															"character": 6,
-															"url": "https://github.com/LIT-Protocol/Vincent/blob/8e21b5da26217bce6eb8963c7b9c9ea95c6a2290/packages/libs/tool-sdk/src/lib/policyCore/vincentPolicy.ts#L375"
-														}
-													],
-													"type": {
+													},
+													{
 														"type": "reference",
-														"target": 24,
+														"target": 38,
 														"name": "EvalDenyResult",
 														"package": "@lit-protocol/vincent-tool-sdk",
 														"refersToTypeParameter": true
 													}
+												],
+												"name": "PolicyLifecycleFunction",
+												"package": "@lit-protocol/vincent-tool-sdk"
+											},
+											{
+												"type": "reference",
+												"target": {
+													"sourceFileName": "src/lib/types.ts",
+													"qualifiedName": "PolicyLifecycleFunction"
 												},
-												{
-													"id": 46,
-													"name": "evaluate",
-													"variant": "declaration",
-													"kind": 1024,
-													"flags": {},
-													"sources": [
-														{
-															"fileName": "policyCore/vincentPolicy.ts",
-															"line": 382,
-															"character": 6,
-															"url": "https://github.com/LIT-Protocol/Vincent/blob/8e21b5da26217bce6eb8963c7b9c9ea95c6a2290/packages/libs/tool-sdk/src/lib/policyCore/vincentPolicy.ts#L382"
-														}
-													],
-													"type": {
+												"typeArguments": [
+													{
 														"type": "reference",
-														"target": {
-															"sourceFileName": "src/lib/types.ts",
-															"qualifiedName": "PolicyLifecycleFunction"
-														},
-														"typeArguments": [
-															{
-																"type": "reference",
-																"target": 19,
-																"name": "PolicyToolParams",
-																"package": "@lit-protocol/vincent-tool-sdk",
-																"refersToTypeParameter": true
-															},
-															{
-																"type": "reference",
-																"target": 20,
-																"name": "UserParams",
-																"package": "@lit-protocol/vincent-tool-sdk",
-																"refersToTypeParameter": true
-															},
-															{
-																"type": "reference",
-																"target": 23,
-																"name": "EvalAllowResult",
-																"package": "@lit-protocol/vincent-tool-sdk",
-																"refersToTypeParameter": true
-															},
-															{
-																"type": "reference",
-																"target": 24,
-																"name": "EvalDenyResult",
-																"package": "@lit-protocol/vincent-tool-sdk",
-																"refersToTypeParameter": true
-															}
-														],
-														"name": "PolicyLifecycleFunction",
-														"package": "@lit-protocol/vincent-tool-sdk"
-													}
-												},
-												{
-													"id": 47,
-													"name": "precheck",
-													"variant": "declaration",
-													"kind": 1024,
-													"flags": {},
-													"sources": [
-														{
-															"fileName": "policyCore/vincentPolicy.ts",
-															"line": 383,
-															"character": 6,
-															"url": "https://github.com/LIT-Protocol/Vincent/blob/8e21b5da26217bce6eb8963c7b9c9ea95c6a2290/packages/libs/tool-sdk/src/lib/policyCore/vincentPolicy.ts#L383"
-														}
-													],
-													"type": {
-														"type": "union",
-														"types": [
-															{
-																"type": "intrinsic",
-																"name": "undefined"
-															},
-															{
-																"type": "reference",
-																"target": {
-																	"sourceFileName": "src/lib/types.ts",
-																	"qualifiedName": "PolicyLifecycleFunction"
-																},
-																"typeArguments": [
-																	{
-																		"type": "reference",
-																		"target": 19,
-																		"name": "PolicyToolParams",
-																		"package": "@lit-protocol/vincent-tool-sdk",
-																		"refersToTypeParameter": true
-																	},
-																	{
-																		"type": "reference",
-																		"target": 20,
-																		"name": "UserParams",
-																		"package": "@lit-protocol/vincent-tool-sdk",
-																		"refersToTypeParameter": true
-																	},
-																	{
-																		"type": "reference",
-																		"target": 21,
-																		"name": "PrecheckAllowResult",
-																		"package": "@lit-protocol/vincent-tool-sdk",
-																		"refersToTypeParameter": true
-																	},
-																	{
-																		"type": "reference",
-																		"target": 22,
-																		"name": "PrecheckDenyResult",
-																		"package": "@lit-protocol/vincent-tool-sdk",
-																		"refersToTypeParameter": true
-																	}
-																],
-																"name": "PolicyLifecycleFunction",
-																"package": "@lit-protocol/vincent-tool-sdk"
-															}
-														]
-													}
-												},
-												{
-													"id": 41,
-													"name": "precheckAllowResultSchema",
-													"variant": "declaration",
-													"kind": 1024,
-													"flags": {},
-													"sources": [
-														{
-															"fileName": "policyCore/vincentPolicy.ts",
-															"line": 376,
-															"character": 6,
-															"url": "https://github.com/LIT-Protocol/Vincent/blob/8e21b5da26217bce6eb8963c7b9c9ea95c6a2290/packages/libs/tool-sdk/src/lib/policyCore/vincentPolicy.ts#L376"
-														}
-													],
-													"type": {
+														"target": 33,
+														"name": "PolicyToolParams",
+														"package": "@lit-protocol/vincent-tool-sdk",
+														"refersToTypeParameter": true
+													},
+													{
 														"type": "reference",
-														"target": 21,
+														"target": 34,
+														"name": "UserParams",
+														"package": "@lit-protocol/vincent-tool-sdk",
+														"refersToTypeParameter": true
+													},
+													{
+														"type": "reference",
+														"target": 35,
 														"name": "PrecheckAllowResult",
 														"package": "@lit-protocol/vincent-tool-sdk",
 														"refersToTypeParameter": true
-													}
-												},
-												{
-													"id": 42,
-													"name": "precheckDenyResultSchema",
-													"variant": "declaration",
-													"kind": 1024,
-													"flags": {},
-													"sources": [
-														{
-															"fileName": "policyCore/vincentPolicy.ts",
-															"line": 377,
-															"character": 6,
-															"url": "https://github.com/LIT-Protocol/Vincent/blob/8e21b5da26217bce6eb8963c7b9c9ea95c6a2290/packages/libs/tool-sdk/src/lib/policyCore/vincentPolicy.ts#L377"
-														}
-													],
-													"type": {
+													},
+													{
 														"type": "reference",
-														"target": 22,
+														"target": 36,
 														"name": "PrecheckDenyResult",
 														"package": "@lit-protocol/vincent-tool-sdk",
 														"refersToTypeParameter": true
 													}
-												}
-											],
-											"groups": [
-												{
-													"title": "Properties",
-													"children": [
-														48,
-														44,
-														45,
-														43,
-														39,
-														40,
-														46,
-														47,
-														41,
-														42
-													]
-												}
-											],
-											"sources": [
-												{
-													"fileName": "policyCore/vincentPolicy.ts",
-													"line": 373,
-													"character": 19,
-													"url": "https://github.com/LIT-Protocol/Vincent/blob/8e21b5da26217bce6eb8963c7b9c9ea95c6a2290/packages/libs/tool-sdk/src/lib/policyCore/vincentPolicy.ts#L373"
-												}
-											]
-										}
+												],
+												"name": "PolicyLifecycleFunction",
+												"package": "@lit-protocol/vincent-tool-sdk"
+											},
+											{
+												"type": "reference",
+												"target": {
+													"sourceFileName": "src/lib/types.ts",
+													"qualifiedName": "CommitLifecycleFunction"
+												},
+												"typeArguments": [
+													{
+														"type": "reference",
+														"target": 39,
+														"name": "CommitParams",
+														"package": "@lit-protocol/vincent-tool-sdk",
+														"refersToTypeParameter": true
+													},
+													{
+														"type": "reference",
+														"target": 40,
+														"name": "CommitAllowResult",
+														"package": "@lit-protocol/vincent-tool-sdk",
+														"refersToTypeParameter": true
+													},
+													{
+														"type": "reference",
+														"target": 41,
+														"name": "CommitDenyResult",
+														"package": "@lit-protocol/vincent-tool-sdk",
+														"refersToTypeParameter": true
+													}
+												],
+												"name": "CommitLifecycleFunction",
+												"package": "@lit-protocol/vincent-tool-sdk"
+											}
+										],
+										"name": "VincentPolicy",
+										"package": "@lit-protocol/vincent-tool-sdk"
 									}
 								},
 								{
-									"id": 35,
+									"id": 49,
 									"name": "ipfsCid",
 									"variant": "declaration",
 									"kind": 1024,
@@ -5502,21 +3781,21 @@
 									"sources": [
 										{
 											"fileName": "policyCore/vincentPolicy.ts",
-											"line": 371,
+											"line": 395,
 											"character": 4,
-											"url": "https://github.com/LIT-Protocol/Vincent/blob/8e21b5da26217bce6eb8963c7b9c9ea95c6a2290/packages/libs/tool-sdk/src/lib/policyCore/vincentPolicy.ts#L371"
+											"url": "https://github.com/LIT-Protocol/Vincent/blob/46a7999ef358981de990d808b7484f24731b23f9/packages/libs/tool-sdk/src/lib/policyCore/vincentPolicy.ts#L395"
 										}
 									],
 									"type": {
 										"type": "reference",
-										"target": 17,
+										"target": 31,
 										"name": "IpfsCid",
 										"package": "@lit-protocol/vincent-tool-sdk",
 										"refersToTypeParameter": true
 									}
 								},
 								{
-									"id": 36,
+									"id": 50,
 									"name": "toolParameterMappings",
 									"variant": "declaration",
 									"kind": 1024,
@@ -5524,9 +3803,9 @@
 									"sources": [
 										{
 											"fileName": "policyCore/vincentPolicy.ts",
-											"line": 372,
+											"line": 396,
 											"character": 4,
-											"url": "https://github.com/LIT-Protocol/Vincent/blob/8e21b5da26217bce6eb8963c7b9c9ea95c6a2290/packages/libs/tool-sdk/src/lib/policyCore/vincentPolicy.ts#L372"
+											"url": "https://github.com/LIT-Protocol/Vincent/blob/46a7999ef358981de990d808b7484f24731b23f9/packages/libs/tool-sdk/src/lib/policyCore/vincentPolicy.ts#L396"
 										}
 									],
 									"type": {
@@ -5568,7 +3847,7 @@
 														"typeArguments": [
 															{
 																"type": "reference",
-																"target": 19,
+																"target": 33,
 																"name": "PolicyToolParams",
 																"package": "@lit-protocol/vincent-tool-sdk",
 																"refersToTypeParameter": true
@@ -5585,209 +3864,382 @@
 									}
 								},
 								{
-									"id": 34,
-									"name": "vincentPolicy",
+									"id": 51,
+									"name": "__schemaTypes",
 									"variant": "declaration",
 									"kind": 1024,
 									"flags": {},
 									"sources": [
 										{
 											"fileName": "policyCore/vincentPolicy.ts",
-											"line": 370,
+											"line": 398,
 											"character": 4,
-											"url": "https://github.com/LIT-Protocol/Vincent/blob/8e21b5da26217bce6eb8963c7b9c9ea95c6a2290/packages/libs/tool-sdk/src/lib/policyCore/vincentPolicy.ts#L370"
+											"url": "https://github.com/LIT-Protocol/Vincent/blob/46a7999ef358981de990d808b7484f24731b23f9/packages/libs/tool-sdk/src/lib/policyCore/vincentPolicy.ts#L398"
 										}
 									],
 									"type": {
-										"type": "reference",
-										"target": {
-											"sourceFileName": "src/lib/types.ts",
-											"qualifiedName": "VincentPolicy"
-										},
-										"typeArguments": [
-											{
-												"type": "reference",
-												"target": 16,
-												"name": "PackageName",
-												"package": "@lit-protocol/vincent-tool-sdk",
-												"refersToTypeParameter": true
-											},
-											{
-												"type": "reference",
-												"target": 19,
-												"name": "PolicyToolParams",
-												"package": "@lit-protocol/vincent-tool-sdk",
-												"refersToTypeParameter": true
-											},
-											{
-												"type": "reference",
-												"target": 20,
-												"name": "UserParams",
-												"package": "@lit-protocol/vincent-tool-sdk",
-												"refersToTypeParameter": true
-											},
-											{
-												"type": "reference",
-												"target": 21,
-												"name": "PrecheckAllowResult",
-												"package": "@lit-protocol/vincent-tool-sdk",
-												"refersToTypeParameter": true
-											},
-											{
-												"type": "reference",
-												"target": 22,
-												"name": "PrecheckDenyResult",
-												"package": "@lit-protocol/vincent-tool-sdk",
-												"refersToTypeParameter": true
-											},
-											{
-												"type": "reference",
-												"target": 23,
-												"name": "EvalAllowResult",
-												"package": "@lit-protocol/vincent-tool-sdk",
-												"refersToTypeParameter": true
-											},
-											{
-												"type": "reference",
-												"target": 24,
-												"name": "EvalDenyResult",
-												"package": "@lit-protocol/vincent-tool-sdk",
-												"refersToTypeParameter": true
-											},
-											{
-												"type": "reference",
-												"target": 25,
-												"name": "CommitParams",
-												"package": "@lit-protocol/vincent-tool-sdk",
-												"refersToTypeParameter": true
-											},
-											{
-												"type": "reference",
-												"target": 26,
-												"name": "CommitAllowResult",
-												"package": "@lit-protocol/vincent-tool-sdk",
-												"refersToTypeParameter": true
-											},
-											{
-												"type": "reference",
-												"target": 27,
-												"name": "CommitDenyResult",
-												"package": "@lit-protocol/vincent-tool-sdk",
-												"refersToTypeParameter": true
-											},
-											{
-												"type": "reference",
-												"target": {
-													"sourceFileName": "src/lib/types.ts",
-													"qualifiedName": "PolicyLifecycleFunction"
-												},
-												"typeArguments": [
-													{
+										"type": "reflection",
+										"declaration": {
+											"id": 52,
+											"name": "__type",
+											"variant": "declaration",
+											"kind": 65536,
+											"flags": {},
+											"children": [
+												{
+													"id": 53,
+													"name": "evalAllowResultSchema",
+													"variant": "declaration",
+													"kind": 1024,
+													"flags": {},
+													"sources": [
+														{
+															"fileName": "policyCore/vincentPolicy.ts",
+															"line": 399,
+															"character": 6,
+															"url": "https://github.com/LIT-Protocol/Vincent/blob/46a7999ef358981de990d808b7484f24731b23f9/packages/libs/tool-sdk/src/lib/policyCore/vincentPolicy.ts#L399"
+														}
+													],
+													"type": {
 														"type": "reference",
-														"target": 19,
-														"name": "PolicyToolParams",
-														"package": "@lit-protocol/vincent-tool-sdk",
-														"refersToTypeParameter": true
-													},
-													{
-														"type": "reference",
-														"target": 20,
-														"name": "UserParams",
-														"package": "@lit-protocol/vincent-tool-sdk",
-														"refersToTypeParameter": true
-													},
-													{
-														"type": "reference",
-														"target": 23,
+														"target": 37,
 														"name": "EvalAllowResult",
 														"package": "@lit-protocol/vincent-tool-sdk",
 														"refersToTypeParameter": true
-													},
-													{
+													}
+												},
+												{
+													"id": 54,
+													"name": "evalDenyResultSchema",
+													"variant": "declaration",
+													"kind": 1024,
+													"flags": {},
+													"sources": [
+														{
+															"fileName": "policyCore/vincentPolicy.ts",
+															"line": 400,
+															"character": 6,
+															"url": "https://github.com/LIT-Protocol/Vincent/blob/46a7999ef358981de990d808b7484f24731b23f9/packages/libs/tool-sdk/src/lib/policyCore/vincentPolicy.ts#L400"
+														}
+													],
+													"type": {
 														"type": "reference",
-														"target": 24,
+														"target": 38,
 														"name": "EvalDenyResult",
 														"package": "@lit-protocol/vincent-tool-sdk",
 														"refersToTypeParameter": true
 													}
-												],
-												"name": "PolicyLifecycleFunction",
-												"package": "@lit-protocol/vincent-tool-sdk"
-											},
-											{
-												"type": "reference",
-												"target": {
-													"sourceFileName": "src/lib/types.ts",
-													"qualifiedName": "PolicyLifecycleFunction"
 												},
-												"typeArguments": [
-													{
+												{
+													"id": 55,
+													"name": "precheckAllowResultSchema",
+													"variant": "declaration",
+													"kind": 1024,
+													"flags": {},
+													"sources": [
+														{
+															"fileName": "policyCore/vincentPolicy.ts",
+															"line": 401,
+															"character": 6,
+															"url": "https://github.com/LIT-Protocol/Vincent/blob/46a7999ef358981de990d808b7484f24731b23f9/packages/libs/tool-sdk/src/lib/policyCore/vincentPolicy.ts#L401"
+														}
+													],
+													"type": {
 														"type": "reference",
-														"target": 19,
-														"name": "PolicyToolParams",
-														"package": "@lit-protocol/vincent-tool-sdk",
-														"refersToTypeParameter": true
-													},
-													{
-														"type": "reference",
-														"target": 20,
-														"name": "UserParams",
-														"package": "@lit-protocol/vincent-tool-sdk",
-														"refersToTypeParameter": true
-													},
-													{
-														"type": "reference",
-														"target": 21,
+														"target": 35,
 														"name": "PrecheckAllowResult",
 														"package": "@lit-protocol/vincent-tool-sdk",
 														"refersToTypeParameter": true
-													},
-													{
+													}
+												},
+												{
+													"id": 56,
+													"name": "precheckDenyResultSchema",
+													"variant": "declaration",
+													"kind": 1024,
+													"flags": {},
+													"sources": [
+														{
+															"fileName": "policyCore/vincentPolicy.ts",
+															"line": 402,
+															"character": 6,
+															"url": "https://github.com/LIT-Protocol/Vincent/blob/46a7999ef358981de990d808b7484f24731b23f9/packages/libs/tool-sdk/src/lib/policyCore/vincentPolicy.ts#L402"
+														}
+													],
+													"type": {
 														"type": "reference",
-														"target": 22,
+														"target": 36,
 														"name": "PrecheckDenyResult",
 														"package": "@lit-protocol/vincent-tool-sdk",
 														"refersToTypeParameter": true
 													}
-												],
-												"name": "PolicyLifecycleFunction",
-												"package": "@lit-protocol/vincent-tool-sdk"
-											},
-											{
-												"type": "reference",
-												"target": {
-													"sourceFileName": "src/lib/types.ts",
-													"qualifiedName": "CommitLifecycleFunction"
 												},
-												"typeArguments": [
-													{
+												{
+													"id": 57,
+													"name": "commitParamsSchema",
+													"variant": "declaration",
+													"kind": 1024,
+													"flags": {},
+													"sources": [
+														{
+															"fileName": "policyCore/vincentPolicy.ts",
+															"line": 403,
+															"character": 6,
+															"url": "https://github.com/LIT-Protocol/Vincent/blob/46a7999ef358981de990d808b7484f24731b23f9/packages/libs/tool-sdk/src/lib/policyCore/vincentPolicy.ts#L403"
+														}
+													],
+													"type": {
 														"type": "reference",
-														"target": 25,
+														"target": 39,
 														"name": "CommitParams",
 														"package": "@lit-protocol/vincent-tool-sdk",
 														"refersToTypeParameter": true
-													},
-													{
+													}
+												},
+												{
+													"id": 58,
+													"name": "commitAllowResultSchema",
+													"variant": "declaration",
+													"kind": 1024,
+													"flags": {},
+													"sources": [
+														{
+															"fileName": "policyCore/vincentPolicy.ts",
+															"line": 404,
+															"character": 6,
+															"url": "https://github.com/LIT-Protocol/Vincent/blob/46a7999ef358981de990d808b7484f24731b23f9/packages/libs/tool-sdk/src/lib/policyCore/vincentPolicy.ts#L404"
+														}
+													],
+													"type": {
 														"type": "reference",
-														"target": 26,
+														"target": 40,
 														"name": "CommitAllowResult",
 														"package": "@lit-protocol/vincent-tool-sdk",
 														"refersToTypeParameter": true
-													},
-													{
+													}
+												},
+												{
+													"id": 59,
+													"name": "commitDenyResultSchema",
+													"variant": "declaration",
+													"kind": 1024,
+													"flags": {},
+													"sources": [
+														{
+															"fileName": "policyCore/vincentPolicy.ts",
+															"line": 405,
+															"character": 6,
+															"url": "https://github.com/LIT-Protocol/Vincent/blob/46a7999ef358981de990d808b7484f24731b23f9/packages/libs/tool-sdk/src/lib/policyCore/vincentPolicy.ts#L405"
+														}
+													],
+													"type": {
 														"type": "reference",
-														"target": 27,
+														"target": 41,
 														"name": "CommitDenyResult",
 														"package": "@lit-protocol/vincent-tool-sdk",
 														"refersToTypeParameter": true
 													}
-												],
-												"name": "CommitLifecycleFunction",
-												"package": "@lit-protocol/vincent-tool-sdk"
-											}
-										],
-										"name": "VincentPolicy",
-										"package": "@lit-protocol/vincent-tool-sdk"
+												},
+												{
+													"id": 60,
+													"name": "evaluate",
+													"variant": "declaration",
+													"kind": 1024,
+													"flags": {},
+													"sources": [
+														{
+															"fileName": "policyCore/vincentPolicy.ts",
+															"line": 407,
+															"character": 6,
+															"url": "https://github.com/LIT-Protocol/Vincent/blob/46a7999ef358981de990d808b7484f24731b23f9/packages/libs/tool-sdk/src/lib/policyCore/vincentPolicy.ts#L407"
+														}
+													],
+													"type": {
+														"type": "reference",
+														"target": {
+															"sourceFileName": "src/lib/types.ts",
+															"qualifiedName": "PolicyLifecycleFunction"
+														},
+														"typeArguments": [
+															{
+																"type": "reference",
+																"target": 33,
+																"name": "PolicyToolParams",
+																"package": "@lit-protocol/vincent-tool-sdk",
+																"refersToTypeParameter": true
+															},
+															{
+																"type": "reference",
+																"target": 34,
+																"name": "UserParams",
+																"package": "@lit-protocol/vincent-tool-sdk",
+																"refersToTypeParameter": true
+															},
+															{
+																"type": "reference",
+																"target": 37,
+																"name": "EvalAllowResult",
+																"package": "@lit-protocol/vincent-tool-sdk",
+																"refersToTypeParameter": true
+															},
+															{
+																"type": "reference",
+																"target": 38,
+																"name": "EvalDenyResult",
+																"package": "@lit-protocol/vincent-tool-sdk",
+																"refersToTypeParameter": true
+															}
+														],
+														"name": "PolicyLifecycleFunction",
+														"package": "@lit-protocol/vincent-tool-sdk"
+													}
+												},
+												{
+													"id": 61,
+													"name": "precheck",
+													"variant": "declaration",
+													"kind": 1024,
+													"flags": {},
+													"sources": [
+														{
+															"fileName": "policyCore/vincentPolicy.ts",
+															"line": 408,
+															"character": 6,
+															"url": "https://github.com/LIT-Protocol/Vincent/blob/46a7999ef358981de990d808b7484f24731b23f9/packages/libs/tool-sdk/src/lib/policyCore/vincentPolicy.ts#L408"
+														}
+													],
+													"type": {
+														"type": "union",
+														"types": [
+															{
+																"type": "intrinsic",
+																"name": "undefined"
+															},
+															{
+																"type": "reference",
+																"target": {
+																	"sourceFileName": "src/lib/types.ts",
+																	"qualifiedName": "PolicyLifecycleFunction"
+																},
+																"typeArguments": [
+																	{
+																		"type": "reference",
+																		"target": 33,
+																		"name": "PolicyToolParams",
+																		"package": "@lit-protocol/vincent-tool-sdk",
+																		"refersToTypeParameter": true
+																	},
+																	{
+																		"type": "reference",
+																		"target": 34,
+																		"name": "UserParams",
+																		"package": "@lit-protocol/vincent-tool-sdk",
+																		"refersToTypeParameter": true
+																	},
+																	{
+																		"type": "reference",
+																		"target": 35,
+																		"name": "PrecheckAllowResult",
+																		"package": "@lit-protocol/vincent-tool-sdk",
+																		"refersToTypeParameter": true
+																	},
+																	{
+																		"type": "reference",
+																		"target": 36,
+																		"name": "PrecheckDenyResult",
+																		"package": "@lit-protocol/vincent-tool-sdk",
+																		"refersToTypeParameter": true
+																	}
+																],
+																"name": "PolicyLifecycleFunction",
+																"package": "@lit-protocol/vincent-tool-sdk"
+															}
+														]
+													}
+												},
+												{
+													"id": 62,
+													"name": "commit",
+													"variant": "declaration",
+													"kind": 1024,
+													"flags": {},
+													"sources": [
+														{
+															"fileName": "policyCore/vincentPolicy.ts",
+															"line": 409,
+															"character": 6,
+															"url": "https://github.com/LIT-Protocol/Vincent/blob/46a7999ef358981de990d808b7484f24731b23f9/packages/libs/tool-sdk/src/lib/policyCore/vincentPolicy.ts#L409"
+														}
+													],
+													"type": {
+														"type": "union",
+														"types": [
+															{
+																"type": "intrinsic",
+																"name": "undefined"
+															},
+															{
+																"type": "reference",
+																"target": {
+																	"sourceFileName": "src/lib/types.ts",
+																	"qualifiedName": "CommitLifecycleFunction"
+																},
+																"typeArguments": [
+																	{
+																		"type": "reference",
+																		"target": 39,
+																		"name": "CommitParams",
+																		"package": "@lit-protocol/vincent-tool-sdk",
+																		"refersToTypeParameter": true
+																	},
+																	{
+																		"type": "reference",
+																		"target": 40,
+																		"name": "CommitAllowResult",
+																		"package": "@lit-protocol/vincent-tool-sdk",
+																		"refersToTypeParameter": true
+																	},
+																	{
+																		"type": "reference",
+																		"target": 41,
+																		"name": "CommitDenyResult",
+																		"package": "@lit-protocol/vincent-tool-sdk",
+																		"refersToTypeParameter": true
+																	}
+																],
+																"name": "CommitLifecycleFunction",
+																"package": "@lit-protocol/vincent-tool-sdk"
+															}
+														]
+													}
+												}
+											],
+											"groups": [
+												{
+													"title": "Properties",
+													"children": [
+														53,
+														54,
+														55,
+														56,
+														57,
+														58,
+														59,
+														60,
+														61,
+														62
+													]
+												}
+											],
+											"sources": [
+												{
+													"fileName": "policyCore/vincentPolicy.ts",
+													"line": 398,
+													"character": 19,
+													"url": "https://github.com/LIT-Protocol/Vincent/blob/46a7999ef358981de990d808b7484f24731b23f9/packages/libs/tool-sdk/src/lib/policyCore/vincentPolicy.ts#L398"
+												}
+											]
+										}
 									}
 								}
 							],
@@ -5795,19 +4247,19 @@
 								{
 									"title": "Properties",
 									"children": [
-										37,
-										35,
-										36,
-										34
+										48,
+										49,
+										50,
+										51
 									]
 								}
 							],
 							"sources": [
 								{
 									"fileName": "policyCore/vincentPolicy.ts",
-									"line": 369,
+									"line": 393,
 									"character": 19,
-									"url": "https://github.com/LIT-Protocol/Vincent/blob/8e21b5da26217bce6eb8963c7b9c9ea95c6a2290/packages/libs/tool-sdk/src/lib/policyCore/vincentPolicy.ts#L369"
+									"url": "https://github.com/LIT-Protocol/Vincent/blob/46a7999ef358981de990d808b7484f24731b23f9/packages/libs/tool-sdk/src/lib/policyCore/vincentPolicy.ts#L393"
 								}
 							]
 						}
@@ -5816,7 +4268,7 @@
 			]
 		},
 		{
-			"id": 97,
+			"id": 121,
 			"name": "supportedPoliciesForTool",
 			"variant": "declaration",
 			"kind": 64,
@@ -5824,14 +4276,14 @@
 			"sources": [
 				{
 					"fileName": "toolCore/helpers/supportedPoliciesForTool.ts",
-					"line": 18,
+					"line": 50,
 					"character": 16,
-					"url": "https://github.com/LIT-Protocol/Vincent/blob/8e21b5da26217bce6eb8963c7b9c9ea95c6a2290/packages/libs/tool-sdk/src/lib/toolCore/helpers/supportedPoliciesForTool.ts#L18"
+					"url": "https://github.com/LIT-Protocol/Vincent/blob/46a7999ef358981de990d808b7484f24731b23f9/packages/libs/tool-sdk/src/lib/toolCore/helpers/supportedPoliciesForTool.ts#L50"
 				}
 			],
 			"signatures": [
 				{
-					"id": 98,
+					"id": 122,
 					"name": "supportedPoliciesForTool",
 					"variant": "signature",
 					"kind": 4096,
@@ -5839,30 +4291,41 @@
 					"comment": {
 						"summary": [
 							{
+								"kind": "code",
+								"text": "`supportedPoliciesForTool()`"
+							},
+							{
 								"kind": "text",
-								"text": "Safely builds a strongly typed policy map from an array of VincentToolPolicy entries.\nEnforces literal string "
+								"text": " takes an array of bundled Vincent Policies, and provides strong type inference for those policies\ninside of your VincentTool's lifecycle functions and return values.\n\n"
 							},
 							{
 								"kind": "code",
-								"text": "`packageName`"
-							},
+								"text": "```typescript\nimport { bundledVincentPolicy } from '@lit-protocol/vincent-policy-spending-limit';\n\nconst SpendingLimitPolicy = createVincentToolPolicy({\n  toolParamsSchema,\n  bundledVincentPolicy,\n  toolParameterMappings: {\n    rpcUrlForUniswap: 'rpcUrlForUniswap',\n    chainIdForUniswap: 'chainIdForUniswap',\n    ethRpcUrl: 'ethRpcUrl',\n    tokenInAddress: 'tokenAddress',\n    tokenInDecimals: 'tokenDecimals',\n    tokenInAmount: 'buyAmount',\n  },\n});\n\n\nexport const vincentTool = createVincentTool({\n  packageName: '@lit-protocol/vincent-tool-uniswap-swap' as const,\n\n  toolParamsSchema,\n  supportedPolicies: supportedPoliciesForTool([SpendingLimitPolicy]),\n\n  ...\n\n  });\n```"
+							}
+						],
+						"blockTags": [
 							{
-								"kind": "text",
-								"text": " keys and exposes reverse lookup maps."
+								"tag": "@category",
+								"content": [
+									{
+										"kind": "text",
+										"text": "API Methods"
+									}
+								]
 							}
 						]
 					},
 					"sources": [
 						{
 							"fileName": "toolCore/helpers/supportedPoliciesForTool.ts",
-							"line": 18,
+							"line": 50,
 							"character": 16,
-							"url": "https://github.com/LIT-Protocol/Vincent/blob/8e21b5da26217bce6eb8963c7b9c9ea95c6a2290/packages/libs/tool-sdk/src/lib/toolCore/helpers/supportedPoliciesForTool.ts#L18"
+							"url": "https://github.com/LIT-Protocol/Vincent/blob/46a7999ef358981de990d808b7484f24731b23f9/packages/libs/tool-sdk/src/lib/toolCore/helpers/supportedPoliciesForTool.ts#L50"
 						}
 					],
 					"typeParameters": [
 						{
-							"id": 99,
+							"id": 123,
 							"name": "Policies",
 							"variant": "typeParam",
 							"kind": 131072,
@@ -5877,33 +4340,14 @@
 									"elementType": {
 										"type": "reflection",
 										"declaration": {
-											"id": 100,
+											"id": 124,
 											"name": "__type",
 											"variant": "declaration",
 											"kind": 65536,
 											"flags": {},
 											"children": [
 												{
-													"id": 104,
-													"name": "ipfsCid",
-													"variant": "declaration",
-													"kind": 1024,
-													"flags": {},
-													"sources": [
-														{
-															"fileName": "toolCore/helpers/supportedPoliciesForTool.ts",
-															"line": 21,
-															"character": 4,
-															"url": "https://github.com/LIT-Protocol/Vincent/blob/8e21b5da26217bce6eb8963c7b9c9ea95c6a2290/packages/libs/tool-sdk/src/lib/toolCore/helpers/supportedPoliciesForTool.ts#L21"
-														}
-													],
-													"type": {
-														"type": "intrinsic",
-														"name": "string"
-													}
-												},
-												{
-													"id": 101,
+													"id": 125,
 													"name": "vincentPolicy",
 													"variant": "declaration",
 													"kind": 1024,
@@ -5911,57 +4355,95 @@
 													"sources": [
 														{
 															"fileName": "toolCore/helpers/supportedPoliciesForTool.ts",
-															"line": 20,
+															"line": 52,
 															"character": 4,
-															"url": "https://github.com/LIT-Protocol/Vincent/blob/8e21b5da26217bce6eb8963c7b9c9ea95c6a2290/packages/libs/tool-sdk/src/lib/toolCore/helpers/supportedPoliciesForTool.ts#L20"
+															"url": "https://github.com/LIT-Protocol/Vincent/blob/46a7999ef358981de990d808b7484f24731b23f9/packages/libs/tool-sdk/src/lib/toolCore/helpers/supportedPoliciesForTool.ts#L52"
 														}
 													],
 													"type": {
-														"type": "reflection",
-														"declaration": {
-															"id": 102,
-															"name": "__type",
-															"variant": "declaration",
-															"kind": 65536,
-															"flags": {},
-															"children": [
-																{
-																	"id": 103,
-																	"name": "packageName",
-																	"variant": "declaration",
-																	"kind": 1024,
-																	"flags": {},
-																	"sources": [
-																		{
-																			"fileName": "toolCore/helpers/supportedPoliciesForTool.ts",
-																			"line": 20,
-																			"character": 21,
-																			"url": "https://github.com/LIT-Protocol/Vincent/blob/8e21b5da26217bce6eb8963c7b9c9ea95c6a2290/packages/libs/tool-sdk/src/lib/toolCore/helpers/supportedPoliciesForTool.ts#L20"
-																		}
-																	],
-																	"type": {
-																		"type": "intrinsic",
-																		"name": "string"
-																	}
-																}
-															],
-															"groups": [
-																{
-																	"title": "Properties",
-																	"children": [
-																		103
-																	]
-																}
-															],
-															"sources": [
-																{
-																	"fileName": "toolCore/helpers/supportedPoliciesForTool.ts",
-																	"line": 20,
-																	"character": 19,
-																	"url": "https://github.com/LIT-Protocol/Vincent/blob/8e21b5da26217bce6eb8963c7b9c9ea95c6a2290/packages/libs/tool-sdk/src/lib/toolCore/helpers/supportedPoliciesForTool.ts#L20"
-																}
-															]
+														"type": "reference",
+														"target": {
+															"sourceFileName": "src/lib/types.ts",
+															"qualifiedName": "VincentPolicy"
+														},
+														"typeArguments": [
+															{
+																"type": "intrinsic",
+																"name": "any"
+															},
+															{
+																"type": "intrinsic",
+																"name": "any"
+															},
+															{
+																"type": "intrinsic",
+																"name": "any"
+															},
+															{
+																"type": "intrinsic",
+																"name": "any"
+															},
+															{
+																"type": "intrinsic",
+																"name": "any"
+															},
+															{
+																"type": "intrinsic",
+																"name": "any"
+															},
+															{
+																"type": "intrinsic",
+																"name": "any"
+															},
+															{
+																"type": "intrinsic",
+																"name": "any"
+															},
+															{
+																"type": "intrinsic",
+																"name": "any"
+															},
+															{
+																"type": "intrinsic",
+																"name": "any"
+															},
+															{
+																"type": "intrinsic",
+																"name": "any"
+															},
+															{
+																"type": "intrinsic",
+																"name": "any"
+															},
+															{
+																"type": "intrinsic",
+																"name": "any"
+															}
+														],
+														"name": "VincentPolicy",
+														"package": "@lit-protocol/vincent-tool-sdk"
+													}
+												},
+												{
+													"id": 126,
+													"name": "ipfsCid",
+													"variant": "declaration",
+													"kind": 1024,
+													"flags": {},
+													"sources": [
+														{
+															"fileName": "toolCore/helpers/supportedPoliciesForTool.ts",
+															"line": 53,
+															"character": 4,
+															"url": "https://github.com/LIT-Protocol/Vincent/blob/46a7999ef358981de990d808b7484f24731b23f9/packages/libs/tool-sdk/src/lib/toolCore/helpers/supportedPoliciesForTool.ts#L53"
 														}
+													],
+													"type": {
+														"type": "reference",
+														"target": 127,
+														"name": "IpfsCid",
+														"package": "@lit-protocol/vincent-tool-sdk",
+														"refersToTypeParameter": true
 													}
 												}
 											],
@@ -5969,17 +4451,17 @@
 												{
 													"title": "Properties",
 													"children": [
-														104,
-														101
+														125,
+														126
 													]
 												}
 											],
 											"sources": [
 												{
 													"fileName": "toolCore/helpers/supportedPoliciesForTool.ts",
-													"line": 19,
+													"line": 51,
 													"character": 34,
-													"url": "https://github.com/LIT-Protocol/Vincent/blob/8e21b5da26217bce6eb8963c7b9c9ea95c6a2290/packages/libs/tool-sdk/src/lib/toolCore/helpers/supportedPoliciesForTool.ts#L19"
+													"url": "https://github.com/LIT-Protocol/Vincent/blob/46a7999ef358981de990d808b7484f24731b23f9/packages/libs/tool-sdk/src/lib/toolCore/helpers/supportedPoliciesForTool.ts#L51"
 												}
 											]
 										}
@@ -5988,8 +4470,8 @@
 							}
 						},
 						{
-							"id": 105,
-							"name": "PkgNames",
+							"id": 127,
+							"name": "IpfsCid",
 							"variant": "typeParam",
 							"kind": 131072,
 							"flags": {
@@ -5998,6 +4480,23 @@
 							"type": {
 								"type": "intrinsic",
 								"name": "string"
+							},
+							"default": {
+								"type": "intrinsic",
+								"name": "string"
+							}
+						},
+						{
+							"id": 128,
+							"name": "PkgNames",
+							"variant": "typeParam",
+							"kind": 131072,
+							"flags": {
+								"isConst": true
+							},
+							"type": {
+								"type": "intrinsic",
+								"name": "any"
 							},
 							"default": {
 								"type": "indexedAccess",
@@ -6019,7 +4518,7 @@
 										},
 										"objectType": {
 											"type": "reference",
-											"target": 99,
+											"target": 123,
 											"name": "Policies",
 											"package": "@lit-protocol/vincent-tool-sdk",
 											"refersToTypeParameter": true
@@ -6031,14 +4530,14 @@
 					],
 					"parameters": [
 						{
-							"id": 106,
+							"id": 129,
 							"name": "policies",
 							"variant": "param",
 							"kind": 32768,
 							"flags": {},
 							"type": {
 								"type": "reference",
-								"target": 99,
+								"target": 123,
 								"name": "Policies",
 								"package": "@lit-protocol/vincent-tool-sdk",
 								"refersToTypeParameter": true
@@ -6054,14 +4553,14 @@
 						"typeArguments": [
 							{
 								"type": "reference",
-								"target": 99,
+								"target": 123,
 								"name": "Policies",
 								"package": "@lit-protocol/vincent-tool-sdk",
 								"refersToTypeParameter": true
 							},
 							{
 								"type": "reference",
-								"target": 105,
+								"target": 128,
 								"name": "PkgNames",
 								"package": "@lit-protocol/vincent-tool-sdk",
 								"refersToTypeParameter": true
@@ -6074,436 +4573,406 @@
 			]
 		},
 		{
-			"id": 60,
-			"name": "vincentPolicyHandler",
+			"id": 294,
+			"name": "BaseToolContext",
 			"variant": "declaration",
-			"kind": 64,
+			"kind": 256,
 			"flags": {},
-			"sources": [
+			"comment": {
+				"summary": [
+					{
+						"kind": "text",
+						"text": "BaseToolContext is returned with tool execution results, and contains information about the app, delegation, and\npolicy evaluation results for any policies that the user had enabled for the tool."
+					}
+				],
+				"blockTags": [
+					{
+						"tag": "@category",
+						"content": [
+							{
+								"kind": "text",
+								"text": "Interfaces"
+							}
+						]
+					}
+				]
+			},
+			"children": [
 				{
-					"fileName": "handlers/vincentPolicyHandler.ts",
-					"line": 32,
-					"character": 22,
-					"url": "https://github.com/LIT-Protocol/Vincent/blob/8e21b5da26217bce6eb8963c7b9c9ea95c6a2290/packages/libs/tool-sdk/src/lib/handlers/vincentPolicyHandler.ts#L32"
-				}
-			],
-			"signatures": [
-				{
-					"id": 61,
-					"name": "vincentPolicyHandler",
-					"variant": "signature",
-					"kind": 4096,
+					"id": 295,
+					"name": "policiesContext",
+					"variant": "declaration",
+					"kind": 1024,
 					"flags": {},
 					"sources": [
 						{
-							"fileName": "handlers/vincentPolicyHandler.ts",
-							"line": 32,
-							"character": 22,
-							"url": "https://github.com/LIT-Protocol/Vincent/blob/8e21b5da26217bce6eb8963c7b9c9ea95c6a2290/packages/libs/tool-sdk/src/lib/handlers/vincentPolicyHandler.ts#L32"
-						}
-					],
-					"typeParameters": [
-						{
-							"id": 62,
-							"name": "PackageName",
-							"variant": "typeParam",
-							"kind": 131072,
-							"flags": {},
-							"type": {
-								"type": "intrinsic",
-								"name": "string"
-							}
-						},
-						{
-							"id": 63,
-							"name": "PolicyToolParams",
-							"variant": "typeParam",
-							"kind": 131072,
-							"flags": {},
-							"type": {
-								"type": "reference",
-								"target": {
-									"sourceFileName": "../../../node_modules/.pnpm/zod@3.25.64/node_modules/zod/dist/types/v3/types.d.ts",
-									"qualifiedName": "ZodType"
-								},
-								"typeArguments": [
-									{
-										"type": "intrinsic",
-										"name": "any"
-									},
-									{
-										"type": "reference",
-										"target": {
-											"sourceFileName": "../../../node_modules/.pnpm/zod@3.25.64/node_modules/zod/dist/types/v3/types.d.ts",
-											"qualifiedName": "ZodTypeDef"
-										},
-										"name": "ZodTypeDef",
-										"package": "zod"
-									},
-									{
-										"type": "intrinsic",
-										"name": "any"
-									}
-								],
-								"name": "ZodType",
-								"package": "zod"
-							}
-						},
-						{
-							"id": 64,
-							"name": "UserParams",
-							"variant": "typeParam",
-							"kind": 131072,
-							"flags": {},
-							"type": {
-								"type": "union",
-								"types": [
-									{
-										"type": "intrinsic",
-										"name": "undefined"
-									},
-									{
-										"type": "reference",
-										"target": {
-											"sourceFileName": "../../../node_modules/.pnpm/zod@3.25.64/node_modules/zod/dist/types/v3/types.d.ts",
-											"qualifiedName": "ZodType"
-										},
-										"typeArguments": [
-											{
-												"type": "intrinsic",
-												"name": "any"
-											},
-											{
-												"type": "reference",
-												"target": {
-													"sourceFileName": "../../../node_modules/.pnpm/zod@3.25.64/node_modules/zod/dist/types/v3/types.d.ts",
-													"qualifiedName": "ZodTypeDef"
-												},
-												"name": "ZodTypeDef",
-												"package": "zod"
-											},
-											{
-												"type": "intrinsic",
-												"name": "any"
-											}
-										],
-										"name": "ZodType",
-										"package": "zod"
-									}
-								]
-							},
-							"default": {
-								"type": "intrinsic",
-								"name": "undefined"
-							}
-						},
-						{
-							"id": 65,
-							"name": "EvalAllowResult",
-							"variant": "typeParam",
-							"kind": 131072,
-							"flags": {},
-							"type": {
-								"type": "union",
-								"types": [
-									{
-										"type": "intrinsic",
-										"name": "undefined"
-									},
-									{
-										"type": "reference",
-										"target": {
-											"sourceFileName": "../../../node_modules/.pnpm/zod@3.25.64/node_modules/zod/dist/types/v3/types.d.ts",
-											"qualifiedName": "ZodType"
-										},
-										"typeArguments": [
-											{
-												"type": "intrinsic",
-												"name": "any"
-											},
-											{
-												"type": "reference",
-												"target": {
-													"sourceFileName": "../../../node_modules/.pnpm/zod@3.25.64/node_modules/zod/dist/types/v3/types.d.ts",
-													"qualifiedName": "ZodTypeDef"
-												},
-												"name": "ZodTypeDef",
-												"package": "zod"
-											},
-											{
-												"type": "intrinsic",
-												"name": "any"
-											}
-										],
-										"name": "ZodType",
-										"package": "zod"
-									}
-								]
-							},
-							"default": {
-								"type": "intrinsic",
-								"name": "undefined"
-							}
-						},
-						{
-							"id": 66,
-							"name": "EvalDenyResult",
-							"variant": "typeParam",
-							"kind": 131072,
-							"flags": {},
-							"type": {
-								"type": "union",
-								"types": [
-									{
-										"type": "intrinsic",
-										"name": "undefined"
-									},
-									{
-										"type": "reference",
-										"target": {
-											"sourceFileName": "../../../node_modules/.pnpm/zod@3.25.64/node_modules/zod/dist/types/v3/types.d.ts",
-											"qualifiedName": "ZodType"
-										},
-										"typeArguments": [
-											{
-												"type": "intrinsic",
-												"name": "any"
-											},
-											{
-												"type": "reference",
-												"target": {
-													"sourceFileName": "../../../node_modules/.pnpm/zod@3.25.64/node_modules/zod/dist/types/v3/types.d.ts",
-													"qualifiedName": "ZodTypeDef"
-												},
-												"name": "ZodTypeDef",
-												"package": "zod"
-											},
-											{
-												"type": "intrinsic",
-												"name": "any"
-											}
-										],
-										"name": "ZodType",
-										"package": "zod"
-									}
-								]
-							},
-							"default": {
-								"type": "intrinsic",
-								"name": "undefined"
-							}
-						}
-					],
-					"parameters": [
-						{
-							"id": 67,
-							"name": "__namedParameters",
-							"variant": "param",
-							"kind": 32768,
-							"flags": {},
-							"type": {
-								"type": "reflection",
-								"declaration": {
-									"id": 68,
-									"name": "__type",
-									"variant": "declaration",
-									"kind": 65536,
-									"flags": {},
-									"children": [
-										{
-											"id": 71,
-											"name": "context",
-											"variant": "declaration",
-											"kind": 1024,
-											"flags": {},
-											"sources": [
-												{
-													"fileName": "handlers/vincentPolicyHandler.ts",
-													"line": 56,
-													"character": 2,
-													"url": "https://github.com/LIT-Protocol/Vincent/blob/8e21b5da26217bce6eb8963c7b9c9ea95c6a2290/packages/libs/tool-sdk/src/lib/handlers/vincentPolicyHandler.ts#L56"
-												}
-											],
-											"type": {
-												"type": "reference",
-												"target": -1,
-												"name": "PolicyConsumerContext",
-												"package": "@lit-protocol/vincent-tool-sdk"
-											}
-										},
-										{
-											"id": 70,
-											"name": "toolParams",
-											"variant": "declaration",
-											"kind": 1024,
-											"flags": {},
-											"sources": [
-												{
-													"fileName": "handlers/vincentPolicyHandler.ts",
-													"line": 55,
-													"character": 2,
-													"url": "https://github.com/LIT-Protocol/Vincent/blob/8e21b5da26217bce6eb8963c7b9c9ea95c6a2290/packages/libs/tool-sdk/src/lib/handlers/vincentPolicyHandler.ts#L55"
-												}
-											],
-											"type": {
-												"type": "intrinsic",
-												"name": "unknown"
-											}
-										},
-										{
-											"id": 69,
-											"name": "vincentPolicy",
-											"variant": "declaration",
-											"kind": 1024,
-											"flags": {},
-											"sources": [
-												{
-													"fileName": "handlers/vincentPolicyHandler.ts",
-													"line": 43,
-													"character": 2,
-													"url": "https://github.com/LIT-Protocol/Vincent/blob/8e21b5da26217bce6eb8963c7b9c9ea95c6a2290/packages/libs/tool-sdk/src/lib/handlers/vincentPolicyHandler.ts#L43"
-												}
-											],
-											"type": {
-												"type": "reference",
-												"target": {
-													"sourceFileName": "src/lib/types.ts",
-													"qualifiedName": "VincentPolicy"
-												},
-												"typeArguments": [
-													{
-														"type": "reference",
-														"target": 62,
-														"name": "PackageName",
-														"package": "@lit-protocol/vincent-tool-sdk",
-														"refersToTypeParameter": true
-													},
-													{
-														"type": "reference",
-														"target": 63,
-														"name": "PolicyToolParams",
-														"package": "@lit-protocol/vincent-tool-sdk",
-														"refersToTypeParameter": true
-													},
-													{
-														"type": "reference",
-														"target": 64,
-														"name": "UserParams",
-														"package": "@lit-protocol/vincent-tool-sdk",
-														"refersToTypeParameter": true
-													},
-													{
-														"type": "intrinsic",
-														"name": "any"
-													},
-													{
-														"type": "intrinsic",
-														"name": "any"
-													},
-													{
-														"type": "reference",
-														"target": 65,
-														"name": "EvalAllowResult",
-														"package": "@lit-protocol/vincent-tool-sdk",
-														"refersToTypeParameter": true
-													},
-													{
-														"type": "reference",
-														"target": 66,
-														"name": "EvalDenyResult",
-														"package": "@lit-protocol/vincent-tool-sdk",
-														"refersToTypeParameter": true
-													},
-													{
-														"type": "intrinsic",
-														"name": "any"
-													},
-													{
-														"type": "intrinsic",
-														"name": "any"
-													},
-													{
-														"type": "intrinsic",
-														"name": "any"
-													}
-												],
-												"name": "VincentPolicy",
-												"package": "@lit-protocol/vincent-tool-sdk"
-											}
-										}
-									],
-									"groups": [
-										{
-											"title": "Properties",
-											"children": [
-												71,
-												70,
-												69
-											]
-										}
-									],
-									"sources": [
-										{
-											"fileName": "handlers/vincentPolicyHandler.ts",
-											"line": 42,
-											"character": 3,
-											"url": "https://github.com/LIT-Protocol/Vincent/blob/8e21b5da26217bce6eb8963c7b9c9ea95c6a2290/packages/libs/tool-sdk/src/lib/handlers/vincentPolicyHandler.ts#L42"
-										}
-									]
-								}
-							}
+							"fileName": "toolCore/toolDef/context/types.ts",
+							"line": 18,
+							"character": 2,
+							"url": "https://github.com/LIT-Protocol/Vincent/blob/46a7999ef358981de990d808b7484f24731b23f9/packages/libs/tool-sdk/src/lib/toolCore/toolDef/context/types.ts#L18"
 						}
 					],
 					"type": {
 						"type": "reference",
-						"target": {
-							"sourceFileName": "../../../node_modules/.pnpm/typescript@5.8.3/node_modules/typescript/lib/lib.es5.d.ts",
-							"qualifiedName": "Promise"
-						},
-						"typeArguments": [
-							{
-								"type": "intrinsic",
-								"name": "void"
-							}
-						],
-						"name": "Promise",
-						"package": "typescript"
+						"target": 307,
+						"name": "Policies",
+						"package": "@lit-protocol/vincent-tool-sdk",
+						"qualifiedName": "BaseToolContext.Policies",
+						"refersToTypeParameter": true
 					}
+				},
+				{
+					"id": 296,
+					"name": "toolIpfsCid",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isInherited": true
+					},
+					"sources": [
+						{
+							"fileName": "types.ts",
+							"line": 413,
+							"character": 2,
+							"url": "https://github.com/LIT-Protocol/Vincent/blob/46a7999ef358981de990d808b7484f24731b23f9/packages/libs/tool-sdk/src/lib/types.ts#L413"
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "string"
+					},
+					"inheritedFrom": {
+						"type": "reference",
+						"target": -1,
+						"name": "BaseContext.toolIpfsCid"
+					}
+				},
+				{
+					"id": 297,
+					"name": "appId",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isInherited": true
+					},
+					"sources": [
+						{
+							"fileName": "types.ts",
+							"line": 414,
+							"character": 2,
+							"url": "https://github.com/LIT-Protocol/Vincent/blob/46a7999ef358981de990d808b7484f24731b23f9/packages/libs/tool-sdk/src/lib/types.ts#L414"
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "number"
+					},
+					"inheritedFrom": {
+						"type": "reference",
+						"target": -1,
+						"name": "BaseContext.appId"
+					}
+				},
+				{
+					"id": 298,
+					"name": "appVersion",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isInherited": true
+					},
+					"sources": [
+						{
+							"fileName": "types.ts",
+							"line": 415,
+							"character": 2,
+							"url": "https://github.com/LIT-Protocol/Vincent/blob/46a7999ef358981de990d808b7484f24731b23f9/packages/libs/tool-sdk/src/lib/types.ts#L415"
+						}
+					],
+					"type": {
+						"type": "intrinsic",
+						"name": "number"
+					},
+					"inheritedFrom": {
+						"type": "reference",
+						"target": -1,
+						"name": "BaseContext.appVersion"
+					}
+				},
+				{
+					"id": 299,
+					"name": "delegation",
+					"variant": "declaration",
+					"kind": 1024,
+					"flags": {
+						"isInherited": true
+					},
+					"sources": [
+						{
+							"fileName": "types.ts",
+							"line": 416,
+							"character": 2,
+							"url": "https://github.com/LIT-Protocol/Vincent/blob/46a7999ef358981de990d808b7484f24731b23f9/packages/libs/tool-sdk/src/lib/types.ts#L416"
+						}
+					],
+					"type": {
+						"type": "reflection",
+						"declaration": {
+							"id": 300,
+							"name": "__type",
+							"variant": "declaration",
+							"kind": 65536,
+							"flags": {},
+							"children": [
+								{
+									"id": 301,
+									"name": "delegateeAddress",
+									"variant": "declaration",
+									"kind": 1024,
+									"flags": {},
+									"sources": [
+										{
+											"fileName": "types.ts",
+											"line": 417,
+											"character": 4,
+											"url": "https://github.com/LIT-Protocol/Vincent/blob/46a7999ef358981de990d808b7484f24731b23f9/packages/libs/tool-sdk/src/lib/types.ts#L417"
+										}
+									],
+									"type": {
+										"type": "intrinsic",
+										"name": "string"
+									}
+								},
+								{
+									"id": 302,
+									"name": "delegatorPkpInfo",
+									"variant": "declaration",
+									"kind": 1024,
+									"flags": {},
+									"sources": [
+										{
+											"fileName": "types.ts",
+											"line": 418,
+											"character": 4,
+											"url": "https://github.com/LIT-Protocol/Vincent/blob/46a7999ef358981de990d808b7484f24731b23f9/packages/libs/tool-sdk/src/lib/types.ts#L418"
+										}
+									],
+									"type": {
+										"type": "reflection",
+										"declaration": {
+											"id": 303,
+											"name": "__type",
+											"variant": "declaration",
+											"kind": 65536,
+											"flags": {},
+											"children": [
+												{
+													"id": 304,
+													"name": "tokenId",
+													"variant": "declaration",
+													"kind": 1024,
+													"flags": {},
+													"sources": [
+														{
+															"fileName": "types.ts",
+															"line": 419,
+															"character": 6,
+															"url": "https://github.com/LIT-Protocol/Vincent/blob/46a7999ef358981de990d808b7484f24731b23f9/packages/libs/tool-sdk/src/lib/types.ts#L419"
+														}
+													],
+													"type": {
+														"type": "intrinsic",
+														"name": "string"
+													}
+												},
+												{
+													"id": 305,
+													"name": "ethAddress",
+													"variant": "declaration",
+													"kind": 1024,
+													"flags": {},
+													"sources": [
+														{
+															"fileName": "types.ts",
+															"line": 420,
+															"character": 6,
+															"url": "https://github.com/LIT-Protocol/Vincent/blob/46a7999ef358981de990d808b7484f24731b23f9/packages/libs/tool-sdk/src/lib/types.ts#L420"
+														}
+													],
+													"type": {
+														"type": "intrinsic",
+														"name": "string"
+													}
+												},
+												{
+													"id": 306,
+													"name": "publicKey",
+													"variant": "declaration",
+													"kind": 1024,
+													"flags": {},
+													"sources": [
+														{
+															"fileName": "types.ts",
+															"line": 421,
+															"character": 6,
+															"url": "https://github.com/LIT-Protocol/Vincent/blob/46a7999ef358981de990d808b7484f24731b23f9/packages/libs/tool-sdk/src/lib/types.ts#L421"
+														}
+													],
+													"type": {
+														"type": "intrinsic",
+														"name": "string"
+													}
+												}
+											],
+											"groups": [
+												{
+													"title": "Properties",
+													"children": [
+														304,
+														305,
+														306
+													]
+												}
+											],
+											"sources": [
+												{
+													"fileName": "types.ts",
+													"line": 418,
+													"character": 22,
+													"url": "https://github.com/LIT-Protocol/Vincent/blob/46a7999ef358981de990d808b7484f24731b23f9/packages/libs/tool-sdk/src/lib/types.ts#L418"
+												}
+											]
+										}
+									}
+								}
+							],
+							"groups": [
+								{
+									"title": "Properties",
+									"children": [
+										301,
+										302
+									]
+								}
+							],
+							"sources": [
+								{
+									"fileName": "types.ts",
+									"line": 416,
+									"character": 14,
+									"url": "https://github.com/LIT-Protocol/Vincent/blob/46a7999ef358981de990d808b7484f24731b23f9/packages/libs/tool-sdk/src/lib/types.ts#L416"
+								}
+							]
+						}
+					},
+					"inheritedFrom": {
+						"type": "reference",
+						"target": -1,
+						"name": "BaseContext.delegation"
+					}
+				}
+			],
+			"groups": [
+				{
+					"title": "Properties",
+					"children": [
+						295,
+						296,
+						297,
+						298,
+						299
+					]
+				}
+			],
+			"sources": [
+				{
+					"fileName": "toolCore/toolDef/context/types.ts",
+					"line": 17,
+					"character": 17,
+					"url": "https://github.com/LIT-Protocol/Vincent/blob/46a7999ef358981de990d808b7484f24731b23f9/packages/libs/tool-sdk/src/lib/toolCore/toolDef/context/types.ts#L17"
+				}
+			],
+			"typeParameters": [
+				{
+					"id": 307,
+					"name": "Policies",
+					"variant": "typeParam",
+					"kind": 131072,
+					"flags": {}
+				}
+			],
+			"extendedTypes": [
+				{
+					"type": "reference",
+					"target": -1,
+					"name": "BaseContext",
+					"package": "@lit-protocol/vincent-tool-sdk"
 				}
 			]
 		},
 		{
-			"id": 72,
-			"name": "vincentToolHandler",
+			"id": 63,
+			"name": "createVincentTool",
 			"variant": "declaration",
 			"kind": 64,
 			"flags": {},
 			"sources": [
 				{
-					"fileName": "handlers/vincentToolHandler.ts",
-					"line": 104,
-					"character": 13,
-					"url": "https://github.com/LIT-Protocol/Vincent/blob/8e21b5da26217bce6eb8963c7b9c9ea95c6a2290/packages/libs/tool-sdk/src/lib/handlers/vincentToolHandler.ts#L104"
+					"fileName": "toolCore/vincentTool.ts",
+					"line": 61,
+					"character": 16,
+					"url": "https://github.com/LIT-Protocol/Vincent/blob/46a7999ef358981de990d808b7484f24731b23f9/packages/libs/tool-sdk/src/lib/toolCore/vincentTool.ts#L61"
 				}
 			],
 			"signatures": [
 				{
-					"id": 73,
-					"name": "vincentToolHandler",
+					"id": 64,
+					"name": "createVincentTool",
 					"variant": "signature",
 					"kind": 4096,
 					"flags": {},
+					"comment": {
+						"summary": [
+							{
+								"kind": "text",
+								"text": "The "
+							},
+							{
+								"kind": "code",
+								"text": "`createVincentTool()`"
+							},
+							{
+								"kind": "text",
+								"text": " method is used to define a tool's lifecycle methods and ensure that arguments provided to the tool's\nlifecycle methods, as well as their return values, are validated and fully type-safe by defining ZOD schemas for them.\n\n"
+							},
+							{
+								"kind": "code",
+								"text": "```typescript\nconst exampleSimpleTool = createVincentTool({\n    packageName: '@lit-protocol/yestool@1.0.0',\n    toolParamsSchema: testSchema,\n    supportedPolicies: supportedPoliciesForTool([testPolicy]),\n\n    precheck: async (params, { succeed, fail }) => {\n      // Should allow succeed() with no arguments\n      succeed();\n\n      // Should allow fail() with string error\n      fail('Error message');\n\n      // @ts-expect-error - Should not allow succeed() with arguments when no schema\n      succeed({ message: 'test' });\n\n      // @ts-expect-error - Should not allow fail() with object when no schema\n      fail({ error: 'test' });\n\n      return succeed();\n    },\n\n    execute: async (params, { succeed }) => {\n      // Should allow succeed() with no arguments\n      succeed();\n\n      // @ts-expect-error - Should not allow succeed() with arguments when no schema\n      return succeed({ data: 'test' });\n    },\n  });\n```"
+							}
+						],
+						"blockTags": [
+							{
+								"tag": "@category",
+								"content": [
+									{
+										"kind": "text",
+										"text": "API Methods"
+									}
+								]
+							}
+						]
+					},
 					"sources": [
 						{
-							"fileName": "handlers/vincentToolHandler.ts",
-							"line": 104,
-							"character": 34,
-							"url": "https://github.com/LIT-Protocol/Vincent/blob/8e21b5da26217bce6eb8963c7b9c9ea95c6a2290/packages/libs/tool-sdk/src/lib/handlers/vincentToolHandler.ts#L104"
+							"fileName": "toolCore/vincentTool.ts",
+							"line": 61,
+							"character": 16,
+							"url": "https://github.com/LIT-Protocol/Vincent/blob/46a7999ef358981de990d808b7484f24731b23f9/packages/libs/tool-sdk/src/lib/toolCore/vincentTool.ts#L61"
 						}
 					],
 					"typeParameters": [
 						{
-							"id": 74,
+							"id": 65,
 							"name": "ToolParamsSchema",
 							"variant": "typeParam",
 							"kind": 131072,
@@ -6538,22 +5007,26 @@
 							}
 						},
 						{
-							"id": 75,
+							"id": 66,
 							"name": "PkgNames",
 							"variant": "typeParam",
 							"kind": 131072,
-							"flags": {},
+							"flags": {
+								"isConst": true
+							},
 							"type": {
 								"type": "intrinsic",
 								"name": "string"
 							}
 						},
 						{
-							"id": 76,
+							"id": 67,
 							"name": "PolicyMap",
 							"variant": "typeParam",
 							"kind": 131072,
-							"flags": {},
+							"flags": {
+								"isConst": true
+							},
 							"type": {
 								"type": "reference",
 								"target": {
@@ -6567,7 +5040,7 @@
 									},
 									{
 										"type": "reference",
-										"target": 75,
+										"target": 66,
 										"name": "PkgNames",
 										"package": "@lit-protocol/vincent-tool-sdk",
 										"refersToTypeParameter": true
@@ -6578,8 +5051,8 @@
 							}
 						},
 						{
-							"id": 77,
-							"name": "PoliciesByPackageName",
+							"id": 68,
+							"name": "PolicyMapByPackageName",
 							"variant": "typeParam",
 							"kind": 131072,
 							"flags": {},
@@ -6595,143 +5068,444 @@
 									"name": "any"
 								}
 							}
+						},
+						{
+							"id": 69,
+							"name": "PrecheckSuccessSchema",
+							"variant": "typeParam",
+							"kind": 131072,
+							"flags": {},
+							"type": {
+								"type": "reference",
+								"target": {
+									"sourceFileName": "../../../node_modules/.pnpm/zod@3.25.64/node_modules/zod/dist/types/v3/types.d.ts",
+									"qualifiedName": "ZodType"
+								},
+								"typeArguments": [
+									{
+										"type": "intrinsic",
+										"name": "any"
+									},
+									{
+										"type": "reference",
+										"target": {
+											"sourceFileName": "../../../node_modules/.pnpm/zod@3.25.64/node_modules/zod/dist/types/v3/types.d.ts",
+											"qualifiedName": "ZodTypeDef"
+										},
+										"name": "ZodTypeDef",
+										"package": "zod"
+									},
+									{
+										"type": "intrinsic",
+										"name": "any"
+									}
+								],
+								"name": "ZodType",
+								"package": "zod"
+							},
+							"default": {
+								"type": "reference",
+								"target": {
+									"sourceFileName": "../../../node_modules/.pnpm/zod@3.25.64/node_modules/zod/dist/types/v3/types.d.ts",
+									"qualifiedName": "ZodUndefined"
+								},
+								"name": "ZodUndefined",
+								"package": "zod"
+							}
+						},
+						{
+							"id": 70,
+							"name": "PrecheckFailSchema",
+							"variant": "typeParam",
+							"kind": 131072,
+							"flags": {},
+							"type": {
+								"type": "reference",
+								"target": {
+									"sourceFileName": "../../../node_modules/.pnpm/zod@3.25.64/node_modules/zod/dist/types/v3/types.d.ts",
+									"qualifiedName": "ZodType"
+								},
+								"typeArguments": [
+									{
+										"type": "intrinsic",
+										"name": "any"
+									},
+									{
+										"type": "reference",
+										"target": {
+											"sourceFileName": "../../../node_modules/.pnpm/zod@3.25.64/node_modules/zod/dist/types/v3/types.d.ts",
+											"qualifiedName": "ZodTypeDef"
+										},
+										"name": "ZodTypeDef",
+										"package": "zod"
+									},
+									{
+										"type": "intrinsic",
+										"name": "any"
+									}
+								],
+								"name": "ZodType",
+								"package": "zod"
+							},
+							"default": {
+								"type": "reference",
+								"target": {
+									"sourceFileName": "../../../node_modules/.pnpm/zod@3.25.64/node_modules/zod/dist/types/v3/types.d.ts",
+									"qualifiedName": "ZodUndefined"
+								},
+								"name": "ZodUndefined",
+								"package": "zod"
+							}
+						},
+						{
+							"id": 71,
+							"name": "ExecuteSuccessSchema",
+							"variant": "typeParam",
+							"kind": 131072,
+							"flags": {},
+							"type": {
+								"type": "reference",
+								"target": {
+									"sourceFileName": "../../../node_modules/.pnpm/zod@3.25.64/node_modules/zod/dist/types/v3/types.d.ts",
+									"qualifiedName": "ZodType"
+								},
+								"typeArguments": [
+									{
+										"type": "intrinsic",
+										"name": "any"
+									},
+									{
+										"type": "reference",
+										"target": {
+											"sourceFileName": "../../../node_modules/.pnpm/zod@3.25.64/node_modules/zod/dist/types/v3/types.d.ts",
+											"qualifiedName": "ZodTypeDef"
+										},
+										"name": "ZodTypeDef",
+										"package": "zod"
+									},
+									{
+										"type": "intrinsic",
+										"name": "any"
+									}
+								],
+								"name": "ZodType",
+								"package": "zod"
+							},
+							"default": {
+								"type": "reference",
+								"target": {
+									"sourceFileName": "../../../node_modules/.pnpm/zod@3.25.64/node_modules/zod/dist/types/v3/types.d.ts",
+									"qualifiedName": "ZodUndefined"
+								},
+								"name": "ZodUndefined",
+								"package": "zod"
+							}
+						},
+						{
+							"id": 72,
+							"name": "ExecuteFailSchema",
+							"variant": "typeParam",
+							"kind": 131072,
+							"flags": {},
+							"type": {
+								"type": "reference",
+								"target": {
+									"sourceFileName": "../../../node_modules/.pnpm/zod@3.25.64/node_modules/zod/dist/types/v3/types.d.ts",
+									"qualifiedName": "ZodType"
+								},
+								"typeArguments": [
+									{
+										"type": "intrinsic",
+										"name": "any"
+									},
+									{
+										"type": "reference",
+										"target": {
+											"sourceFileName": "../../../node_modules/.pnpm/zod@3.25.64/node_modules/zod/dist/types/v3/types.d.ts",
+											"qualifiedName": "ZodTypeDef"
+										},
+										"name": "ZodTypeDef",
+										"package": "zod"
+									},
+									{
+										"type": "intrinsic",
+										"name": "any"
+									}
+								],
+								"name": "ZodType",
+								"package": "zod"
+							},
+							"default": {
+								"type": "reference",
+								"target": {
+									"sourceFileName": "../../../node_modules/.pnpm/zod@3.25.64/node_modules/zod/dist/types/v3/types.d.ts",
+									"qualifiedName": "ZodUndefined"
+								},
+								"name": "ZodUndefined",
+								"package": "zod"
+							}
 						}
 					],
 					"parameters": [
 						{
-							"id": 78,
-							"name": "__namedParameters",
+							"id": 73,
+							"name": "toolDef",
 							"variant": "param",
 							"kind": 32768,
 							"flags": {},
 							"type": {
 								"type": "reflection",
 								"declaration": {
-									"id": 79,
+									"id": 74,
 									"name": "__type",
 									"variant": "declaration",
 									"kind": 65536,
 									"flags": {},
 									"children": [
 										{
-											"id": 81,
-											"name": "context",
+											"id": 75,
+											"name": "packageName",
 											"variant": "declaration",
 											"kind": 1024,
 											"flags": {},
 											"sources": [
 												{
-													"fileName": "handlers/vincentToolHandler.ts",
-													"line": 124,
+													"fileName": "toolCore/toolDef/types.ts",
+													"line": 47,
 													"character": 2,
-													"url": "https://github.com/LIT-Protocol/Vincent/blob/8e21b5da26217bce6eb8963c7b9c9ea95c6a2290/packages/libs/tool-sdk/src/lib/handlers/vincentToolHandler.ts#L124"
+													"url": "https://github.com/LIT-Protocol/Vincent/blob/46a7999ef358981de990d808b7484f24731b23f9/packages/libs/tool-sdk/src/lib/toolCore/toolDef/types.ts#L47"
+												}
+											],
+											"type": {
+												"type": "intrinsic",
+												"name": "string"
+											}
+										},
+										{
+											"id": 76,
+											"name": "toolParamsSchema",
+											"variant": "declaration",
+											"kind": 1024,
+											"flags": {},
+											"sources": [
+												{
+													"fileName": "toolCore/toolDef/types.ts",
+													"line": 48,
+													"character": 2,
+													"url": "https://github.com/LIT-Protocol/Vincent/blob/46a7999ef358981de990d808b7484f24731b23f9/packages/libs/tool-sdk/src/lib/toolCore/toolDef/types.ts#L48"
 												}
 											],
 											"type": {
 												"type": "reference",
-												"target": -1,
-												"name": "ToolConsumerContext",
-												"package": "@lit-protocol/vincent-tool-sdk"
+												"target": 65,
+												"name": "ToolParamsSchema",
+												"package": "@lit-protocol/vincent-tool-sdk",
+												"refersToTypeParameter": true
 											}
 										},
 										{
-											"id": 82,
-											"name": "toolParams",
+											"id": 77,
+											"name": "supportedPolicies",
 											"variant": "declaration",
 											"kind": 1024,
 											"flags": {},
 											"sources": [
 												{
-													"fileName": "handlers/vincentToolHandler.ts",
-													"line": 125,
+													"fileName": "toolCore/toolDef/types.ts",
+													"line": 49,
 													"character": 2,
-													"url": "https://github.com/LIT-Protocol/Vincent/blob/8e21b5da26217bce6eb8963c7b9c9ea95c6a2290/packages/libs/tool-sdk/src/lib/handlers/vincentToolHandler.ts#L125"
+													"url": "https://github.com/LIT-Protocol/Vincent/blob/46a7999ef358981de990d808b7484f24731b23f9/packages/libs/tool-sdk/src/lib/toolCore/toolDef/types.ts#L49"
+												}
+											],
+											"type": {
+												"type": "reference",
+												"target": 67,
+												"name": "PolicyMap",
+												"package": "@lit-protocol/vincent-tool-sdk",
+												"refersToTypeParameter": true
+											}
+										},
+										{
+											"id": 78,
+											"name": "precheckSuccessSchema",
+											"variant": "declaration",
+											"kind": 1024,
+											"flags": {
+												"isOptional": true
+											},
+											"sources": [
+												{
+													"fileName": "toolCore/toolDef/types.ts",
+													"line": 51,
+													"character": 2,
+													"url": "https://github.com/LIT-Protocol/Vincent/blob/46a7999ef358981de990d808b7484f24731b23f9/packages/libs/tool-sdk/src/lib/toolCore/toolDef/types.ts#L51"
+												}
+											],
+											"type": {
+												"type": "reference",
+												"target": 69,
+												"name": "PrecheckSuccessSchema",
+												"package": "@lit-protocol/vincent-tool-sdk",
+												"refersToTypeParameter": true
+											}
+										},
+										{
+											"id": 79,
+											"name": "precheckFailSchema",
+											"variant": "declaration",
+											"kind": 1024,
+											"flags": {
+												"isOptional": true
+											},
+											"sources": [
+												{
+													"fileName": "toolCore/toolDef/types.ts",
+													"line": 52,
+													"character": 2,
+													"url": "https://github.com/LIT-Protocol/Vincent/blob/46a7999ef358981de990d808b7484f24731b23f9/packages/libs/tool-sdk/src/lib/toolCore/toolDef/types.ts#L52"
+												}
+											],
+											"type": {
+												"type": "reference",
+												"target": 70,
+												"name": "PrecheckFailSchema",
+												"package": "@lit-protocol/vincent-tool-sdk",
+												"refersToTypeParameter": true
+											}
+										},
+										{
+											"id": 80,
+											"name": "executeSuccessSchema",
+											"variant": "declaration",
+											"kind": 1024,
+											"flags": {
+												"isOptional": true
+											},
+											"sources": [
+												{
+													"fileName": "toolCore/toolDef/types.ts",
+													"line": 53,
+													"character": 2,
+													"url": "https://github.com/LIT-Protocol/Vincent/blob/46a7999ef358981de990d808b7484f24731b23f9/packages/libs/tool-sdk/src/lib/toolCore/toolDef/types.ts#L53"
+												}
+											],
+											"type": {
+												"type": "reference",
+												"target": 71,
+												"name": "ExecuteSuccessSchema",
+												"package": "@lit-protocol/vincent-tool-sdk",
+												"refersToTypeParameter": true
+											}
+										},
+										{
+											"id": 81,
+											"name": "executeFailSchema",
+											"variant": "declaration",
+											"kind": 1024,
+											"flags": {
+												"isOptional": true
+											},
+											"sources": [
+												{
+													"fileName": "toolCore/toolDef/types.ts",
+													"line": 54,
+													"character": 2,
+													"url": "https://github.com/LIT-Protocol/Vincent/blob/46a7999ef358981de990d808b7484f24731b23f9/packages/libs/tool-sdk/src/lib/toolCore/toolDef/types.ts#L54"
+												}
+											],
+											"type": {
+												"type": "reference",
+												"target": 72,
+												"name": "ExecuteFailSchema",
+												"package": "@lit-protocol/vincent-tool-sdk",
+												"refersToTypeParameter": true
+											}
+										},
+										{
+											"id": 82,
+											"name": "precheck",
+											"variant": "declaration",
+											"kind": 1024,
+											"flags": {
+												"isOptional": true
+											},
+											"sources": [
+												{
+													"fileName": "toolCore/toolDef/types.ts",
+													"line": 56,
+													"character": 2,
+													"url": "https://github.com/LIT-Protocol/Vincent/blob/46a7999ef358981de990d808b7484f24731b23f9/packages/libs/tool-sdk/src/lib/toolCore/toolDef/types.ts#L56"
 												}
 											],
 											"type": {
 												"type": "reference",
 												"target": {
-													"sourceFileName": "../../../node_modules/.pnpm/typescript@5.8.3/node_modules/typescript/lib/lib.es5.d.ts",
-													"qualifiedName": "Record"
+													"sourceFileName": "src/lib/toolCore/toolDef/types.ts",
+													"qualifiedName": "ToolDefLifecycleFunction"
 												},
 												"typeArguments": [
 													{
-														"type": "intrinsic",
-														"name": "string"
-													},
-													{
-														"type": "intrinsic",
-														"name": "unknown"
-													}
-												],
-												"name": "Record",
-												"package": "typescript"
-											}
-										},
-										{
-											"id": 80,
-											"name": "vincentTool",
-											"variant": "declaration",
-											"kind": 1024,
-											"flags": {},
-											"sources": [
-												{
-													"fileName": "handlers/vincentToolHandler.ts",
-													"line": 114,
-													"character": 2,
-													"url": "https://github.com/LIT-Protocol/Vincent/blob/8e21b5da26217bce6eb8963c7b9c9ea95c6a2290/packages/libs/tool-sdk/src/lib/handlers/vincentToolHandler.ts#L114"
-												}
-											],
-											"type": {
-												"type": "reference",
-												"target": 195,
-												"typeArguments": [
-													{
 														"type": "reference",
-														"target": 74,
+														"target": 65,
 														"name": "ToolParamsSchema",
 														"package": "@lit-protocol/vincent-tool-sdk",
 														"refersToTypeParameter": true
 													},
 													{
 														"type": "reference",
-														"target": 75,
-														"name": "PkgNames",
+														"target": -1,
+														"typeArguments": [
+															{
+																"type": "reference",
+																"target": 68,
+																"name": "PolicyMapByPackageName",
+																"package": "@lit-protocol/vincent-tool-sdk",
+																"refersToTypeParameter": true
+															}
+														],
+														"name": "PolicyEvaluationResultContext",
+														"package": "@lit-protocol/vincent-tool-sdk"
+													},
+													{
+														"type": "reference",
+														"target": 69,
+														"name": "PrecheckSuccessSchema",
 														"package": "@lit-protocol/vincent-tool-sdk",
 														"refersToTypeParameter": true
 													},
 													{
 														"type": "reference",
-														"target": 76,
-														"name": "PolicyMap",
+														"target": 70,
+														"name": "PrecheckFailSchema",
 														"package": "@lit-protocol/vincent-tool-sdk",
 														"refersToTypeParameter": true
-													},
-													{
-														"type": "reference",
-														"target": 77,
-														"name": "PoliciesByPackageName",
-														"package": "@lit-protocol/vincent-tool-sdk",
-														"refersToTypeParameter": true
-													},
-													{
-														"type": "intrinsic",
-														"name": "any"
-													},
-													{
-														"type": "intrinsic",
-														"name": "any"
-													},
-													{
-														"type": "intrinsic",
-														"name": "any"
-													},
-													{
-														"type": "intrinsic",
-														"name": "any"
 													}
 												],
-												"name": "VincentTool",
+												"name": "ToolDefLifecycleFunction",
+												"package": "@lit-protocol/vincent-tool-sdk"
+											}
+										},
+										{
+											"id": 83,
+											"name": "execute",
+											"variant": "declaration",
+											"kind": 1024,
+											"flags": {},
+											"sources": [
+												{
+													"fileName": "toolCore/toolDef/types.ts",
+													"line": 57,
+													"character": 2,
+													"url": "https://github.com/LIT-Protocol/Vincent/blob/46a7999ef358981de990d808b7484f24731b23f9/packages/libs/tool-sdk/src/lib/toolCore/toolDef/types.ts#L57"
+												}
+											],
+											"type": {
+												"type": "reference",
+												"target": {
+													"sourceFileName": "src/lib/toolCore/toolDef/types.ts",
+													"qualifiedName": "ToolDefLifecycleFunction"
+												},
+												"name": "ToolDefLifecycleFunction",
 												"package": "@lit-protocol/vincent-tool-sdk"
 											}
 										}
@@ -6740,18 +5514,24 @@
 										{
 											"title": "Properties",
 											"children": [
+												75,
+												76,
+												77,
+												78,
+												79,
+												80,
 												81,
 												82,
-												80
+												83
 											]
 										}
 									],
 									"sources": [
 										{
-											"fileName": "handlers/vincentToolHandler.ts",
-											"line": 113,
-											"character": 3,
-											"url": "https://github.com/LIT-Protocol/Vincent/blob/8e21b5da26217bce6eb8963c7b9c9ea95c6a2290/packages/libs/tool-sdk/src/lib/handlers/vincentToolHandler.ts#L113"
+											"fileName": "toolCore/toolDef/types.ts",
+											"line": 46,
+											"character": 4,
+											"url": "https://github.com/LIT-Protocol/Vincent/blob/46a7999ef358981de990d808b7484f24731b23f9/packages/libs/tool-sdk/src/lib/toolCore/toolDef/types.ts#L46"
 										}
 									]
 								}
@@ -6759,54 +5539,68 @@
 						}
 					],
 					"type": {
-						"type": "reflection",
-						"declaration": {
-							"id": 83,
-							"name": "__type",
-							"variant": "declaration",
-							"kind": 65536,
-							"flags": {},
-							"sources": [
-								{
-									"fileName": "handlers/vincentToolHandler.ts",
-									"line": 127,
-									"character": 9,
-									"url": "https://github.com/LIT-Protocol/Vincent/blob/8e21b5da26217bce6eb8963c7b9c9ea95c6a2290/packages/libs/tool-sdk/src/lib/handlers/vincentToolHandler.ts#L127"
-								}
-							],
-							"signatures": [
-								{
-									"id": 84,
-									"name": "__type",
-									"variant": "signature",
-									"kind": 4096,
-									"flags": {},
-									"sources": [
-										{
-											"fileName": "handlers/vincentToolHandler.ts",
-											"line": 127,
-											"character": 9,
-											"url": "https://github.com/LIT-Protocol/Vincent/blob/8e21b5da26217bce6eb8963c7b9c9ea95c6a2290/packages/libs/tool-sdk/src/lib/handlers/vincentToolHandler.ts#L127"
-										}
-									],
-									"type": {
-										"type": "reference",
-										"target": {
-											"sourceFileName": "../../../node_modules/.pnpm/typescript@5.8.3/node_modules/typescript/lib/lib.es5.d.ts",
-											"qualifiedName": "Promise"
-										},
-										"typeArguments": [
-											{
-												"type": "intrinsic",
-												"name": "void"
-											}
-										],
-										"name": "Promise",
-										"package": "typescript"
-									}
-								}
-							]
-						}
+						"type": "reference",
+						"target": -1,
+						"typeArguments": [
+							{
+								"type": "reference",
+								"target": 65,
+								"name": "ToolParamsSchema",
+								"package": "@lit-protocol/vincent-tool-sdk",
+								"refersToTypeParameter": true
+							},
+							{
+								"type": "reference",
+								"target": 66,
+								"name": "PkgNames",
+								"package": "@lit-protocol/vincent-tool-sdk",
+								"refersToTypeParameter": true
+							},
+							{
+								"type": "reference",
+								"target": 67,
+								"name": "PolicyMap",
+								"package": "@lit-protocol/vincent-tool-sdk",
+								"refersToTypeParameter": true
+							},
+							{
+								"type": "reference",
+								"target": 68,
+								"name": "PolicyMapByPackageName",
+								"package": "@lit-protocol/vincent-tool-sdk",
+								"refersToTypeParameter": true
+							},
+							{
+								"type": "reference",
+								"target": 71,
+								"name": "ExecuteSuccessSchema",
+								"package": "@lit-protocol/vincent-tool-sdk",
+								"refersToTypeParameter": true
+							},
+							{
+								"type": "reference",
+								"target": 72,
+								"name": "ExecuteFailSchema",
+								"package": "@lit-protocol/vincent-tool-sdk",
+								"refersToTypeParameter": true
+							},
+							{
+								"type": "reference",
+								"target": 69,
+								"name": "PrecheckSuccessSchema",
+								"package": "@lit-protocol/vincent-tool-sdk",
+								"refersToTypeParameter": true
+							},
+							{
+								"type": "reference",
+								"target": 70,
+								"name": "PrecheckFailSchema",
+								"package": "@lit-protocol/vincent-tool-sdk",
+								"refersToTypeParameter": true
+							}
+						],
+						"name": "VincentTool",
+						"package": "@lit-protocol/vincent-tool-sdk"
 					}
 				}
 			]
@@ -6816,30 +5610,44 @@
 		{
 			"title": "Interfaces",
 			"children": [
-				223
+				164,
+				294
 			]
 		},
 		{
 			"title": "Type Aliases",
 			"children": [
-				107,
-				114,
-				156,
-				195,
-				121
+				144,
+				156
 			]
 		},
 		{
 			"title": "Functions",
 			"children": [
-				91,
-				85,
 				1,
-				49,
-				14,
-				97,
-				60,
-				72
+				28,
+				121,
+				63
+			]
+		}
+	],
+	"categories": [
+		{
+			"title": "API Methods",
+			"children": [
+				1,
+				28,
+				121,
+				63
+			]
+		},
+		{
+			"title": "Interfaces",
+			"children": [
+				164,
+				144,
+				156,
+				294
 			]
 		}
 	],
@@ -7113,576 +5921,476 @@
 			"qualifiedName": "policyDef"
 		},
 		"14": {
-			"sourceFileName": "src/lib/policyCore/vincentPolicy.ts",
-			"qualifiedName": "createVincentToolPolicy"
+			"sourceFileName": "src/lib/policyCore/policyDef/types.ts",
+			"qualifiedName": "__type"
 		},
 		"15": {
-			"sourceFileName": "src/lib/policyCore/vincentPolicy.ts",
-			"qualifiedName": "createVincentToolPolicy"
+			"sourceFileName": "src/lib/policyCore/policyDef/types.ts",
+			"qualifiedName": "__type.packageName"
 		},
 		"16": {
-			"sourceFileName": "src/lib/policyCore/vincentPolicy.ts",
-			"qualifiedName": "PackageName"
+			"sourceFileName": "src/lib/policyCore/policyDef/types.ts",
+			"qualifiedName": "__type.toolParamsSchema"
 		},
 		"17": {
-			"sourceFileName": "src/lib/policyCore/vincentPolicy.ts",
-			"qualifiedName": "IpfsCid"
+			"sourceFileName": "src/lib/policyCore/policyDef/types.ts",
+			"qualifiedName": "__type.userParamsSchema"
 		},
 		"18": {
-			"sourceFileName": "src/lib/policyCore/vincentPolicy.ts",
-			"qualifiedName": "ToolParamsSchema"
+			"sourceFileName": "src/lib/policyCore/policyDef/types.ts",
+			"qualifiedName": "__type.evalAllowResultSchema"
 		},
 		"19": {
-			"sourceFileName": "src/lib/policyCore/vincentPolicy.ts",
-			"qualifiedName": "PolicyToolParams"
+			"sourceFileName": "src/lib/policyCore/policyDef/types.ts",
+			"qualifiedName": "__type.evalDenyResultSchema"
 		},
 		"20": {
-			"sourceFileName": "src/lib/policyCore/vincentPolicy.ts",
-			"qualifiedName": "UserParams"
+			"sourceFileName": "src/lib/policyCore/policyDef/types.ts",
+			"qualifiedName": "__type.precheckAllowResultSchema"
 		},
 		"21": {
-			"sourceFileName": "src/lib/policyCore/vincentPolicy.ts",
-			"qualifiedName": "PrecheckAllowResult"
+			"sourceFileName": "src/lib/policyCore/policyDef/types.ts",
+			"qualifiedName": "__type.precheckDenyResultSchema"
 		},
 		"22": {
-			"sourceFileName": "src/lib/policyCore/vincentPolicy.ts",
-			"qualifiedName": "PrecheckDenyResult"
+			"sourceFileName": "src/lib/policyCore/policyDef/types.ts",
+			"qualifiedName": "__type.commitParamsSchema"
 		},
 		"23": {
-			"sourceFileName": "src/lib/policyCore/vincentPolicy.ts",
-			"qualifiedName": "EvalAllowResult"
+			"sourceFileName": "src/lib/policyCore/policyDef/types.ts",
+			"qualifiedName": "__type.commitAllowResultSchema"
 		},
 		"24": {
-			"sourceFileName": "src/lib/policyCore/vincentPolicy.ts",
-			"qualifiedName": "EvalDenyResult"
+			"sourceFileName": "src/lib/policyCore/policyDef/types.ts",
+			"qualifiedName": "__type.commitDenyResultSchema"
 		},
 		"25": {
-			"sourceFileName": "src/lib/policyCore/vincentPolicy.ts",
-			"qualifiedName": "CommitParams"
+			"sourceFileName": "src/lib/policyCore/policyDef/types.ts",
+			"qualifiedName": "__type.evaluate"
 		},
 		"26": {
-			"sourceFileName": "src/lib/policyCore/vincentPolicy.ts",
-			"qualifiedName": "CommitAllowResult"
+			"sourceFileName": "src/lib/policyCore/policyDef/types.ts",
+			"qualifiedName": "__type.precheck"
 		},
 		"27": {
-			"sourceFileName": "src/lib/policyCore/vincentPolicy.ts",
-			"qualifiedName": "CommitDenyResult"
+			"sourceFileName": "src/lib/policyCore/policyDef/types.ts",
+			"qualifiedName": "__type.commit"
 		},
 		"28": {
 			"sourceFileName": "src/lib/policyCore/vincentPolicy.ts",
-			"qualifiedName": "config"
+			"qualifiedName": "createVincentToolPolicy"
 		},
 		"29": {
 			"sourceFileName": "src/lib/policyCore/vincentPolicy.ts",
-			"qualifiedName": "__type"
+			"qualifiedName": "createVincentToolPolicy"
 		},
 		"30": {
 			"sourceFileName": "src/lib/policyCore/vincentPolicy.ts",
-			"qualifiedName": "__type.toolParamsSchema"
+			"qualifiedName": "PackageName"
 		},
 		"31": {
 			"sourceFileName": "src/lib/policyCore/vincentPolicy.ts",
-			"qualifiedName": "__type.bundledVincentPolicy"
+			"qualifiedName": "IpfsCid"
 		},
 		"32": {
 			"sourceFileName": "src/lib/policyCore/vincentPolicy.ts",
-			"qualifiedName": "__type.toolParameterMappings"
+			"qualifiedName": "ToolParamsSchema"
 		},
 		"33": {
 			"sourceFileName": "src/lib/policyCore/vincentPolicy.ts",
-			"qualifiedName": "__type"
+			"qualifiedName": "PolicyToolParams"
 		},
 		"34": {
 			"sourceFileName": "src/lib/policyCore/vincentPolicy.ts",
-			"qualifiedName": "__type.vincentPolicy"
+			"qualifiedName": "UserParams"
 		},
 		"35": {
 			"sourceFileName": "src/lib/policyCore/vincentPolicy.ts",
-			"qualifiedName": "__type.ipfsCid"
+			"qualifiedName": "PrecheckAllowResult"
 		},
 		"36": {
 			"sourceFileName": "src/lib/policyCore/vincentPolicy.ts",
-			"qualifiedName": "__type.toolParameterMappings"
+			"qualifiedName": "PrecheckDenyResult"
 		},
 		"37": {
 			"sourceFileName": "src/lib/policyCore/vincentPolicy.ts",
-			"qualifiedName": "__type.__schemaTypes"
+			"qualifiedName": "EvalAllowResult"
 		},
 		"38": {
 			"sourceFileName": "src/lib/policyCore/vincentPolicy.ts",
-			"qualifiedName": "__type"
+			"qualifiedName": "EvalDenyResult"
 		},
 		"39": {
 			"sourceFileName": "src/lib/policyCore/vincentPolicy.ts",
-			"qualifiedName": "__type.evalAllowResultSchema"
+			"qualifiedName": "CommitParams"
 		},
 		"40": {
 			"sourceFileName": "src/lib/policyCore/vincentPolicy.ts",
-			"qualifiedName": "__type.evalDenyResultSchema"
+			"qualifiedName": "CommitAllowResult"
 		},
 		"41": {
 			"sourceFileName": "src/lib/policyCore/vincentPolicy.ts",
-			"qualifiedName": "__type.precheckAllowResultSchema"
+			"qualifiedName": "CommitDenyResult"
 		},
 		"42": {
 			"sourceFileName": "src/lib/policyCore/vincentPolicy.ts",
-			"qualifiedName": "__type.precheckDenyResultSchema"
+			"qualifiedName": "config"
 		},
 		"43": {
 			"sourceFileName": "src/lib/policyCore/vincentPolicy.ts",
-			"qualifiedName": "__type.commitParamsSchema"
+			"qualifiedName": "__type"
 		},
 		"44": {
 			"sourceFileName": "src/lib/policyCore/vincentPolicy.ts",
-			"qualifiedName": "__type.commitAllowResultSchema"
+			"qualifiedName": "__type.toolParamsSchema"
 		},
 		"45": {
 			"sourceFileName": "src/lib/policyCore/vincentPolicy.ts",
-			"qualifiedName": "__type.commitDenyResultSchema"
+			"qualifiedName": "__type.bundledVincentPolicy"
 		},
 		"46": {
 			"sourceFileName": "src/lib/policyCore/vincentPolicy.ts",
-			"qualifiedName": "__type.evaluate"
+			"qualifiedName": "__type.toolParameterMappings"
 		},
 		"47": {
 			"sourceFileName": "src/lib/policyCore/vincentPolicy.ts",
-			"qualifiedName": "__type.precheck"
+			"qualifiedName": "__type"
 		},
 		"48": {
 			"sourceFileName": "src/lib/policyCore/vincentPolicy.ts",
-			"qualifiedName": "__type.commit"
+			"qualifiedName": "__type.vincentPolicy"
 		},
 		"49": {
-			"sourceFileName": "src/lib/toolCore/vincentTool.ts",
-			"qualifiedName": "createVincentTool"
+			"sourceFileName": "src/lib/policyCore/vincentPolicy.ts",
+			"qualifiedName": "__type.ipfsCid"
 		},
 		"50": {
+			"sourceFileName": "src/lib/policyCore/vincentPolicy.ts",
+			"qualifiedName": "__type.toolParameterMappings"
+		},
+		"51": {
+			"sourceFileName": "src/lib/policyCore/vincentPolicy.ts",
+			"qualifiedName": "__type.__schemaTypes"
+		},
+		"52": {
+			"sourceFileName": "src/lib/policyCore/vincentPolicy.ts",
+			"qualifiedName": "__type"
+		},
+		"53": {
+			"sourceFileName": "src/lib/policyCore/vincentPolicy.ts",
+			"qualifiedName": "__type.evalAllowResultSchema"
+		},
+		"54": {
+			"sourceFileName": "src/lib/policyCore/vincentPolicy.ts",
+			"qualifiedName": "__type.evalDenyResultSchema"
+		},
+		"55": {
+			"sourceFileName": "src/lib/policyCore/vincentPolicy.ts",
+			"qualifiedName": "__type.precheckAllowResultSchema"
+		},
+		"56": {
+			"sourceFileName": "src/lib/policyCore/vincentPolicy.ts",
+			"qualifiedName": "__type.precheckDenyResultSchema"
+		},
+		"57": {
+			"sourceFileName": "src/lib/policyCore/vincentPolicy.ts",
+			"qualifiedName": "__type.commitParamsSchema"
+		},
+		"58": {
+			"sourceFileName": "src/lib/policyCore/vincentPolicy.ts",
+			"qualifiedName": "__type.commitAllowResultSchema"
+		},
+		"59": {
+			"sourceFileName": "src/lib/policyCore/vincentPolicy.ts",
+			"qualifiedName": "__type.commitDenyResultSchema"
+		},
+		"60": {
+			"sourceFileName": "src/lib/policyCore/vincentPolicy.ts",
+			"qualifiedName": "__type.evaluate"
+		},
+		"61": {
+			"sourceFileName": "src/lib/policyCore/vincentPolicy.ts",
+			"qualifiedName": "__type.precheck"
+		},
+		"62": {
+			"sourceFileName": "src/lib/policyCore/vincentPolicy.ts",
+			"qualifiedName": "__type.commit"
+		},
+		"63": {
 			"sourceFileName": "src/lib/toolCore/vincentTool.ts",
 			"qualifiedName": "createVincentTool"
 		},
-		"51": {
+		"64": {
+			"sourceFileName": "src/lib/toolCore/vincentTool.ts",
+			"qualifiedName": "createVincentTool"
+		},
+		"65": {
 			"sourceFileName": "src/lib/toolCore/vincentTool.ts",
 			"qualifiedName": "ToolParamsSchema"
 		},
-		"52": {
+		"66": {
 			"sourceFileName": "src/lib/toolCore/vincentTool.ts",
 			"qualifiedName": "PkgNames"
 		},
-		"53": {
+		"67": {
 			"sourceFileName": "src/lib/toolCore/vincentTool.ts",
 			"qualifiedName": "PolicyMap"
 		},
-		"54": {
+		"68": {
 			"sourceFileName": "src/lib/toolCore/vincentTool.ts",
 			"qualifiedName": "PolicyMapByPackageName"
 		},
-		"55": {
+		"69": {
 			"sourceFileName": "src/lib/toolCore/vincentTool.ts",
 			"qualifiedName": "PrecheckSuccessSchema"
 		},
-		"56": {
+		"70": {
 			"sourceFileName": "src/lib/toolCore/vincentTool.ts",
 			"qualifiedName": "PrecheckFailSchema"
 		},
-		"57": {
+		"71": {
 			"sourceFileName": "src/lib/toolCore/vincentTool.ts",
 			"qualifiedName": "ExecuteSuccessSchema"
 		},
-		"58": {
+		"72": {
 			"sourceFileName": "src/lib/toolCore/vincentTool.ts",
 			"qualifiedName": "ExecuteFailSchema"
 		},
-		"59": {
+		"73": {
 			"sourceFileName": "src/lib/toolCore/vincentTool.ts",
 			"qualifiedName": "toolDef"
 		},
-		"60": {
-			"sourceFileName": "src/lib/handlers/vincentPolicyHandler.ts",
-			"qualifiedName": "vincentPolicyHandler"
-		},
-		"61": {
-			"sourceFileName": "src/lib/handlers/vincentPolicyHandler.ts",
-			"qualifiedName": "vincentPolicyHandler"
-		},
-		"62": {
-			"sourceFileName": "src/lib/handlers/vincentPolicyHandler.ts",
-			"qualifiedName": "PackageName"
-		},
-		"63": {
-			"sourceFileName": "src/lib/handlers/vincentPolicyHandler.ts",
-			"qualifiedName": "PolicyToolParams"
-		},
-		"64": {
-			"sourceFileName": "src/lib/handlers/vincentPolicyHandler.ts",
-			"qualifiedName": "UserParams"
-		},
-		"65": {
-			"sourceFileName": "src/lib/handlers/vincentPolicyHandler.ts",
-			"qualifiedName": "EvalAllowResult"
-		},
-		"66": {
-			"sourceFileName": "src/lib/handlers/vincentPolicyHandler.ts",
-			"qualifiedName": "EvalDenyResult"
-		},
-		"67": {
-			"sourceFileName": "src/lib/handlers/vincentPolicyHandler.ts",
-			"qualifiedName": "__0"
-		},
-		"68": {
-			"sourceFileName": "src/lib/handlers/vincentPolicyHandler.ts",
-			"qualifiedName": "__type"
-		},
-		"69": {
-			"sourceFileName": "src/lib/handlers/vincentPolicyHandler.ts",
-			"qualifiedName": "__type.vincentPolicy"
-		},
-		"70": {
-			"sourceFileName": "src/lib/handlers/vincentPolicyHandler.ts",
-			"qualifiedName": "__type.toolParams"
-		},
-		"71": {
-			"sourceFileName": "src/lib/handlers/vincentPolicyHandler.ts",
-			"qualifiedName": "__type.context"
-		},
-		"72": {
-			"sourceFileName": "src/lib/handlers/vincentToolHandler.ts",
-			"qualifiedName": "vincentToolHandler"
-		},
-		"73": {
-			"sourceFileName": "src/lib/handlers/vincentToolHandler.ts",
-			"qualifiedName": "vincentToolHandler"
-		},
 		"74": {
-			"sourceFileName": "src/lib/handlers/vincentToolHandler.ts",
-			"qualifiedName": "ToolParamsSchema"
+			"sourceFileName": "src/lib/toolCore/toolDef/types.ts",
+			"qualifiedName": "__type"
 		},
 		"75": {
-			"sourceFileName": "src/lib/handlers/vincentToolHandler.ts",
-			"qualifiedName": "PkgNames"
+			"sourceFileName": "src/lib/toolCore/toolDef/types.ts",
+			"qualifiedName": "__type.packageName"
 		},
 		"76": {
-			"sourceFileName": "src/lib/handlers/vincentToolHandler.ts",
-			"qualifiedName": "PolicyMap"
+			"sourceFileName": "src/lib/toolCore/toolDef/types.ts",
+			"qualifiedName": "__type.toolParamsSchema"
 		},
 		"77": {
-			"sourceFileName": "src/lib/handlers/vincentToolHandler.ts",
-			"qualifiedName": "PoliciesByPackageName"
+			"sourceFileName": "src/lib/toolCore/toolDef/types.ts",
+			"qualifiedName": "__type.supportedPolicies"
 		},
 		"78": {
-			"sourceFileName": "src/lib/handlers/vincentToolHandler.ts",
-			"qualifiedName": "__0"
+			"sourceFileName": "src/lib/toolCore/toolDef/types.ts",
+			"qualifiedName": "__type.precheckSuccessSchema"
 		},
 		"79": {
-			"sourceFileName": "src/lib/handlers/vincentToolHandler.ts",
-			"qualifiedName": "__type"
+			"sourceFileName": "src/lib/toolCore/toolDef/types.ts",
+			"qualifiedName": "__type.precheckFailSchema"
 		},
 		"80": {
-			"sourceFileName": "src/lib/handlers/vincentToolHandler.ts",
-			"qualifiedName": "__type.vincentTool"
+			"sourceFileName": "src/lib/toolCore/toolDef/types.ts",
+			"qualifiedName": "__type.executeSuccessSchema"
 		},
 		"81": {
-			"sourceFileName": "src/lib/handlers/vincentToolHandler.ts",
-			"qualifiedName": "__type.context"
+			"sourceFileName": "src/lib/toolCore/toolDef/types.ts",
+			"qualifiedName": "__type.executeFailSchema"
 		},
 		"82": {
-			"sourceFileName": "src/lib/handlers/vincentToolHandler.ts",
-			"qualifiedName": "__type.toolParams"
+			"sourceFileName": "src/lib/toolCore/toolDef/types.ts",
+			"qualifiedName": "__type.precheck"
 		},
 		"83": {
-			"sourceFileName": "src/lib/handlers/vincentToolHandler.ts",
-			"qualifiedName": "__function"
+			"sourceFileName": "src/lib/toolCore/toolDef/types.ts",
+			"qualifiedName": "__type.execute"
 		},
-		"84": {
-			"sourceFileName": "src/lib/handlers/vincentToolHandler.ts",
-			"qualifiedName": "__function"
-		},
-		"85": {
-			"sourceFileName": "src/lib/toolCore/bundledTool/bundledTool.ts",
-			"qualifiedName": "asBundledVincentTool"
-		},
-		"86": {
-			"sourceFileName": "src/lib/toolCore/bundledTool/bundledTool.ts",
-			"qualifiedName": "asBundledVincentTool"
-		},
-		"87": {
-			"sourceFileName": "src/lib/toolCore/bundledTool/bundledTool.ts",
-			"qualifiedName": "VT"
-		},
-		"88": {
-			"sourceFileName": "src/lib/toolCore/bundledTool/bundledTool.ts",
-			"qualifiedName": "IpfsCid"
-		},
-		"89": {
-			"sourceFileName": "src/lib/toolCore/bundledTool/bundledTool.ts",
-			"qualifiedName": "vincentTool"
-		},
-		"90": {
-			"sourceFileName": "src/lib/toolCore/bundledTool/bundledTool.ts",
-			"qualifiedName": "ipfsCid"
-		},
-		"91": {
-			"sourceFileName": "src/lib/policyCore/bundledPolicy/bundledPolicy.ts",
-			"qualifiedName": "asBundledVincentPolicy"
-		},
-		"92": {
-			"sourceFileName": "src/lib/policyCore/bundledPolicy/bundledPolicy.ts",
-			"qualifiedName": "asBundledVincentPolicy"
-		},
-		"93": {
-			"sourceFileName": "src/lib/policyCore/bundledPolicy/bundledPolicy.ts",
-			"qualifiedName": "VP"
-		},
-		"94": {
-			"sourceFileName": "src/lib/policyCore/bundledPolicy/bundledPolicy.ts",
-			"qualifiedName": "IpfsCid"
-		},
-		"95": {
-			"sourceFileName": "src/lib/policyCore/bundledPolicy/bundledPolicy.ts",
-			"qualifiedName": "vincentPolicy"
-		},
-		"96": {
-			"sourceFileName": "src/lib/policyCore/bundledPolicy/bundledPolicy.ts",
-			"qualifiedName": "ipfsCid"
-		},
-		"97": {
+		"121": {
 			"sourceFileName": "src/lib/toolCore/helpers/supportedPoliciesForTool.ts",
 			"qualifiedName": "supportedPoliciesForTool"
 		},
-		"98": {
+		"122": {
 			"sourceFileName": "src/lib/toolCore/helpers/supportedPoliciesForTool.ts",
 			"qualifiedName": "supportedPoliciesForTool"
 		},
-		"99": {
+		"123": {
 			"sourceFileName": "src/lib/toolCore/helpers/supportedPoliciesForTool.ts",
 			"qualifiedName": "Policies"
 		},
-		"100": {
+		"124": {
 			"sourceFileName": "src/lib/toolCore/helpers/supportedPoliciesForTool.ts",
 			"qualifiedName": "__type"
 		},
-		"101": {
+		"125": {
 			"sourceFileName": "src/lib/toolCore/helpers/supportedPoliciesForTool.ts",
 			"qualifiedName": "__type.vincentPolicy"
 		},
-		"102": {
-			"sourceFileName": "src/lib/toolCore/helpers/supportedPoliciesForTool.ts",
-			"qualifiedName": "__type"
-		},
-		"103": {
-			"sourceFileName": "src/lib/toolCore/helpers/supportedPoliciesForTool.ts",
-			"qualifiedName": "__type.packageName"
-		},
-		"104": {
+		"126": {
 			"sourceFileName": "src/lib/toolCore/helpers/supportedPoliciesForTool.ts",
 			"qualifiedName": "__type.ipfsCid"
 		},
-		"105": {
+		"127": {
+			"sourceFileName": "src/lib/toolCore/helpers/supportedPoliciesForTool.ts",
+			"qualifiedName": "IpfsCid"
+		},
+		"128": {
 			"sourceFileName": "src/lib/toolCore/helpers/supportedPoliciesForTool.ts",
 			"qualifiedName": "PkgNames"
 		},
-		"106": {
+		"129": {
 			"sourceFileName": "src/lib/toolCore/helpers/supportedPoliciesForTool.ts",
 			"qualifiedName": "policies"
 		},
-		"107": {
-			"sourceFileName": "src/lib/policyCore/bundledPolicy/types.ts",
-			"qualifiedName": "BundledVincentPolicy"
+		"144": {
+			"sourceFileName": "src/lib/policyCore/policyDef/types.ts",
+			"qualifiedName": "PolicyDefLifecycleFunction"
 		},
-		"108": {
-			"sourceFileName": "src/lib/policyCore/bundledPolicy/types.ts",
+		"145": {
+			"sourceFileName": "src/lib/policyCore/policyDef/types.ts",
 			"qualifiedName": "__type"
 		},
-		"109": {
-			"sourceFileName": "src/lib/policyCore/bundledPolicy/types.ts",
-			"qualifiedName": "__type.ipfsCid"
-		},
-		"110": {
-			"sourceFileName": "src/lib/policyCore/bundledPolicy/types.ts",
-			"qualifiedName": "__type.vincentPolicy"
-		},
-		"112": {
-			"sourceFileName": "src/lib/policyCore/bundledPolicy/types.ts",
-			"qualifiedName": "VP"
-		},
-		"113": {
-			"sourceFileName": "src/lib/policyCore/bundledPolicy/types.ts",
-			"qualifiedName": "IpfsCid"
-		},
-		"114": {
-			"sourceFileName": "src/lib/toolCore/bundledTool/types.ts",
-			"qualifiedName": "BundledVincentTool"
-		},
-		"115": {
-			"sourceFileName": "src/lib/toolCore/bundledTool/types.ts",
+		"146": {
+			"sourceFileName": "src/lib/policyCore/policyDef/types.ts",
 			"qualifiedName": "__type"
 		},
-		"116": {
-			"sourceFileName": "src/lib/toolCore/bundledTool/types.ts",
-			"qualifiedName": "__type.ipfsCid"
+		"147": {
+			"sourceFileName": "src/lib/policyCore/policyDef/types.ts",
+			"qualifiedName": "args"
 		},
-		"117": {
-			"sourceFileName": "src/lib/toolCore/bundledTool/types.ts",
-			"qualifiedName": "__type.vincentTool"
-		},
-		"119": {
-			"sourceFileName": "src/lib/toolCore/bundledTool/types.ts",
-			"qualifiedName": "VT"
-		},
-		"120": {
-			"sourceFileName": "src/lib/toolCore/bundledTool/types.ts",
-			"qualifiedName": "IpfsCid"
-		},
-		"121": {
-			"sourceFileName": "src/lib/types.ts",
-			"qualifiedName": "VincentToolPolicy"
-		},
-		"122": {
-			"sourceFileName": "src/lib/types.ts",
+		"148": {
+			"sourceFileName": "src/lib/policyCore/policyDef/types.ts",
 			"qualifiedName": "__type"
 		},
-		"123": {
-			"sourceFileName": "src/lib/types.ts",
-			"qualifiedName": "__type.ipfsCid"
+		"149": {
+			"sourceFileName": "src/lib/policyCore/policyDef/types.ts",
+			"qualifiedName": "__type.toolParams"
 		},
-		"124": {
-			"sourceFileName": "src/lib/types.ts",
-			"qualifiedName": "__type.vincentPolicy"
+		"150": {
+			"sourceFileName": "src/lib/policyCore/policyDef/types.ts",
+			"qualifiedName": "__type.userParams"
 		},
-		"125": {
-			"sourceFileName": "src/lib/types.ts",
-			"qualifiedName": "__type"
+		"151": {
+			"sourceFileName": "src/lib/policyCore/policyDef/types.ts",
+			"qualifiedName": "ctx"
 		},
-		"126": {
-			"sourceFileName": "src/lib/types.ts",
-			"qualifiedName": "__type.packageName"
+		"152": {
+			"sourceFileName": "src/lib/policyCore/policyDef/types.ts",
+			"qualifiedName": "ToolParams"
 		},
-		"127": {
-			"sourceFileName": "src/lib/types.ts",
-			"qualifiedName": "__type.toolParameterMappings"
+		"153": {
+			"sourceFileName": "src/lib/policyCore/policyDef/types.ts",
+			"qualifiedName": "UserParams"
 		},
-		"140": {
-			"sourceFileName": "src/lib/types.ts",
-			"qualifiedName": "ToolParamsSchema"
+		"154": {
+			"sourceFileName": "src/lib/policyCore/policyDef/types.ts",
+			"qualifiedName": "AllowResult"
 		},
-		"141": {
-			"sourceFileName": "src/lib/types.ts",
-			"qualifiedName": "VP"
-		},
-		"142": {
-			"sourceFileName": "src/lib/types.ts",
-			"qualifiedName": "PackageName"
-		},
-		"143": {
-			"sourceFileName": "src/lib/types.ts",
-			"qualifiedName": "IpfsCid"
+		"155": {
+			"sourceFileName": "src/lib/policyCore/policyDef/types.ts",
+			"qualifiedName": "DenyResult"
 		},
 		"156": {
-			"sourceFileName": "src/lib/types.ts",
-			"qualifiedName": "PolicyEvaluationResultContext"
+			"sourceFileName": "src/lib/policyCore/policyDef/types.ts",
+			"qualifiedName": "PolicyDefCommitFunction"
 		},
 		"157": {
-			"sourceFileName": "src/lib/types.ts",
+			"sourceFileName": "src/lib/policyCore/policyDef/types.ts",
 			"qualifiedName": "__type"
 		},
 		"158": {
-			"sourceFileName": "src/lib/types.ts",
-			"qualifiedName": "__type.evaluatedPolicies"
+			"sourceFileName": "src/lib/policyCore/policyDef/types.ts",
+			"qualifiedName": "__type"
 		},
 		"159": {
-			"sourceFileName": "src/lib/types.ts",
-			"qualifiedName": "__type"
+			"sourceFileName": "src/lib/policyCore/policyDef/types.ts",
+			"qualifiedName": "args"
 		},
 		"160": {
-			"sourceFileName": "src/lib/types.ts",
-			"qualifiedName": "__type.allow"
+			"sourceFileName": "src/lib/policyCore/policyDef/types.ts",
+			"qualifiedName": "context"
 		},
 		"161": {
-			"sourceFileName": "src/lib/types.ts",
-			"qualifiedName": "__type.allowedPolicies"
+			"sourceFileName": "src/lib/policyCore/policyDef/types.ts",
+			"qualifiedName": "CommitParams"
 		},
 		"162": {
-			"sourceFileName": "src/lib/types.ts",
-			"qualifiedName": "__type"
+			"sourceFileName": "src/lib/policyCore/policyDef/types.ts",
+			"qualifiedName": "CommitAllowResult"
 		},
 		"163": {
-			"sourceFileName": "src/lib/types.ts",
-			"qualifiedName": "__type.result"
+			"sourceFileName": "src/lib/policyCore/policyDef/types.ts",
+			"qualifiedName": "CommitDenyResult"
 		},
 		"164": {
-			"sourceFileName": "src/lib/types.ts",
-			"qualifiedName": "__type"
+			"sourceFileName": "src/lib/policyCore/policyDef/context/types.ts",
+			"qualifiedName": "PolicyContext"
 		},
 		"165": {
-			"sourceFileName": "src/lib/types.ts",
-			"qualifiedName": "__type.evalAllowResultSchema"
+			"sourceFileName": "src/lib/policyCore/policyDef/context/types.ts",
+			"qualifiedName": "PolicyContext.allow"
 		},
 		"166": {
-			"sourceFileName": "src/lib/types.ts",
-			"qualifiedName": "__type.deniedPolicy"
+			"sourceFileName": "src/lib/policyCore/policyDef/context/types.ts",
+			"qualifiedName": "__type"
 		},
 		"167": {
-			"sourceFileName": "src/lib/types.ts",
+			"sourceFileName": "src/lib/policyCore/policyDef/context/types.ts",
 			"qualifiedName": "__type"
 		},
 		"168": {
-			"sourceFileName": "src/lib/types.ts",
-			"qualifiedName": "__type.allow"
-		},
-		"169": {
-			"sourceFileName": "src/lib/types.ts",
-			"qualifiedName": "__type.deniedPolicy"
-		},
-		"170": {
-			"sourceFileName": "src/lib/types.ts",
+			"sourceFileName": "src/lib/policyCore/policyDef/context/types.ts",
 			"qualifiedName": "__type"
 		},
+		"169": {
+			"sourceFileName": "src/lib/policyCore/policyDef/context/types.ts",
+			"qualifiedName": "__type"
+		},
+		"170": {
+			"sourceFileName": "src/lib/policyCore/policyDef/context/types.ts",
+			"qualifiedName": "result"
+		},
 		"171": {
-			"sourceFileName": "src/lib/types.ts",
-			"qualifiedName": "__type.packageName"
+			"sourceFileName": "src/lib/policyCore/policyDef/context/types.ts",
+			"qualifiedName": "PolicyContext.deny"
 		},
 		"172": {
-			"sourceFileName": "src/lib/types.ts",
-			"qualifiedName": "__type.result"
+			"sourceFileName": "src/lib/policyCore/policyDef/context/types.ts",
+			"qualifiedName": "__type"
 		},
 		"173": {
-			"sourceFileName": "src/lib/types.ts",
+			"sourceFileName": "src/lib/policyCore/policyDef/context/types.ts",
 			"qualifiedName": "__type"
 		},
 		"174": {
-			"sourceFileName": "src/lib/types.ts",
-			"qualifiedName": "__type.error"
+			"sourceFileName": "src/lib/policyCore/policyDef/context/types.ts",
+			"qualifiedName": "error"
 		},
 		"175": {
-			"sourceFileName": "src/lib/types.ts",
+			"sourceFileName": "src/lib/policyCore/policyDef/context/types.ts",
 			"qualifiedName": "__type"
 		},
 		"176": {
-			"sourceFileName": "src/lib/types.ts",
-			"qualifiedName": "__type.evalDenyResultSchema"
+			"sourceFileName": "src/lib/policyCore/policyDef/context/types.ts",
+			"qualifiedName": "__type"
 		},
 		"177": {
-			"sourceFileName": "src/lib/types.ts",
-			"qualifiedName": "__type.allowedPolicies"
+			"sourceFileName": "src/lib/policyCore/policyDef/context/types.ts",
+			"qualifiedName": "result"
 		},
 		"178": {
-			"sourceFileName": "src/lib/types.ts",
-			"qualifiedName": "__type"
+			"sourceFileName": "src/lib/policyCore/policyDef/context/types.ts",
+			"qualifiedName": "error"
 		},
 		"179": {
 			"sourceFileName": "src/lib/types.ts",
-			"qualifiedName": "__type.result"
+			"qualifiedName": "BaseContext.toolIpfsCid"
 		},
 		"180": {
 			"sourceFileName": "src/lib/types.ts",
-			"qualifiedName": "__type"
+			"qualifiedName": "BaseContext.appId"
 		},
 		"181": {
 			"sourceFileName": "src/lib/types.ts",
-			"qualifiedName": "__type.evalAllowResultSchema"
+			"qualifiedName": "BaseContext.appVersion"
 		},
 		"182": {
 			"sourceFileName": "src/lib/types.ts",
-			"qualifiedName": "Policies"
+			"qualifiedName": "BaseContext.delegation"
 		},
 		"183": {
 			"sourceFileName": "src/lib/types.ts",
@@ -7690,129 +6398,89 @@
 		},
 		"184": {
 			"sourceFileName": "src/lib/types.ts",
-			"qualifiedName": "__type.vincentPolicy"
-		},
-		"195": {
-			"sourceFileName": "src/lib/types.ts",
-			"qualifiedName": "VincentTool"
-		},
-		"196": {
-			"sourceFileName": "src/lib/types.ts",
-			"qualifiedName": "__type"
-		},
-		"197": {
-			"sourceFileName": "src/lib/types.ts",
-			"qualifiedName": "__type.packageName"
-		},
-		"198": {
-			"sourceFileName": "src/lib/types.ts",
-			"qualifiedName": "__type.precheck"
-		},
-		"199": {
-			"sourceFileName": "src/lib/types.ts",
-			"qualifiedName": "__type.execute"
-		},
-		"200": {
-			"sourceFileName": "src/lib/types.ts",
-			"qualifiedName": "__type.toolParamsSchema"
-		},
-		"201": {
-			"sourceFileName": "src/lib/types.ts",
-			"qualifiedName": "__type.supportedPolicies"
-		},
-		"208": {
-			"sourceFileName": "src/lib/types.ts",
-			"qualifiedName": "ToolParamsSchema"
-		},
-		"209": {
-			"sourceFileName": "src/lib/types.ts",
-			"qualifiedName": "PkgNames"
-		},
-		"210": {
-			"sourceFileName": "src/lib/types.ts",
-			"qualifiedName": "PolicyMap"
-		},
-		"211": {
-			"sourceFileName": "src/lib/types.ts",
-			"qualifiedName": "PoliciesByPackageName"
-		},
-		"212": {
-			"sourceFileName": "src/lib/types.ts",
-			"qualifiedName": "ExecuteSuccessSchema"
-		},
-		"213": {
-			"sourceFileName": "src/lib/types.ts",
-			"qualifiedName": "ExecuteFailSchema"
-		},
-		"214": {
-			"sourceFileName": "src/lib/types.ts",
-			"qualifiedName": "PrecheckSuccessSchema"
-		},
-		"215": {
-			"sourceFileName": "src/lib/types.ts",
-			"qualifiedName": "PrecheckFailSchema"
-		},
-		"216": {
-			"sourceFileName": "src/lib/types.ts",
-			"qualifiedName": "ExecuteFn"
-		},
-		"217": {
-			"sourceFileName": "src/lib/types.ts",
-			"qualifiedName": "PrecheckFn"
-		},
-		"223": {
-			"sourceFileName": "src/lib/toolCore/toolDef/context/types.ts",
-			"qualifiedName": "BaseToolContext"
-		},
-		"224": {
-			"sourceFileName": "src/lib/toolCore/toolDef/context/types.ts",
-			"qualifiedName": "BaseToolContext.policiesContext"
-		},
-		"225": {
-			"sourceFileName": "src/lib/types.ts",
-			"qualifiedName": "BaseContext.toolIpfsCid"
-		},
-		"226": {
-			"sourceFileName": "src/lib/types.ts",
-			"qualifiedName": "BaseContext.appId"
-		},
-		"227": {
-			"sourceFileName": "src/lib/types.ts",
-			"qualifiedName": "BaseContext.appVersion"
-		},
-		"228": {
-			"sourceFileName": "src/lib/types.ts",
-			"qualifiedName": "BaseContext.delegation"
-		},
-		"229": {
-			"sourceFileName": "src/lib/types.ts",
-			"qualifiedName": "__type"
-		},
-		"230": {
-			"sourceFileName": "src/lib/types.ts",
 			"qualifiedName": "__type.delegateeAddress"
 		},
-		"231": {
+		"185": {
 			"sourceFileName": "src/lib/types.ts",
 			"qualifiedName": "__type.delegatorPkpInfo"
 		},
-		"232": {
+		"186": {
 			"sourceFileName": "src/lib/types.ts",
 			"qualifiedName": "__type"
 		},
-		"233": {
+		"187": {
 			"sourceFileName": "src/lib/types.ts",
 			"qualifiedName": "__type.tokenId"
 		},
-		"234": {
+		"188": {
 			"sourceFileName": "src/lib/types.ts",
 			"qualifiedName": "__type.ethAddress"
 		},
-		"235": {
+		"189": {
 			"sourceFileName": "src/lib/types.ts",
 			"qualifiedName": "__type.publicKey"
 		},
-		"236": {
+		"190": {
+			"sourceFileName": "src/lib/policyCore/policyDef/context/types.ts",
+			"qualifiedName": "PolicyContext.AllowSchema"
+		},
+		"191": {
+			"sourceFileName": "src/lib/policyCore/policyDef/context/types.ts",
+			"qualifiedName": "PolicyContext.DenySchema"
+		},
+		"294": {
+			"sourceFileName": "src/lib/toolCore/toolDef/context/types.ts",
+			"qualifiedName": "BaseToolContext"
+		},
+		"295": {
+			"sourceFileName": "src/lib/toolCore/toolDef/context/types.ts",
+			"qualifiedName": "BaseToolContext.policiesContext"
+		},
+		"296": {
+			"sourceFileName": "src/lib/types.ts",
+			"qualifiedName": "BaseContext.toolIpfsCid"
+		},
+		"297": {
+			"sourceFileName": "src/lib/types.ts",
+			"qualifiedName": "BaseContext.appId"
+		},
+		"298": {
+			"sourceFileName": "src/lib/types.ts",
+			"qualifiedName": "BaseContext.appVersion"
+		},
+		"299": {
+			"sourceFileName": "src/lib/types.ts",
+			"qualifiedName": "BaseContext.delegation"
+		},
+		"300": {
+			"sourceFileName": "src/lib/types.ts",
+			"qualifiedName": "__type"
+		},
+		"301": {
+			"sourceFileName": "src/lib/types.ts",
+			"qualifiedName": "__type.delegateeAddress"
+		},
+		"302": {
+			"sourceFileName": "src/lib/types.ts",
+			"qualifiedName": "__type.delegatorPkpInfo"
+		},
+		"303": {
+			"sourceFileName": "src/lib/types.ts",
+			"qualifiedName": "__type"
+		},
+		"304": {
+			"sourceFileName": "src/lib/types.ts",
+			"qualifiedName": "__type.tokenId"
+		},
+		"305": {
+			"sourceFileName": "src/lib/types.ts",
+			"qualifiedName": "__type.ethAddress"
+		},
+		"306": {
+			"sourceFileName": "src/lib/types.ts",
+			"qualifiedName": "__type.publicKey"
+		},
+		"307": {
 			"sourceFileName": "src/lib/toolCore/toolDef/context/types.ts",
 			"qualifiedName": "BaseToolContext.Policies"
 		}

--- a/packages/libs/tool-sdk/src/index.ts
+++ b/packages/libs/tool-sdk/src/index.ts
@@ -10,6 +10,11 @@ export { supportedPoliciesForTool } from './lib/toolCore/helpers/supportedPolici
 
 export type { BundledVincentPolicy } from './lib/policyCore/bundledPolicy/types';
 export type { BundledVincentTool } from './lib/toolCore/bundledTool/types';
+export type {
+  PolicyDefLifecycleFunction,
+  PolicyDefCommitFunction,
+} from './lib/policyCore/policyDef/types';
+export type { PolicyContext } from './lib/policyCore/policyDef/context/types';
 
 export type {
   VincentToolPolicy,

--- a/packages/libs/tool-sdk/src/lib/handlers/vincentPolicyHandler.ts
+++ b/packages/libs/tool-sdk/src/lib/handlers/vincentPolicyHandler.ts
@@ -29,6 +29,7 @@ const bigintReplacer = (key: any, value: any) => {
   return typeof value === 'bigint' ? value.toString() : value;
 };
 
+/** @hidden */
 export async function vincentPolicyHandler<
   PackageName extends string,
   PolicyToolParams extends z.ZodType,

--- a/packages/libs/tool-sdk/src/lib/handlers/vincentToolHandler.ts
+++ b/packages/libs/tool-sdk/src/lib/handlers/vincentToolHandler.ts
@@ -101,6 +101,7 @@ export function createToolExecutionContext<
   return newContext;
 }
 
+/** @hidden */
 export const vincentToolHandler = <
   ToolParamsSchema extends z.ZodType,
   PkgNames extends string,

--- a/packages/libs/tool-sdk/src/lib/policyCore/bundledPolicy/bundledPolicy.ts
+++ b/packages/libs/tool-sdk/src/lib/policyCore/bundledPolicy/bundledPolicy.ts
@@ -3,6 +3,7 @@
 import { __bundledPolicyBrand, BundledVincentPolicy } from './types';
 import { VincentPolicy } from '../../types';
 
+/** @hidden */
 export function asBundledVincentPolicy<
   const VP extends VincentPolicy<any, any, any, any, any, any, any, any, any, any, any, any, any>,
   const IpfsCid extends string,
@@ -11,5 +12,5 @@ export function asBundledVincentPolicy<
     ipfsCid,
     vincentPolicy,
     [__bundledPolicyBrand]: 'BundledVincentPolicy',
-  } as BundledVincentPolicy<VP, IpfsCid>;
+  };
 }

--- a/packages/libs/tool-sdk/src/lib/policyCore/bundledPolicy/types.ts
+++ b/packages/libs/tool-sdk/src/lib/policyCore/bundledPolicy/types.ts
@@ -10,6 +10,8 @@ export type __bundledPolicyBrand = typeof __bundledPolicyBrand;
 /**
  * A VincentPolicy bundled with an IPFS CID and uniquely branded.
  * This ensures only correctly constructed objects are assignable.
+ *
+ *  @hidden
  */
 export type BundledVincentPolicy<
   VP extends VincentPolicy<any, any, any, any, any, any, any, any, any, any, any, any, any>,

--- a/packages/libs/tool-sdk/src/lib/policyCore/policyDef/context/types.ts
+++ b/packages/libs/tool-sdk/src/lib/policyCore/policyDef/context/types.ts
@@ -33,6 +33,10 @@ export type ContextDenyResponse<DenyResult> = MustCallContextAllowOrDeny<
 >;
 export type ContextDenyResponseNoResult = MustCallContextAllowOrDeny<PolicyResponseDenyNoResult>;
 
+/**
+ * @expand
+ * @category Interfaces
+ * */
 export interface PolicyContext<
   AllowSchema extends z.ZodType = z.ZodUndefined,
   DenySchema extends z.ZodType = z.ZodUndefined,

--- a/packages/libs/tool-sdk/src/lib/policyCore/policyDef/types.ts
+++ b/packages/libs/tool-sdk/src/lib/policyCore/policyDef/types.ts
@@ -8,6 +8,11 @@ import {
   PolicyContext,
 } from './context/types';
 
+/** `evaluate()` and `precheck()` functions that you define when using `createVincentPolicy()` will match this function signature.
+ * Note that the arguments and return types are inferred based on the ZOD schemas that you pass to `createVincentPolicy`
+ *
+ * @category Interfaces
+ */
 export type PolicyDefLifecycleFunction<
   ToolParams extends z.ZodType,
   UserParams extends z.ZodType = z.ZodUndefined,
@@ -29,6 +34,12 @@ export type PolicyDefLifecycleFunction<
         : ContextDenyResponse<z.infer<DenyResult>>)
   >
 >;
+
+/** Unlike `evaluate()` and `precheck()`, commit receives specific arguments provided by the tool during its `execute()` phase
+ * instead of than `toolParams` and `userParams` that the tool was called with.
+ *
+ * @category Interfaces
+ */
 export type PolicyDefCommitFunction<
   CommitParams extends z.ZodType = z.ZodUndefined,
   CommitAllowResult extends z.ZodType = z.ZodUndefined,
@@ -47,6 +58,7 @@ export type PolicyDefCommitFunction<
   >
 >;
 
+/** @inline */
 export type VincentPolicyDef<
   PackageName extends string,
   PolicyToolParams extends z.ZodType,

--- a/packages/libs/tool-sdk/src/lib/policyCore/vincentPolicy.ts
+++ b/packages/libs/tool-sdk/src/lib/policyCore/vincentPolicy.ts
@@ -28,9 +28,10 @@ import { createAllowResult, returnNoResultDeny, wrapAllow } from './helpers/resu
 import { BundledVincentPolicy } from './bundledPolicy/types';
 
 /**
- * Wraps a raw VincentPolicyDef with internal logic and returns a fully typed
- * policy object, preserving inference for all lifecycle methods (`evaluate`, `precheck`, `commit`)
- * and providing metadata such as `ipfsCid` and `packageName`.
+ * The `createVincentPolicy()` method is used to define a policy's lifecycle methods and ensure that arguments provided to the tool's
+ * lifecycle methods, as well as their return values, are validated and fully type-safe by defining ZOD schemas for them.
+ *
+ * @category API Methods
  */
 export function createVincentPolicy<
   PackageName extends string,
@@ -295,9 +296,31 @@ export function createVincentPolicy<
 }
 
 /**
- * Adapts a single policy to a specific tool by applying parameter mappings.
- * This allows the policy's schema-defined params to be inferred and automatically
- * extracted from the tool's input params. Also attaches schema metadata for result typing.
+ * `createVincentToolPolicy()` is used to bind a policy to a specific tool. You must provide a `toolParameterMappings` argument
+ * which instructs the tool which of its toolParams should be passed to the Vincent Policy during evaluation, and
+ * defines what the argument passed to the tool should be.
+ *
+ * For example, a Tool might receive an argument called `tokenInAmount`, but it may need to pass that as `buyAmount` to a
+ * policy that uses the `tokenInAmount` for its own purposes.
+ *
+ * ```typescript
+ * import { bundledVincentPolicy } from '@lit-protocol/vincent-policy-spending-limit';
+ *
+ * const SpendingLimitPolicy = createVincentToolPolicy({
+ *   toolParamsSchema,
+ *   bundledVincentPolicy,
+ *   toolParameterMappings: {
+ *     rpcUrlForUniswap: 'rpcUrlForUniswap',
+ *     chainIdForUniswap: 'chainIdForUniswap',
+ *     ethRpcUrl: 'ethRpcUrl',
+ *     tokenInAddress: 'tokenAddress',
+ *     tokenInDecimals: 'tokenDecimals',
+ *     tokenInAmount: 'buyAmount',
+ *   },
+ * });
+ * ```
+ *
+ * @category API Methods
  */
 export function createVincentToolPolicy<
   const PackageName extends string,
@@ -350,6 +373,7 @@ export function createVincentToolPolicy<
     ipfsCid,
     toolParameterMappings: config.toolParameterMappings,
     // Explicitly include schema types in the returned object for type inference
+    /** @hidden */
     __schemaTypes: {
       evalAllowResultSchema: vincentPolicy.evalAllowResultSchema,
       evalDenyResultSchema: vincentPolicy.evalDenyResultSchema,
@@ -370,6 +394,7 @@ export function createVincentToolPolicy<
     vincentPolicy: typeof vincentPolicy;
     ipfsCid: typeof ipfsCid;
     toolParameterMappings: typeof config.toolParameterMappings;
+    /* @hidden */
     __schemaTypes: {
       evalAllowResultSchema: EvalAllowResult;
       evalDenyResultSchema: EvalDenyResult;

--- a/packages/libs/tool-sdk/src/lib/toolCore/bundledTool/bundledTool.ts
+++ b/packages/libs/tool-sdk/src/lib/toolCore/bundledTool/bundledTool.ts
@@ -3,6 +3,7 @@
 import { __bundledToolBrand, BundledVincentTool } from './types';
 import { VincentTool } from '../../types';
 
+/** @hidden */
 export function asBundledVincentTool<
   const VT extends VincentTool<any, any, any, any, any, any, any, any, any, any>,
   const IpfsCid extends string,

--- a/packages/libs/tool-sdk/src/lib/toolCore/bundledTool/types.ts
+++ b/packages/libs/tool-sdk/src/lib/toolCore/bundledTool/types.ts
@@ -10,6 +10,8 @@ export type __bundledToolBrand = typeof __bundledToolBrand;
 /**
  * A VincentTool bundled with an IPFS CID and uniquely branded.
  * This ensures only correctly constructed objects are assignable.
+ *
+ * @hidden
  */
 export type BundledVincentTool<
   VT extends VincentTool<any, any, any, any, any, any, any, any, any, any>,

--- a/packages/libs/tool-sdk/src/lib/toolCore/helpers/supportedPoliciesForTool.ts
+++ b/packages/libs/tool-sdk/src/lib/toolCore/helpers/supportedPoliciesForTool.ts
@@ -1,5 +1,7 @@
 // src/lib/toolCore/helpers/supportedPoliciesForTool.ts
 
+import { VincentPolicy } from '../../types';
+
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
 export type ToolPolicyMap<T extends readonly any[], PkgNames extends string> = {
@@ -12,14 +14,46 @@ export type ToolPolicyMap<T extends readonly any[], PkgNames extends string> = {
 };
 
 /**
- * Safely builds a strongly typed policy map from an array of VincentToolPolicy entries.
- * Enforces literal string `packageName` keys and exposes reverse lookup maps.
+ * `supportedPoliciesForTool()` takes an array of bundled Vincent Policies, and provides strong type inference for those policies
+ * inside of your VincentTool's lifecycle functions and return values.
+ *
+ * ```typescript
+ * import { bundledVincentPolicy } from '@lit-protocol/vincent-policy-spending-limit';
+ *
+ * const SpendingLimitPolicy = createVincentToolPolicy({
+ *   toolParamsSchema,
+ *   bundledVincentPolicy,
+ *   toolParameterMappings: {
+ *     rpcUrlForUniswap: 'rpcUrlForUniswap',
+ *     chainIdForUniswap: 'chainIdForUniswap',
+ *     ethRpcUrl: 'ethRpcUrl',
+ *     tokenInAddress: 'tokenAddress',
+ *     tokenInDecimals: 'tokenDecimals',
+ *     tokenInAmount: 'buyAmount',
+ *   },
+ * });
+ *
+ *
+ * export const vincentTool = createVincentTool({
+ *   packageName: '@lit-protocol/vincent-tool-uniswap-swap' as const,
+ *
+ *   toolParamsSchema,
+ *   supportedPolicies: supportedPoliciesForTool([SpendingLimitPolicy]),
+ *
+ *   ...
+ *
+ *   });
+ * ```
+ *
+ * @category API Methods
+ * @inlineType VincentPolicy
  */
 export function supportedPoliciesForTool<
   const Policies extends readonly {
-    vincentPolicy: { packageName: string };
-    ipfsCid: string;
+    vincentPolicy: VincentPolicy<any, any, any, any, any, any, any, any, any, any, any, any, any>;
+    ipfsCid: IpfsCid;
   }[],
+  const IpfsCid extends string = string,
   const PkgNames extends
     Policies[number]['vincentPolicy']['packageName'] = Policies[number]['vincentPolicy']['packageName'],
 >(policies: Policies): ToolPolicyMap<Policies, PkgNames> {

--- a/packages/libs/tool-sdk/src/lib/toolCore/toolDef/context/types.ts
+++ b/packages/libs/tool-sdk/src/lib/toolCore/toolDef/context/types.ts
@@ -9,6 +9,11 @@ import {
   ToolResultSuccessNoResult,
 } from '../../../types';
 
+/** BaseToolContext is returned with tool execution results, and contains information about the app, delegation, and
+ * policy evaluation results for any policies that the user had enabled for the tool.
+ *
+ * @category Interfaces
+ */
 export interface BaseToolContext<Policies> extends BaseContext {
   policiesContext: Policies;
 }

--- a/packages/libs/tool-sdk/src/lib/toolCore/toolDef/types.ts
+++ b/packages/libs/tool-sdk/src/lib/toolCore/toolDef/types.ts
@@ -19,6 +19,7 @@ export type ToolDefLifecycleFunction<
   EnforceToolResult<ContextSuccess<z.infer<SuccessSchema>> | ContextFailure<z.infer<FailSchema>>>
 >;
 
+/** @inline */
 export type VincentToolDef<
   ToolParamsSchema extends z.ZodType,
   PkgNames extends string,

--- a/packages/libs/tool-sdk/src/lib/toolCore/vincentTool.ts
+++ b/packages/libs/tool-sdk/src/lib/toolCore/vincentTool.ts
@@ -21,9 +21,42 @@ import { ToolDefLifecycleFunction, VincentToolDef } from './toolDef/types';
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
 /**
- * Wraps a VincentToolDef object and returns a fully typed tool with
- * standard lifecycle entrypoints (`precheck`, `execute`) and strong inference
- * based on schemas and supported policies.
+ * The `createVincentTool()` method is used to define a tool's lifecycle methods and ensure that arguments provided to the tool's
+ * lifecycle methods, as well as their return values, are validated and fully type-safe by defining ZOD schemas for them.
+ *
+ *```typescript
+ * const exampleSimpleTool = createVincentTool({
+ *     packageName: '@lit-protocol/yestool@1.0.0',
+ *     toolParamsSchema: testSchema,
+ *     supportedPolicies: supportedPoliciesForTool([testPolicy]),
+ *
+ *     precheck: async (params, { succeed, fail }) => {
+ *       // Should allow succeed() with no arguments
+ *       succeed();
+ *
+ *       // Should allow fail() with string error
+ *       fail('Error message');
+ *
+ *       // @ts-expect-error - Should not allow succeed() with arguments when no schema
+ *       succeed({ message: 'test' });
+ *
+ *       // @ts-expect-error - Should not allow fail() with object when no schema
+ *       fail({ error: 'test' });
+ *
+ *       return succeed();
+ *     },
+ *
+ *     execute: async (params, { succeed }) => {
+ *       // Should allow succeed() with no arguments
+ *       succeed();
+ *
+ *       // @ts-expect-error - Should not allow succeed() with arguments when no schema
+ *       return succeed({ data: 'test' });
+ *     },
+ *   });
+ * ```
+ *
+ * @category API Methods
  */
 export function createVincentTool<
   ToolParamsSchema extends z.ZodType,

--- a/packages/libs/tool-sdk/src/lib/types.ts
+++ b/packages/libs/tool-sdk/src/lib/types.ts
@@ -71,9 +71,10 @@ export type PolicyLifecycleFunction<
 export type InferOrUndefined<T> = T extends z.ZodType ? z.infer<T> : undefined;
 
 // Tool supported policy with proper typing on the parameter mappings
+/** @hidden */
 export type VincentToolPolicy<
   ToolParamsSchema extends z.ZodType,
-  VP extends VincentPolicy<any, any, any, any, any, any, any, any, any, any>,
+  VP extends VincentPolicy<any, any, any, any, any, any, any, any, any, any, any, any, any>,
   PackageName extends string = string,
   IpfsCid extends string = string,
 > = {
@@ -113,6 +114,7 @@ export type CommitLifecycleFunction<
       : PolicyResponseDenyNoResult)
 >;
 
+/** @inline */
 export type VincentPolicy<
   PackageName extends string,
   PolicyToolParams extends z.ZodType,
@@ -155,6 +157,7 @@ export type VincentPolicy<
   commit?: CommitFn;
 };
 
+/** @hidden */
 export type PolicyEvaluationResultContext<
   Policies extends Record<
     string,
@@ -354,6 +357,7 @@ export type ToolLifecycleFunction<
   context: BaseToolContext<Policies>,
 ) => Promise<ToolResult<SuccessSchema, FailSchema>>;
 
+/** @hidden */
 export type VincentTool<
   ToolParamsSchema extends z.ZodType,
   PkgNames extends string,

--- a/packages/libs/tool-sdk/typedoc-configs/base.config.js
+++ b/packages/libs/tool-sdk/typedoc-configs/base.config.js
@@ -8,8 +8,8 @@ module.exports = {
   navigation: {
     includeCategories: true,
   },
-  defaultCategory: 'API',
   categorizeByGroup: false,
-  // categoryOrder: ['vincent-tool-sdk'],
+  categoryOrder: ['API Methods', 'Interfaces'],
   visibilityFilters: {},
+  sort: 'source-order',
 };


### PR DESCRIPTION
# Description
Just some docs updates for clarity, to reduce verbosity, and grouping the docs together by API methods vs. interfaces

