### PR TITLE
Add `Vincent is in Alpha` warning

### DIFF
--- a/docs/custom.css
+++ b/docs/custom.css
@@ -60,3 +60,66 @@
   text-indent: -9999px;
   overflow: hidden;
 }
+
+/* Warning box styling */
+.warning-box {
+  background-color: #fff3cd;
+  border-left: 8px solid #f39c12;
+  padding: 15px;
+  margin-bottom: 20px;
+  border-radius: 4px;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.05);
+}
+
+/* Dark theme overrides */
+[data-theme='dark'] .warning-box {
+  background-color: #2d1f0f;
+  border-left: 8px solid #f1c40f;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
+}
+
+/* OS theme overrides */
+@media (prefers-color-scheme: dark) {
+  .warning-box {
+    background-color: #2d1f0f;
+    border-left: 8px solid #f1c40f;
+    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
+  }
+}
+
+/* Warning box title */
+.warning-box-title {
+  color: #d68910;
+  font-weight: 700;
+  font-size: 1rem;
+  margin-top: 0;
+  margin-bottom: 8px;
+  display: flex;
+  align-items: center;
+}
+
+/* Dark theme title override */
+[data-theme='dark'] .warning-box-title {
+  color: #f1c40f;
+}
+
+/* OS theme title overrides */
+@media (prefers-color-scheme: dark) {
+  .warning-box-title {
+    color: #f1c40f;
+  }
+}
+
+/* Warning icon - using inline SVG data URI */
+.warning-icon {
+  display: inline-block;
+  width: 20px;
+  height: 20px;
+  margin-right: 8px;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' width='24' height='24'%3E%3Cpath d='M12 2L1.5 21h21L12 2z' fill='%23f39c12'/%3E%3Cpath d='M12 8v6' stroke='white' stroke-width='2' stroke-linecap='round'/%3E%3Ccircle cx='12' cy='18' r='1' fill='white'/%3E%3C/svg%3E");
+  background-size: contain;
+  background-repeat: no-repeat;
+  background-position: center;
+  text-indent: -9999px;
+  overflow: hidden;
+}

--- a/docs/custom.css
+++ b/docs/custom.css
@@ -1,125 +1,90 @@
-/* Info box styling */
-.info-box {
-  background-color: #eef9fd;
-  border-left: 8px solid #3498db;
+/* Common box styling */
+.box {
   padding: 15px;
   margin-bottom: 20px;
   border-radius: 4px;
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.05);
+  border-left: 8px solid;
 }
 
-/* Dark theme overrides */
-[data-theme='dark'] .info-box {
-  background-color: #1a2b3c;
-  border-left: 8px solid #4a9eff;
+/* Dark theme box overrides */
+[data-theme='dark'] .box {
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
 }
 
-/* OS theme overrides */
-@media (prefers-color-scheme: dark) {
-  .info-box {
-    background-color: #1a2b3c;
-    border-left: 8px solid #4a9eff;
-    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
-  }
+/* Box title common styling */
+.box-title {
+  font-weight: 700;
+  font-size: 1rem;
+  margin-top: 0;
+  margin-bottom: 8px;
+  display: flex;
+  align-items: center;
+}
+
+/* Common icon styling */
+.box-icon {
+  display: inline-block;
+  width: 20px;
+  height: 20px;
+  margin-right: 8px;
+  background-size: contain;
+  background-repeat: no-repeat;
+  background-position: center;
+  text-indent: -9999px;
+  overflow: hidden;
+}
+
+/* Info box styling */
+.info-box {
+  background-color: #eef9fd;
+  border-left-color: #3498db;
+}
+
+/* Dark theme info box overrides */
+[data-theme='dark'] .info-box {
+  background-color: #1a2b3c;
+  border-left-color: #4a9eff;
 }
 
 /* Info box title */
 .info-box-title {
   color: #2980b9;
-  font-weight: 700;
-  font-size: 1rem;
-  margin-top: 0;
-  margin-bottom: 8px;
-  display: flex;
-  align-items: center;
 }
 
-/* Dark theme title override */
+/* Dark theme info title override */
 [data-theme='dark'] .info-box-title {
   color: #4a9eff;
 }
 
-/* OS theme title overrides */
-@media (prefers-color-scheme: dark) {
-  .info-box-title {
-    color: #4a9eff;
-  }
-}
-
 /* Info icon - using inline SVG data URI */
 .info-icon {
-  display: inline-block;
-  width: 20px;
-  height: 20px;
-  margin-right: 8px;
   background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' width='24' height='24'%3E%3Ccircle cx='12' cy='12' r='10' fill='%233498db'/%3E%3Ccircle cx='12' cy='7' r='1.5' fill='white'/%3E%3Crect x='10.5' y='10' width='3' height='7' rx='1.5' fill='white'/%3E%3C/svg%3E");
-  background-size: contain;
-  background-repeat: no-repeat;
-  background-position: center;
-  text-indent: -9999px;
-  overflow: hidden;
 }
 
 /* Warning box styling */
 .warning-box {
   background-color: #fff3cd;
-  border-left: 8px solid #f39c12;
-  padding: 15px;
-  margin-bottom: 20px;
-  border-radius: 4px;
-  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.05);
+  border-left-color: #f39c12;
 }
 
-/* Dark theme overrides */
+/* Dark theme warning box overrides */
 [data-theme='dark'] .warning-box {
   background-color: #2d1f0f;
-  border-left: 8px solid #f1c40f;
-  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
-}
-
-/* OS theme overrides */
-@media (prefers-color-scheme: dark) {
-  .warning-box {
-    background-color: #2d1f0f;
-    border-left: 8px solid #f1c40f;
-    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
-  }
+  border-left-color: #f1c40f;
 }
 
 /* Warning box title */
 .warning-box-title {
   color: #d68910;
-  font-weight: 700;
-  font-size: 1rem;
-  margin-top: 0;
-  margin-bottom: 8px;
-  display: flex;
-  align-items: center;
 }
 
-/* Dark theme title override */
+/* Dark theme warning title override */
 [data-theme='dark'] .warning-box-title {
   color: #f1c40f;
 }
 
-/* OS theme title overrides */
-@media (prefers-color-scheme: dark) {
-  .warning-box-title {
-    color: #f1c40f;
-  }
-}
-
 /* Warning icon - using inline SVG data URI */
 .warning-icon {
-  display: inline-block;
-  width: 20px;
-  height: 20px;
-  margin-right: 8px;
   background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' width='24' height='24'%3E%3Cpath d='M12 2L1.5 21h21L12 2z' fill='%23f39c12'/%3E%3Cpath d='M12 8v6' stroke='white' stroke-width='2' stroke-linecap='round'/%3E%3Ccircle cx='12' cy='18' r='1' fill='white'/%3E%3C/svg%3E");
-  background-size: contain;
-  background-repeat: no-repeat;
-  background-position: center;
-  text-indent: -9999px;
-  overflow: hidden;
 }

--- a/docs/src/Developers/App-Agent-Developers/Creating-Apps.md
+++ b/docs/src/Developers/App-Agent-Developers/Creating-Apps.md
@@ -5,17 +5,17 @@ title: Creating Vincent Apps
 
 # How a Vincent App Works
 
-<div class="warning-box">
-  <div class="warning-box-title">
-    <span class="warning-icon">Warning</span> Vincent is in Alpha
-  </div>
+<div class="box warning-box">
+  <p class="box-title warning-box-title">
+    <span class="box-icon warning-icon">Warning</span> Vincent is in Alpha
+  </p>
   <p>The Vincent App Registry is under active development and is subject to change.</p>
   <p>Vincent Apps and their registered delegations created during the Alpha phase <strong>will not persist</strong> after the App Registry is finalized.</p>
 </div>
 
-<div class="info-box">
-  <p class="info-box-title">
-    <span class="info-icon">Info</span> Note
+<div class="box info-box">
+  <p class="box-title info-box-title">
+    <span class="box-icon info-icon">Info</span> Note
   </p>
   <p>In this guide, you'll create and register your first Vincent App using the <a href="https://dashboard.heyvincent.ai/">Vincent App Dashboard</a>. You’ll select from existing Vincent Tools and Policies, configure your App metadata, and register the App Delegatees whom are authorized to execute your App's Tools.</p>
   <p>If you're unfamiliar with what a Vincent App is, checkout the <a href="./Getting-Started.md">Getting Started</a> guide to learn more.</p>
@@ -47,8 +47,8 @@ Before registering your Vincent App, you’ll need to decide on the core compone
 Vincent Tools define the executable operations your App can perform on behalf of its Users such as swapping tokens, transferring assets, or querying APIs.
 
 <div class="info-box">
-  <p class="info-box-title">
-    <span class="info-icon">Info</span> Note
+  <p class="box-title info-box-title">
+    <span class="box-icon info-icon">Info</span> Note
   </p>
   <p>A Vincent Tool Registry that contains a list of all the available Vincent Tools and their associated Policies will be available soon.</p>
 
@@ -71,9 +71,9 @@ Additionally, you can checkout the [Creating a Vincent Tool](../Tool-Developers/
 
 Vincent Policies are programmable constraints that govern when and how each Vincent Tool can be executed.
 
-<div class="info-box">
-  <p class="info-box-title">
-    <span class="info-icon">Info</span> Note
+<div class="box info-box">
+  <p class="box-title info-box-title">
+    <span class="box-icon info-icon">Info</span> Note
   </p>
   <p>Similar to selecting which Vincent Tools you'd like your App to use, you'll need to manually copy and paste the IPFS CID of each Vincent Policy you'd like to use for each Tool into the Vincent App Dashboard when registering your App.</p>
   <p>The below table includes links to the IPFS CID of each Policy that will be automatically updated as new iterations of the Policy are published.</p>
@@ -89,9 +89,9 @@ Additionally, you can checkout the [Creating a Vincent Policy](../Policy-Develop
 
 # 3. Registering Your Vincent App
 
-<div class="info-box">
-  <p class="info-box-title">
-    <span class="info-icon">Info</span> Before registering your Vincent App
+<div class="box info-box">
+  <p class="box-title info-box-title">
+    <span class="box-icon info-icon">Info</span> Before registering your Vincent App
   </p>
   <p>Registering an App requires that you have tokens on Lit Protocol's Yellowstone blockchain to pay for gas. You can use <a href="https://chronicle-yellowstone-faucet.getlit.dev/">this faucet</a> to get the Lit test tokens used to pay for registering your App.</p>
 </div>

--- a/docs/src/Developers/App-Agent-Developers/Creating-Apps.md
+++ b/docs/src/Developers/App-Agent-Developers/Creating-Apps.md
@@ -5,6 +5,14 @@ title: Creating Vincent Apps
 
 # How a Vincent App Works
 
+<div class="warning-box">
+  <div class="warning-box-title">
+    <span class="warning-icon">Warning</span> Vincent is in Alpha
+  </div>
+  <p>The Vincent App Registry is under active development and is subject to change.</p>
+  <p>Vincent Apps and their registered delegations created during the Alpha phase <strong>will not persist</strong> after the App Registry is finalized.</p>
+</div>
+
 <div class="info-box">
   <p class="info-box-title">
     <span class="info-icon">Info</span> Note

--- a/docs/src/Developers/App-Agent-Developers/Executing-Tools.md
+++ b/docs/src/Developers/App-Agent-Developers/Executing-Tools.md
@@ -117,9 +117,9 @@ If `precheck` returns a failure result, you should check the `error` property on
 
 # Executing the Tool Client's `execute` function
 
-<div class="info-box">
-  <p class="info-box-title">
-    <span class="info-icon">Info</span> Before executing the Tool
+<div class="box info-box">
+  <p class="box-title info-box-title">
+    <span class="box-icon info-icon">Info</span> Before executing the Tool
   </p>
   <p>Executing a Tool using the Lit Protocol network requires a <a href="https://developer.litprotocol.com/paying-for-lit/capacity-credits">Lit Capacity Credit</a> minted for the Ethereum Address you're using for the `ethersSigner` when creating the Tool Client instance with `getVincentToolClient`.</p>
   <p>In order to mint a Capacity Credit, you'll need to have tokens on Lit Protocol's Yellowstone blockchain. You can use <a href="https://chronicle-yellowstone-faucet.getlit.dev/">this faucet</a> to get the Lit test tokens used to pay for minting a Capacity Credit.</p>

--- a/docs/src/Developers/App-Agent-Developers/Upgrading-Apps.md
+++ b/docs/src/Developers/App-Agent-Developers/Upgrading-Apps.md
@@ -40,9 +40,9 @@ Each App Version includes:
 
 # Creating a New Version
 
-<div class="info-box">
-  <p class="info-box-title">
-    <span class="info-icon">Info</span> Before creating a new App Version
+<div class="box info-box">
+  <p class="box-title info-box-title">
+    <span class="box-icon info-icon">Info</span> Before creating a new App Version
   </p>
   <p>Creating a new App Version requires that you have tokens on Lit Protocol's Yellowstone blockchain to pay for gas. You can use <a href="https://chronicle-yellowstone-faucet.getlit.dev/">this faucet</a> to get the Lit test tokens used to pay for creating the new App Version.</p>
 </div>

--- a/docs/src/Why-Vincent.md
+++ b/docs/src/Why-Vincent.md
@@ -4,10 +4,10 @@ title: Why Vincent?
 
 # Start Here
 
-<div class="warning-box">
-  <div class="warning-box-title">
-    <span class="warning-icon">Warning</span> Vincent is in Alpha
-  </div>
+<div class="box warning-box">
+  <p class="box-title warning-box-title">
+    <span class="box-icon warning-icon">Warning</span> Vincent is in Alpha
+  </p>
   <p>The Vincent App Registry is under active development and is subject to change.</p>
   <p>Vincent Apps and their registered delegations created during the Alpha phase <strong>will not persist</strong> after the App Registry is finalized.</p>
 </div>

--- a/docs/src/Why-Vincent.md
+++ b/docs/src/Why-Vincent.md
@@ -4,6 +4,14 @@ title: Why Vincent?
 
 # Start Here
 
+<div class="warning-box">
+  <div class="warning-box-title">
+    <span class="warning-icon">Warning</span> Vincent is in Alpha
+  </div>
+  <p>The Vincent App Registry is under active development and is subject to change.</p>
+  <p>Vincent Apps and their registered delegations created during the Alpha phase <strong>will not persist</strong> after the App Registry is finalized.</p>
+</div>
+
 Vincent is an open-source framework powered by [Lit Protocol](https://litprotocol.com/) that empowers developers to create automated, user-controlled AI agents. With Vincent, you can build agents that automate the execution of operations across crypto networks, traditional finance (TradFi), and e-commerce platforms—all while ensuring users retain full control over their assets and data. Powered by Lit’s decentralized [key management network](https://developer.litprotocol.com/resources/how-it-works) and smart contracts, Vincent is your gateway to the future of the automated, User-Owned Web.
 
 [Demo](https://demo.heyvincent.ai/) |


### PR DESCRIPTION
# Description

Add the following warning to the doc pages:

- Why Vincent (homepage)
- Creating Vincent Apps

<img width="948" alt="image" src="https://github.com/user-attachments/assets/01740572-e7d5-4e3c-9176-eff6d206d408" />

- Also removes the previous fix for OS color theme preference as having light mode selected for OS broke the styling for dark theme. I don't think there's a proper fix for this, and users should just select the theme they want to use and the OS theme option might be broken for them

<img width="894" alt="image" src="https://github.com/user-attachments/assets/9b6cc4f5-8e35-4e1c-ace2-da89e8ffb640" />


# Checklist:

- [ ] I created a [release plan](https://nx.dev/recipes/nx-release/file-based-versioning-version-plans) (`nx release plan`) describing my changes and the version bump
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
