### PR TITLE
SIWE Auth For Developers

### DIFF
--- a/packages/apps/app-dashboard/package.json
+++ b/packages/apps/app-dashboard/package.json
@@ -21,6 +21,7 @@
     "@lit-protocol/pkp-ethers": "^7.2.0",
     "@lit-protocol/types": "^7.0.8",
     "@lit-protocol/vincent-app-sdk": "1.0.1",
+    "@lit-protocol/vincent-registry-sdk": "^1.0.3",
     "@radix-ui/react-checkbox": "^1.2.3",
     "@radix-ui/react-dialog": "^1.1.6",
     "@radix-ui/react-dropdown-menu": "^2.1.12",

--- a/packages/apps/app-dashboard/src/services/developer-dashboard/vinceptApiClientWithSiwe.ts
+++ b/packages/apps/app-dashboard/src/services/developer-dashboard/vinceptApiClientWithSiwe.ts
@@ -1,0 +1,280 @@
+import { useCallback, useState, useEffect } from 'react';
+import { vincentApiClient } from '@lit-protocol/vincent-registry-sdk';
+import { useAccount, useSignMessage } from 'wagmi';
+import { verifyMessage } from 'viem';
+
+/**
+ * SIWE validation and authentication utilities
+ */
+interface SIWEData {
+  message: string;
+  signature: string;
+  address: string;
+  domain: string;
+  expirationTime: string;
+  issuedAt: string;
+}
+
+const SIWE_STORAGE_KEY = 'vincentDeveloperSIWE';
+const SIWE_EXPIRATION_HOURS = 72;
+const domain = window.location.hostname;
+
+// Global storage for current SIWE token to be used in requests
+let currentSIWEToken: string | null = null;
+
+// Global promise to prevent concurrent authentication attempts
+let authenticationPromise: Promise<boolean> | null = null;
+
+/**
+ * Get current SIWE token for request headers
+ */
+export const getCurrentSIWEToken = (): string | null => {
+  return currentSIWEToken;
+};
+
+/**
+ * Validates SIWE data from localStorage. Just return true/false, if false, the user can just sign a new SIWE. No need for displaying an error message.
+ */
+const validateSIWEData = async (siweData: SIWEData, currentAddress: string): Promise<boolean> => {
+  try {
+    // Check expiration
+    if (new Date(siweData.expirationTime) <= new Date()) return false;
+
+    // Check address match
+    if (siweData.address.toLowerCase() !== currentAddress.toLowerCase()) return false;
+
+    // Check domain
+    if (siweData.domain !== domain) return false;
+
+    // Verify signature
+    const isValidSignature = await verifyMessage({
+      address: siweData.address as `0x${string}`,
+      message: siweData.message,
+      signature: siweData.signature as `0x${string}`,
+    });
+
+    return isValidSignature;
+  } catch (error) {
+    return false;
+  }
+};
+
+/**
+ * Removes invalid SIWE data from localStorage
+ */
+const clearInvalidSIWE = (): void => {
+  localStorage.removeItem(SIWE_STORAGE_KEY);
+  currentSIWEToken = null;
+};
+
+/**
+ * Generates a cryptographically secure nonce
+ */
+const generateSecureNonce = (): string => {
+  if (crypto.randomUUID) {
+    return crypto.randomUUID();
+  }
+
+  const array = new Uint8Array(16);
+  crypto.getRandomValues(array);
+  return Array.from(array, (byte) => byte.toString(16).padStart(2, '0')).join('');
+};
+
+/**
+ * Generates a new SIWE message
+ */
+const generateSIWEMessage = (address: string): string => {
+  const issuedAt = new Date().toISOString();
+  const expirationTime = new Date(
+    Date.now() + SIWE_EXPIRATION_HOURS * 60 * 60 * 1000,
+  ).toISOString();
+  const nonce = generateSecureNonce();
+
+  return `${domain} wants you to sign in with your Ethereum account:
+${address}
+
+Vincent Developer Registry Access
+
+URI: ${domain}
+Version: 1
+Chain ID: 175188
+Nonce: ${nonce}
+Issued At: ${issuedAt}
+Expiration Time: ${expirationTime}`;
+};
+
+/**
+ * Hook that wraps vincentApiClient hooks and handles SIWE authentication for registry changes
+ *
+ * @returns Object containing wrapped API hooks with automatic SIWE authentication and utility functions
+ */
+export function useVincentApiWithSIWE() {
+  const { address, isConnected } = useAccount();
+  const { signMessageAsync } = useSignMessage();
+  const [isAuthenticating, setIsAuthenticating] = useState(false);
+
+  /**
+   * Check and set up SIWE token on component mount or address change
+   */
+  useEffect(() => {
+    const initializeSIWE = async () => {
+      if (!isConnected || !address) {
+        currentSIWEToken = null;
+        return;
+      }
+
+      const storedSIWE = localStorage.getItem(SIWE_STORAGE_KEY);
+      if (storedSIWE) {
+        try {
+          const siweData: SIWEData = JSON.parse(storedSIWE);
+
+          if (await validateSIWEData(siweData, address)) {
+            currentSIWEToken = siweData.signature;
+          } else {
+            clearInvalidSIWE();
+          }
+        } catch (error) {
+          clearInvalidSIWE();
+        }
+      }
+    };
+
+    initializeSIWE();
+  }, [address, isConnected]);
+
+  /**
+   * Manually trigger SIWE authentication with race condition protection
+   */
+  const authenticateWithSIWE = useCallback(async (): Promise<boolean> => {
+    // If already authenticating, return the existing promise
+    if (authenticationPromise) {
+      return authenticationPromise;
+    }
+
+    if (!isConnected || !address) {
+      throw new Error('Wallet not connected');
+    }
+
+    // New authentication promise
+    authenticationPromise = (async () => {
+      setIsAuthenticating(true);
+
+      try {
+        const message = generateSIWEMessage(address);
+        const signature = await signMessageAsync({ message });
+
+        const newSIWEData: SIWEData = {
+          message,
+          signature,
+          address,
+          domain,
+          expirationTime: new Date(
+            Date.now() + SIWE_EXPIRATION_HOURS * 60 * 60 * 1000,
+          ).toISOString(),
+          issuedAt: new Date().toISOString(),
+        };
+
+        localStorage.setItem(SIWE_STORAGE_KEY, JSON.stringify(newSIWEData));
+        currentSIWEToken = signature;
+        return true;
+      } catch (error) {
+        throw new Error('SIWE authentication failed');
+      } finally {
+        setIsAuthenticating(false);
+      }
+    })();
+
+    try {
+      return await authenticationPromise;
+    } finally {
+      // Clear the promise after completion
+      authenticationPromise = null;
+    }
+  }, [address, isConnected, signMessageAsync]);
+
+  /**
+   * Check if SIWE authentication is available
+   */
+  const hasSIWEAuthentication = useCallback(() => {
+    return currentSIWEToken !== null;
+  }, []);
+
+  // Create a wrapper for query hooks without authentication (GET requests)
+  const createQueryWrapper = useCallback(<T extends (...args: any[]) => any>(originalHook: T) => {
+    return (args: Parameters<T>[0], options?: Parameters<T>[1]) => {
+      // No authentication needed for GET requests
+      return originalHook(args, options);
+    };
+  }, []);
+
+  // Create a wrapper for mutation hooks that checks SIWE authentication (POST/PUT/DELETE)
+  const createMutationWrapper = useCallback(
+    <T extends () => readonly [any, any]>(originalHook: T, method: string) => {
+      return () => {
+        const [originalMutation, mutationResult] = originalHook();
+
+        const wrappedMutation = useCallback(
+          async (args: any) => {
+            if (method === 'POST' || method === 'PUT' || method === 'DELETE') {
+              if (!isConnected || !address) {
+                throw new Error('Wallet not connected');
+              }
+
+              // Ensure we have authentication before proceeding
+              if (!currentSIWEToken) {
+                await authenticateWithSIWE();
+              }
+            }
+
+            return originalMutation(args);
+          },
+          [originalMutation],
+        );
+
+        return [wrappedMutation, mutationResult] as const;
+      };
+    },
+    [isConnected, address, authenticateWithSIWE],
+  );
+
+  return {
+    authenticateWithSIWE,
+    hasSIWEAuthentication,
+    isAuthenticating,
+
+    // Lazy query hooks (GET requests - no authentication needed)
+    /* Temporarily commented out since they're not exported from the SDK
+    useLazyListAppsQuery: createQueryWrapper(vincentApiClient.useLazyListAppsQuery),
+    useLazyGetAppQuery: createQueryWrapper(vincentApiClient.useLazyGetAppQuery),
+    useLazyGetAppVersionsQuery: createQueryWrapper(vincentApiClient.useLazyGetAppVersionsQuery),
+    useLazyGetAppVersionQuery: createQueryWrapper(vincentApiClient.useLazyGetAppVersionQuery),
+    useLazyListAllToolsQuery: createQueryWrapper(vincentApiClient.useLazyListAllToolsQuery),
+    useLazyGetToolQuery: createQueryWrapper(vincentApiClient.useLazyGetToolQuery),
+    useLazyGetToolVersionsQuery: createQueryWrapper(vincentApiClient.useLazyGetToolVersionsQuery),
+    useLazyGetToolVersionQuery: createQueryWrapper(vincentApiClient.useLazyGetToolVersionQuery),
+    useLazyListAllPoliciesQuery: createQueryWrapper(vincentApiClient.useLazyListAllPoliciesQuery),
+    useLazyGetPolicyQuery: createQueryWrapper(vincentApiClient.useLazyGetPolicyQuery),
+    useLazyGetPolicyVersionsQuery: createQueryWrapper(vincentApiClient.useLazyGetPolicyVersionsQuery),
+    useLazyGetPolicyVersionQuery: createQueryWrapper(vincentApiClient.useLazyGetPolicyVersionQuery),
+
+    // Mutation hooks (POST/PUT/DELETE requests - SIWE authentication required)
+    useCreateAppMutation: createMutationWrapper(vincentApiClient.useCreateAppMutation, 'POST'),
+    useEditAppMutation: createMutationWrapper(vincentApiClient.useEditAppMutation, 'PUT'),
+    useDeleteAppMutation: createMutationWrapper(vincentApiClient.useDeleteAppMutation, 'DELETE'),
+    useCreateAppVersionMutation: createMutationWrapper(vincentApiClient.useCreateAppVersionMutation, 'POST'),
+    useEditAppVersionMutation: createMutationWrapper(vincentApiClient.useEditAppVersionMutation, 'PUT'),
+    useEnableAppVersionMutation: createMutationWrapper(vincentApiClient.useEnableAppVersionMutation, 'POST'),
+    useDisableAppVersionMutation: createMutationWrapper(vincentApiClient.useDisableAppVersionMutation, 'POST'),
+    useCreateToolMutation: createMutationWrapper(vincentApiClient.useCreateToolMutation, 'POST'),
+    useEditToolMutation: createMutationWrapper(vincentApiClient.useEditToolMutation, 'PUT'),
+    useChangeToolOwnerMutation: createMutationWrapper(vincentApiClient.useChangeToolOwnerMutation, 'PUT'),
+    useCreateToolVersionMutation: createMutationWrapper(vincentApiClient.useCreateToolVersionMutation, 'POST'),
+    useEditToolVersionMutation: createMutationWrapper(vincentApiClient.useEditToolVersionMutation, 'PUT'),
+    useCreatePolicyMutation: createMutationWrapper(vincentApiClient.useCreatePolicyMutation, 'POST'),
+    useEditPolicyMutation: createMutationWrapper(vincentApiClient.useEditPolicyMutation, 'PUT'),
+    useCreatePolicyVersionMutation: createMutationWrapper(vincentApiClient.useCreatePolicyVersionMutation, 'POST'),
+    useEditPolicyVersionMutation: createMutationWrapper(vincentApiClient.useEditPolicyVersionMutation, 'PUT'),
+    useChangePolicyOwnerMutation: createMutationWrapper(vincentApiClient.useChangePolicyOwnerMutation, 'PUT'),
+    */
+  };
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -192,6 +192,9 @@ importers:
       '@lit-protocol/vincent-app-sdk':
         specifier: 1.0.1
         version: 1.0.1(@walletconnect/modal@2.7.0(@types/react@19.1.8)(react@19.1.0))(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)
+      '@lit-protocol/vincent-registry-sdk':
+        specifier: ^1.0.3
+        version: 1.0.3(react-redux@9.2.0(@types/react@19.1.8)(react@19.1.0)(redux@5.0.1))(react@19.1.0)
       '@radix-ui/react-checkbox':
         specifier: ^1.2.3
         version: 1.3.2(@types/react-dom@19.1.6(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
@@ -2161,6 +2164,9 @@ packages:
     resolution: {integrity: sha512-ibDdrZWdrd7RkrJhqLhio/mZPACn0Hc5W7GRNzfTdFr88xu9KRjr0YwfHyc4Q1qevq6nXltZQpuno7pBKUEcxg==}
     engines: {node: ^20.11.1, pnpm: 10.7.0}
 
+  '@lit-protocol/vincent-registry-sdk@1.0.3':
+    resolution: {integrity: sha512-cdu7Jl1LMADyA6qWcISKd8eFeV+SNKhmKwPrR7C0LIP7RyJ42pfVvD1K5rA4RWx31guQEys/qxoRk2W8Ol2WpA==}
+
   '@lit-protocol/vincent-tool-sdk@1.0.1':
     resolution: {integrity: sha512-wSGlLCFnL/uTqWnK3N4pQvOhPniKTG1Te3UAs+lOj+hjiiFfDQ7WPpTMqEZ7koMz8Xviq4bZTCeMOPdX5exFvA==}
 
@@ -4003,9 +4009,11 @@ packages:
 
   '@walletconnect/ethereum-provider@2.17.0':
     resolution: {integrity: sha512-b+KTAXOb6JjoxkwpgYQQKPUcTwENGmdEdZoIDLeRicUmZTn/IQKfkMoC2frClB4YxkyoVMtj1oMV2JAax+yu9A==}
+    deprecated: 'Reliability and performance improvements. See: https://github.com/WalletConnect/walletconnect-monorepo/releases'
 
   '@walletconnect/ethereum-provider@2.9.2':
     resolution: {integrity: sha512-eO1dkhZffV1g7vpG19XUJTw09M/bwGUwwhy1mJ3AOPbOSbMPvwiCuRz2Kbtm1g9B0Jv15Dl+TvJ9vTgYF8zoZg==}
+    deprecated: 'Reliability and performance improvements. See: https://github.com/WalletConnect/walletconnect-monorepo/releases'
     peerDependencies:
       '@walletconnect/modal': '>=2'
     peerDependenciesMeta:
@@ -4615,6 +4623,7 @@ packages:
 
   bun@1.2.16:
     resolution: {integrity: sha512-sjZH6rr1P6yu44+XPA8r+ZojwmK9Kbz9lO6KAA/4HRIupdpC31k7b93crLBm19wEYmd6f2+3+57/7tbOcmHbGg==}
+    cpu: [arm64, x64, aarch64]
     os: [darwin, linux, win32]
     hasBin: true
 
@@ -12688,6 +12697,16 @@ snapshots:
       - typescript
       - uploadthing
       - utf-8-validate
+
+  '@lit-protocol/vincent-registry-sdk@1.0.3(react-redux@9.2.0(@types/react@19.1.8)(react@19.1.0)(redux@5.0.1))(react@19.1.0)':
+    dependencies:
+      '@asteasolutions/zod-to-openapi': 7.3.4(zod@3.25.64)
+      '@reduxjs/toolkit': 2.8.2(react-redux@9.2.0(@types/react@19.1.8)(react@19.1.0)(redux@5.0.1))(react@19.1.0)
+      tslib: 2.8.1
+      zod: 3.25.64
+    transitivePeerDependencies:
+      - react
+      - react-redux
 
   '@lit-protocol/vincent-tool-sdk@1.0.1(bufferutil@4.0.9)(utf-8-validate@5.0.10)':
     dependencies:


### PR DESCRIPTION
# Description

SIWE Auth for developers on the developer dashboard. We need to authenticate their requests to the registry. This change:
- Wraps the `vincentClientApi` hooks to require SIWE auth for mutations
- Caches a SIWE in `localstorage` for 72 hours
- Automatic validation on mount
- Only allows one authentication promise to exist at a time (to prevent race conditions)
- We will later attach the SIWE to the authentication header by fetching it with the `getCurrentSiweToken` function

Currently the returns are commented out since the `@lit-protocol/vincent-registry-sdk` doesn't export the lazy hooks.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [ ] I created a [release plan](https://nx.dev/recipes/nx-release/file-based-versioning-version-plans) (`nx release plan`) describing my changes and the version bump
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings (temporarily they do)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
