### PR TITLE
Registry Backend - Implement missing AppTool functionality

### DIFF
--- a/.nx/version-plans/version-plan-1750809053574.md
+++ b/.nx/version-plans/version-plan-1750809053574.md
@@ -1,0 +1,5 @@
+---
+registry-sdk: minor
+---
+
+Add endpoint to allow editing of `supportedPolicies` for app tools.

--- a/.nx/version-plans/version-plan-1750809053574.md
+++ b/.nx/version-plans/version-plan-1750809053574.md
@@ -1,5 +1,0 @@
----
-registry-sdk: minor
----
-
-Add endpoint to allow editing of `supportedPolicies` for app tools.

--- a/.nx/version-plans/version-plan-1750809155512.md
+++ b/.nx/version-plans/version-plan-1750809155512.md
@@ -1,0 +1,5 @@
+---
+registry-backend: minor
+---
+
+Implemented routes for managing app tools

--- a/.nx/version-plans/version-plan-1750809155512.md
+++ b/.nx/version-plans/version-plan-1750809155512.md
@@ -1,5 +1,0 @@
----
-registry-backend: minor
----
-
-Implemented routes for managing app tools

--- a/nx.json
+++ b/nx.json
@@ -53,6 +53,7 @@
       "tool-sdk",
       "app-sdk",
       "registry-sdk",
+      "registry-backend",
       "policy-spending-limit",
       "tool-erc20-approval",
       "tool-uniswap-swap"

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   "devDependencies": {
     "@dotenvx/dotenvx": "^1.44.2",
     "@eslint/js": "^9.25.1",
-    "@lit-protocol/flags": "^2.0.0",
+    "@lit-protocol/flags": "^2.1.0",
     "@nx/esbuild": "21.2.1",
     "@nx/eslint": "21.2.1",
     "@nx/eslint-plugin": "21.2.1",

--- a/packages/apps/app-dashboard/package.json
+++ b/packages/apps/app-dashboard/package.json
@@ -22,7 +22,7 @@
     "@lit-protocol/pkp-ethers": "^7.2.0",
     "@lit-protocol/types": "^7.0.8",
     "@lit-protocol/vincent-app-sdk": "1.0.1",
-    "@lit-protocol/vincent-registry-sdk": "^2.0.0",
+    "@lit-protocol/vincent-registry-sdk": "^2.1.0",
     "@radix-ui/react-checkbox": "^1.2.3",
     "@radix-ui/react-dialog": "^1.1.6",
     "@radix-ui/react-dropdown-menu": "^2.1.12",

--- a/packages/apps/registry-backend/CHANGELOG.md
+++ b/packages/apps/registry-backend/CHANGELOG.md
@@ -1,0 +1,13 @@
+## 0.1.0 (2025-06-25)
+
+### 🚀 Features
+
+- Implemented routes for managing app tools ([13a0ce44](https://github.com/LIT-Protocol/Vincent/commit/13a0ce44))
+
+### 🧱 Updated Dependencies
+
+- Updated registry-sdk to 2.1.0
+
+### ❤️ Thank You
+
+- Daryl Collins

--- a/packages/apps/registry-backend/package.json
+++ b/packages/apps/registry-backend/package.json
@@ -13,6 +13,9 @@
     "dist",
     "src/lib/express/static/openapi.html"
   ],
+  "bin": {
+    "apiServer": "./dist/bin/apiServer.mjs"
+  },
   "packageManager": "pnpm@10.7.0",
   "engines": {
     "node": "^20.11.1",

--- a/packages/apps/registry-backend/package.json
+++ b/packages/apps/registry-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lit-protocol/registry-backend",
-  "version": "0.0.2",
+  "version": "0.1.0",
   "private": true,
   "type:": "module",
   "scripts": {

--- a/packages/apps/registry-backend/package.json
+++ b/packages/apps/registry-backend/package.json
@@ -22,7 +22,7 @@
     "pnpm": "10.7.0"
   },
   "dependencies": {
-    "@lit-protocol/flags": "2.0.0",
+    "@lit-protocol/flags": "^2.1.0",
     "@lit-protocol/vincent-registry-sdk": "workspace:*",
     "@t3-oss/env-core": "^0.13.6",
     "bs58": "^6.0.0",

--- a/packages/apps/registry-backend/package.json
+++ b/packages/apps/registry-backend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@lit-protocol/registry-backend",
   "version": "0.0.2",
-  "private": false,
+  "private": true,
   "type:": "module",
   "scripts": {
     "build": "pnpm unbuild",

--- a/packages/apps/registry-backend/src/lib/express/app/requireAppTool.ts
+++ b/packages/apps/registry-backend/src/lib/express/app/requireAppTool.ts
@@ -1,0 +1,68 @@
+import { Request, Response, NextFunction } from 'express';
+import { AppTool } from '../../mongo/app';
+
+import { RequestWithAppAndVersion } from './requireAppVersion';
+
+interface RequestWithAppVersionAndTool extends RequestWithAppAndVersion {
+  vincentAppTool: InstanceType<typeof AppTool>;
+}
+
+// Type guard function that expects vincentApp and vincentAppVersion to already exist
+export const requireAppTool = (toolPackageNameParam = 'toolPackageName') => {
+  return async (req: Request, res: Response, next: NextFunction): Promise<void> => {
+    const reqWithAppVersion = req as RequestWithAppAndVersion;
+
+    // Ensure app and appVersion middleware ran first
+    if (!reqWithAppVersion.vincentApp) {
+      res.status(500).json({
+        error: 'App middleware must run before AppTool middleware',
+      });
+      return;
+    }
+
+    if (!reqWithAppVersion.vincentAppVersion) {
+      res.status(500).json({
+        error: 'AppVersion middleware must run before AppTool middleware',
+      });
+      return;
+    }
+
+    const toolPackageName = req.params[toolPackageNameParam];
+
+    try {
+      const appTool = await AppTool.findOne({
+        appId: reqWithAppVersion.vincentApp.appId,
+        appVersion: reqWithAppVersion.vincentAppVersion.version,
+        toolPackageName,
+        isDeleted: { $ne: true },
+      });
+
+      if (!appTool) {
+        res.status(404).end();
+        return;
+      }
+
+      (req as RequestWithAppVersionAndTool).vincentAppTool = appTool;
+      next();
+    } catch (error) {
+      res.status(500).json({
+        message: `Error fetching tool ${toolPackageName} for app ${reqWithAppVersion.vincentApp.appId} version ${reqWithAppVersion.vincentAppVersion.version}`,
+        error,
+      });
+      return;
+    }
+  };
+};
+
+// Type-safe handler wrapper
+export type AppToolHandler = (
+  req: RequestWithAppVersionAndTool,
+  res: Response,
+  next: NextFunction,
+) => void | Promise<void>;
+
+export const withAppTool = (handler: AppToolHandler) => {
+  return (req: Request, res: Response, next: NextFunction) => {
+    return handler(req as RequestWithAppVersionAndTool, res, next);
+  };
+};

--- a/packages/apps/registry-backend/src/lib/express/app/requireAppVersion.ts
+++ b/packages/apps/registry-backend/src/lib/express/app/requireAppVersion.ts
@@ -3,7 +3,7 @@ import { AppVersion } from '../../mongo/app';
 
 import { RequestWithApp } from './requireApp';
 
-interface RequestWithAppAndVersion extends RequestWithApp {
+export interface RequestWithAppAndVersion extends RequestWithApp {
   vincentAppVersion: InstanceType<typeof AppVersion>;
 }
 

--- a/packages/apps/registry-backend/src/lib/mongo/app.ts
+++ b/packages/apps/registry-backend/src/lib/mongo/app.ts
@@ -41,7 +41,7 @@ export const AppToolSchema = new Schema(
     appId: { type: Number, required: true },
     appVersion: { type: Number, required: true },
     toolPackageName: { type: String, required: true },
-    toolVersion: { type: Number, required: true },
+    toolVersion: { type: String, required: true },
     hiddenSupportedPolicies: [{ type: String }],
     isDeleted: { type: Boolean, default: false },
   } as const,

--- a/packages/apps/registry-backend/test/integration/appVersionTool.spec.ts
+++ b/packages/apps/registry-backend/test/integration/appVersionTool.spec.ts
@@ -1,0 +1,458 @@
+import { api, store } from './setup';
+import { expectAssertArray, expectAssertObject } from '../assertions';
+import { logIfVerbose } from '../log';
+
+const VERBOSE_LOGGING = true;
+
+const verboseLog = (value: any) => {
+  logIfVerbose(value, VERBOSE_LOGGING);
+};
+
+/* eslint-disable @typescript-eslint/no-non-null-assertion */
+describe('AppVersionTool API Integration Tests', () => {
+  beforeAll(async () => {
+    verboseLog('AppVersionTool API Integration Tests');
+  });
+
+  // Variables to store test data
+  let testAppId: number | undefined;
+  let testToolPackageName1: string;
+  let testToolPackageName2: string;
+  // @ts-expect-error It's a test
+  let testToolVersion1: string;
+  // @ts-expect-error It's a test
+  let testToolVersion2: string;
+  const firstAppVersion = 1; // Initial app version
+  let secondAppVersion: number;
+
+  // Test data for creating an app
+  const appData = {
+    name: 'Test App for AppVersionTool',
+    description: 'Test app for AppVersionTool integration tests',
+    contactEmail: 'test@example.com',
+    appUserUrl: 'https://example.com/app',
+    logo: 'https://example.com/logo.png',
+    redirectUris: ['https://example.com/callback'],
+    deploymentStatus: 'dev' as const,
+    managerAddress: '0x1234567890abcdef1234567890abcdef12345678',
+  };
+
+  // Test data for creating tools
+  const toolData1 = {
+    title: 'Test Tool 1',
+    description: 'Test tool 1 for AppVersionTool integration tests',
+    activeVersion: '1.0.0',
+    authorWalletAddress: '0x1093891467868461234876123873',
+  };
+
+  const toolData2 = {
+    title: 'Test Tool 2',
+    description: 'Test tool 2 for AppVersionTool integration tests',
+    activeVersion: '1.0.0',
+    authorWalletAddress: '0x1093891467868461234876123873',
+  };
+
+  // Test data for creating app versions
+  const appVersionData = {
+    changes: 'Second version for AppVersionTool tests',
+  };
+
+  // Test data for creating app version tools
+  const appVersionToolData1 = {
+    toolVersion: '1.0.0',
+    hiddenSupportedPolicies: ['@vincent/policy1', '@vincent/policy2'],
+  };
+
+  const appVersionToolData2 = {
+    toolVersion: '1.0.0',
+  };
+
+  describe('Setup: Create tools', () => {
+    it('should create the first tool', async () => {
+      // Generate a unique package name for testing
+      testToolPackageName1 = `@lit-protocol/vincent-tool-erc20-approval`;
+      testToolVersion1 = toolData1.activeVersion;
+
+      const result = await store.dispatch(
+        api.endpoints.createTool.initiate({
+          packageName: testToolPackageName1,
+          toolCreate: toolData1,
+        }),
+      );
+
+      verboseLog(result);
+      expect(result).not.toHaveProperty('error');
+
+      const { data } = result;
+      expectAssertObject(data);
+
+      expect(data).toMatchObject({
+        packageName: testToolPackageName1,
+        ...toolData1,
+      });
+    });
+
+    it('should create the second tool', async () => {
+      // Generate a unique package name for testing
+      testToolPackageName2 = `@lit-protocol/vincent-tool-uniswap-swap`;
+      testToolVersion2 = toolData2.activeVersion;
+
+      const result = await store.dispatch(
+        api.endpoints.createTool.initiate({
+          packageName: testToolPackageName2,
+          toolCreate: toolData2,
+        }),
+      );
+
+      verboseLog(result);
+      expect(result).not.toHaveProperty('error');
+
+      const { data } = result;
+      expectAssertObject(data);
+
+      expect(data).toMatchObject({
+        packageName: testToolPackageName2,
+        ...toolData2,
+      });
+    });
+  });
+
+  describe('Setup: Create app and app versions', () => {
+    it('should create a new app', async () => {
+      const result = await store.dispatch(
+        api.endpoints.createApp.initiate({
+          appCreate: appData,
+        }),
+      );
+
+      verboseLog(result);
+      expect(result).not.toHaveProperty('error');
+
+      const { data } = result;
+      expectAssertObject(data);
+
+      testAppId = data.appId;
+
+      expect(data).toMatchObject(appData);
+    });
+
+    it('should create a second app version', async () => {
+      const result = await store.dispatch(
+        api.endpoints.createAppVersion.initiate({
+          appId: testAppId!,
+          appVersionCreate: appVersionData,
+        }),
+      );
+
+      verboseLog(result);
+      expect(result).not.toHaveProperty('error');
+
+      const { data } = result;
+      expectAssertObject(data);
+
+      expect(data).toHaveProperty('changes', appVersionData.changes);
+      expect(data).toHaveProperty('version');
+
+      secondAppVersion = data.version;
+    });
+  });
+
+  describe('GET /app/:appId/version/:version/tools', () => {
+    it('should return an empty list of tools for a new app version', async () => {
+      const result = await store.dispatch(
+        api.endpoints.listAppVersionTools.initiate({
+          appId: testAppId!,
+          version: firstAppVersion,
+        }),
+      );
+
+      verboseLog(result);
+      expect(result).not.toHaveProperty('error');
+
+      const { data } = result;
+      expectAssertArray(data);
+
+      expect(data).toHaveLength(0);
+    });
+  });
+
+  describe('POST /app/:appId/version/:version/tool/:toolPackageName', () => {
+    it('should create an app version tool for the first app version using the first tool', async () => {
+      const result = await store.dispatch(
+        api.endpoints.createAppVersionTool.initiate({
+          appId: testAppId!,
+          appVersion: firstAppVersion,
+          toolPackageName: testToolPackageName1,
+          appVersionToolCreate: appVersionToolData1,
+        }),
+      );
+
+      verboseLog(result);
+      expect(result).not.toHaveProperty('error');
+
+      const { data } = result;
+      expectAssertObject(data);
+
+      expect(data).toMatchObject({
+        appId: testAppId,
+        appVersion: firstAppVersion,
+        toolPackageName: testToolPackageName1,
+        toolVersion: appVersionToolData1.toolVersion,
+        hiddenSupportedPolicies: appVersionToolData1.hiddenSupportedPolicies,
+      });
+    });
+
+    it('should create app version tools for the second app version using both tools', async () => {
+      // Create app version tool for the second app version using the first tool
+      const result1 = await store.dispatch(
+        api.endpoints.createAppVersionTool.initiate({
+          appId: testAppId!,
+          appVersion: secondAppVersion,
+          toolPackageName: testToolPackageName1,
+          appVersionToolCreate: appVersionToolData1,
+        }),
+      );
+
+      verboseLog(result1);
+      expect(result1).not.toHaveProperty('error');
+
+      const { data: data1 } = result1;
+      expectAssertObject(data1);
+
+      expect(data1).toMatchObject({
+        appId: testAppId,
+        appVersion: secondAppVersion,
+        toolPackageName: testToolPackageName1,
+        toolVersion: appVersionToolData1.toolVersion,
+        hiddenSupportedPolicies: appVersionToolData1.hiddenSupportedPolicies,
+      });
+
+      // Create app version tool for the second app version using the second tool
+      const result2 = await store.dispatch(
+        api.endpoints.createAppVersionTool.initiate({
+          appId: testAppId!,
+          appVersion: secondAppVersion,
+          toolPackageName: testToolPackageName2,
+          appVersionToolCreate: appVersionToolData2,
+        }),
+      );
+
+      verboseLog(result2);
+      expect(result2).not.toHaveProperty('error');
+
+      const { data: data2 } = result2;
+      expectAssertObject(data2);
+
+      expect(data2).toMatchObject({
+        appId: testAppId,
+        appVersion: secondAppVersion,
+        toolPackageName: testToolPackageName2,
+        toolVersion: appVersionToolData2.toolVersion,
+      });
+    });
+
+    it('should return 409 when trying to create a duplicate app version tool', async () => {
+      const result = await store.dispatch(
+        api.endpoints.createAppVersionTool.initiate({
+          appId: testAppId!,
+          appVersion: firstAppVersion,
+          toolPackageName: testToolPackageName1,
+          appVersionToolCreate: appVersionToolData1,
+        }),
+      );
+
+      verboseLog(result);
+      expect(result).toHaveProperty('error');
+
+      // @ts-expect-error It's a test
+      if (result.isError) {
+        const { error } = result;
+        expectAssertObject(error);
+        // @ts-expect-error it's a test
+        expect(error.status).toBe(409);
+      }
+    });
+  });
+
+  describe('GET /app/:appId/version/:version/tools', () => {
+    it('should list all tools for the first app version', async () => {
+      store.dispatch(api.util.resetApiState());
+
+      const result = await store.dispatch(
+        api.endpoints.listAppVersionTools.initiate({
+          appId: testAppId!,
+          version: firstAppVersion,
+        }),
+      );
+
+      verboseLog(result);
+      expect(result).not.toHaveProperty('error');
+
+      const { data } = result;
+      expectAssertArray(data);
+
+      expect(data).toHaveLength(1);
+      // @ts-expect-error It's a test
+      expect(data[0]).toMatchObject({
+        appId: testAppId,
+        appVersion: firstAppVersion,
+        toolPackageName: testToolPackageName1,
+        toolVersion: appVersionToolData1.toolVersion,
+      });
+    });
+
+    it('should list all tools for the second app version', async () => {
+      store.dispatch(api.util.resetApiState());
+
+      const result = await store.dispatch(
+        api.endpoints.listAppVersionTools.initiate({
+          appId: testAppId!,
+          version: secondAppVersion,
+        }),
+      );
+
+      verboseLog(result);
+      expect(result).not.toHaveProperty('error');
+
+      const { data } = result;
+      expectAssertArray(data);
+
+      expect(data).toHaveLength(2);
+
+      // Check that both tools are in the list
+      // @ts-expect-error It's a test
+      const toolPackageNames = data.map((tool) => tool.toolPackageName);
+      expect(toolPackageNames).toContain(testToolPackageName1);
+      expect(toolPackageNames).toContain(testToolPackageName2);
+    });
+  });
+
+  describe('PUT /app/:appId/version/:version/tool/:toolPackageName', () => {
+    it('should edit an app version tool', async () => {
+      const updatedPolicies = [
+        '@vincent/updated-policy1',
+        '@vincent/updated-policy2',
+        '@vincent/updated-policy3',
+      ];
+
+      {
+        // Use the generated client to update the hiddenSupportedPolicies
+        const result = await store.dispatch(
+          api.endpoints.editAppVersionTool.initiate({
+            appId: testAppId!,
+            appVersion: firstAppVersion,
+            toolPackageName: testToolPackageName1,
+            appVersionToolEdit: {
+              hiddenSupportedPolicies: updatedPolicies,
+            },
+          }),
+        );
+
+        verboseLog(result);
+        expect(result).not.toHaveProperty('error');
+
+        const { data: updatedTool } = result;
+        expectAssertObject(updatedTool);
+        expect(updatedTool).toHaveProperty('hiddenSupportedPolicies');
+        expect(updatedTool.hiddenSupportedPolicies).toEqual(updatedPolicies);
+      }
+
+      // Verify the update by fetching the tool again
+      store.dispatch(api.util.resetApiState());
+
+      {
+        const result = await store.dispatch(
+          api.endpoints.listAppVersionTools.initiate({
+            appId: testAppId!,
+            version: firstAppVersion,
+          }),
+        );
+
+        verboseLog(result);
+        expect(result).not.toHaveProperty('error');
+
+        const { data } = result;
+        expectAssertArray(data);
+
+        expect(data).toHaveLength(1);
+        // @ts-expect-error It's a test
+        expect(data[0]).toMatchObject({
+          appId: testAppId,
+          appVersion: firstAppVersion,
+          toolPackageName: testToolPackageName1,
+          toolVersion: appVersionToolData1.toolVersion,
+          hiddenSupportedPolicies: updatedPolicies,
+        });
+      }
+    });
+  });
+
+  describe('DELETE /app/:appId', () => {
+    it('should delete an app and all its versions and tools', async () => {
+      // First, delete the app
+      const result = await store.dispatch(api.endpoints.deleteApp.initiate({ appId: testAppId! }));
+
+      verboseLog(result);
+      expect(result).not.toHaveProperty('error');
+
+      const { data } = result;
+      expectAssertObject(data);
+
+      // Verify the message in the response
+      expect(data).toHaveProperty('message');
+      expect(data.message).toContain('deleted successfully');
+
+      // Reset the API cache
+      store.dispatch(api.util.resetApiState());
+
+      // Verify the app is deleted by checking for a 404
+      const getAppResult = await store.dispatch(
+        api.endpoints.getApp.initiate({ appId: testAppId! }),
+      );
+
+      expect(getAppResult.isError).toBe(true);
+      if (getAppResult.isError) {
+        const { error } = getAppResult;
+        expectAssertObject(error);
+        // @ts-expect-error it's a test
+        expect(error.status).toBe(404);
+      }
+
+      // Verify the app version tools are deleted by checking for an empty list
+      const getToolsResult = await store.dispatch(
+        api.endpoints.listAppVersionTools.initiate({
+          appId: testAppId!,
+          version: firstAppVersion,
+        }),
+      );
+
+      // This should either return an error or an empty array
+      if (!getToolsResult.isError) {
+        const { data: toolsData } = getToolsResult;
+        expectAssertArray(toolsData);
+        expect(toolsData).toHaveLength(0);
+      }
+    });
+  });
+
+  // Clean up the tools created for the test
+  describe('Cleanup: Delete tools', () => {
+    it('should delete the first tool', async () => {
+      const result = await store.dispatch(
+        api.endpoints.deleteTool.initiate({ packageName: testToolPackageName1 }),
+      );
+
+      verboseLog(result);
+      expect(result).not.toHaveProperty('error');
+    });
+
+    it('should delete the second tool', async () => {
+      const result = await store.dispatch(
+        api.endpoints.deleteTool.initiate({ packageName: testToolPackageName2 }),
+      );
+
+      verboseLog(result);
+      expect(result).not.toHaveProperty('error');
+    });
+  });
+});

--- a/packages/apps/registry-backend/test/integration/index.spec.ts
+++ b/packages/apps/registry-backend/test/integration/index.spec.ts
@@ -6,6 +6,7 @@ import './openapi.spec';
 import './tool.spec';
 import './policy.spec';
 import './app.spec';
+import './appVersionTool.spec';
 
 // This empty test ensures that the file is recognized as a test file
 describe('Integration Test Suite', () => {

--- a/packages/apps/registry-backend/tsconfig.app.json
+++ b/packages/apps/registry-backend/tsconfig.app.json
@@ -1,6 +1,6 @@
 {
   "extends": ["@tsconfig/node20/tsconfig.json", "./tsconfig.json"],
-  "include": ["src/**/*.ts", "src/*.ts"],
+  "include": ["src/**/*.ts", "src/*.ts", "src/**/*.json"],
   "strictNullChecks": true,
   "allowJs": true,
   "types": ["jest", "node"],
@@ -9,7 +9,8 @@
     "module": "esnext",
     "moduleResolution": "Bundler",
     "strict": true,
-    "outDir": "./dist"
+    "outDir": "./dist",
+    "resolveJsonModule": true
   },
   "references": [
     {

--- a/packages/libs/registry-sdk/CHANGELOG.md
+++ b/packages/libs/registry-sdk/CHANGELOG.md
@@ -1,3 +1,13 @@
+## 2.1.0 (2025-06-25)
+
+### 🚀 Features
+
+- Add endpoint to allow editing of `supportedPolicies` for app tools. ([2615143d](https://github.com/LIT-Protocol/Vincent/commit/2615143d))
+
+### ❤️ Thank You
+
+- Daryl Collins
+
 # 2.0.0 (2025-06-24)
 
 ### 🚀 Features

--- a/packages/libs/registry-sdk/package.json
+++ b/packages/libs/registry-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lit-protocol/vincent-registry-sdk",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "Vincent Registry API definitions and generated code",
   "packageManager": "pnpm@10.7.0",
   "private": false,

--- a/packages/libs/registry-sdk/src/generated/openapi.json
+++ b/packages/libs/registry-sdk/src/generated/openapi.json
@@ -367,6 +367,23 @@
         ],
         "additionalProperties": false
       },
+      "AppVersionToolEdit": {
+        "type": "object",
+        "properties": {
+          "hiddenSupportedPolicies": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Policies that are supported by this tool, but are hidden from users of this app specifically",
+            "example": [
+              "@vincent/foo-bar-policy-1",
+              "@vincent/foo-bar-policy-2"
+            ]
+          }
+        },
+        "additionalProperties": false
+      },
       "AppVersionTool": {
         "type": "object",
         "properties": {
@@ -1779,6 +1796,87 @@
           },
           "400": {
             "description": "Invalid input"
+          },
+          "422": {
+            "description": "Validation exception"
+          },
+          "default": {
+            "description": "Unexpected error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "app/version/tool"
+        ],
+        "summary": "Edits a tool for an application version",
+        "operationId": "editAppVersionTool",
+        "parameters": [
+          {
+            "schema": {
+              "type": "number"
+            },
+            "required": true,
+            "description": "ID of the target application",
+            "example": 132,
+            "name": "appId",
+            "in": "path"
+          },
+          {
+            "schema": {
+              "type": "number"
+            },
+            "required": true,
+            "description": "Version # of the target application version",
+            "example": 3,
+            "name": "appVersion",
+            "in": "path"
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "description": "The NPM package name",
+            "example": "@vincent/foo-bar",
+            "name": "toolPackageName",
+            "in": "path"
+          }
+        ],
+        "requestBody": {
+          "description": "Updated tool configuration for the application version",
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AppVersionToolEdit"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AppVersionTool"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid input"
+          },
+          "404": {
+            "description": "Application, version, or tool not found"
           },
           "422": {
             "description": "Validation exception"

--- a/packages/libs/registry-sdk/src/generated/vincentApiClientNode.ts
+++ b/packages/libs/registry-sdk/src/generated/vincentApiClientNode.ts
@@ -72,6 +72,13 @@ const injectedRtkApi = api.injectEndpoints({
         body: queryArg.appVersionToolCreate,
       }),
     }),
+    editAppVersionTool: build.mutation<EditAppVersionToolApiResponse, EditAppVersionToolApiArg>({
+      query: (queryArg) => ({
+        url: `/app/${encodeURIComponent(String(queryArg.appId))}/version/${encodeURIComponent(String(queryArg.appVersion))}/tool/${encodeURIComponent(String(queryArg.toolPackageName))}`,
+        method: 'PUT',
+        body: queryArg.appVersionToolEdit,
+      }),
+    }),
     listAllTools: build.query<ListAllToolsApiResponse, ListAllToolsApiArg>({
       query: () => ({ url: `/tools` }),
     }),
@@ -276,6 +283,18 @@ export type CreateAppVersionToolApiArg = {
   toolPackageName: string;
   /** Tool configuration for the application version */
   appVersionToolCreate: AppVersionToolCreate;
+};
+export type EditAppVersionToolApiResponse =
+  /** status 200 Successful operation */ AppVersionToolRead;
+export type EditAppVersionToolApiArg = {
+  /** ID of the target application */
+  appId: number;
+  /** Version # of the target application version */
+  appVersion: number;
+  /** The NPM package name */
+  toolPackageName: string;
+  /** Updated tool configuration for the application version */
+  appVersionToolEdit: AppVersionToolEdit;
 };
 export type ListAllToolsApiResponse = /** status 200 Successful operation */ ToolListRead;
 export type ListAllToolsApiArg = void;
@@ -578,6 +597,10 @@ export type AppVersionToolCreate = {
   hiddenSupportedPolicies?: string[];
   /** Tool version */
   toolVersion: string;
+};
+export type AppVersionToolEdit = {
+  /** Policies that are supported by this tool, but are hidden from users of this app specifically */
+  hiddenSupportedPolicies?: string[];
 };
 export type Tool = {
   /** Timestamp when this was last modified */

--- a/packages/libs/registry-sdk/src/generated/vincentApiClientReact.ts
+++ b/packages/libs/registry-sdk/src/generated/vincentApiClientReact.ts
@@ -72,6 +72,13 @@ const injectedRtkApi = api.injectEndpoints({
         body: queryArg.appVersionToolCreate,
       }),
     }),
+    editAppVersionTool: build.mutation<EditAppVersionToolApiResponse, EditAppVersionToolApiArg>({
+      query: (queryArg) => ({
+        url: `/app/${encodeURIComponent(String(queryArg.appId))}/version/${encodeURIComponent(String(queryArg.appVersion))}/tool/${encodeURIComponent(String(queryArg.toolPackageName))}`,
+        method: 'PUT',
+        body: queryArg.appVersionToolEdit,
+      }),
+    }),
     listAllTools: build.query<ListAllToolsApiResponse, ListAllToolsApiArg>({
       query: () => ({ url: `/tools` }),
     }),
@@ -276,6 +283,18 @@ export type CreateAppVersionToolApiArg = {
   toolPackageName: string;
   /** Tool configuration for the application version */
   appVersionToolCreate: AppVersionToolCreate;
+};
+export type EditAppVersionToolApiResponse =
+  /** status 200 Successful operation */ AppVersionToolRead;
+export type EditAppVersionToolApiArg = {
+  /** ID of the target application */
+  appId: number;
+  /** Version # of the target application version */
+  appVersion: number;
+  /** The NPM package name */
+  toolPackageName: string;
+  /** Updated tool configuration for the application version */
+  appVersionToolEdit: AppVersionToolEdit;
 };
 export type ListAllToolsApiResponse = /** status 200 Successful operation */ ToolListRead;
 export type ListAllToolsApiArg = void;
@@ -578,6 +597,10 @@ export type AppVersionToolCreate = {
   hiddenSupportedPolicies?: string[];
   /** Tool version */
   toolVersion: string;
+};
+export type AppVersionToolEdit = {
+  /** Policies that are supported by this tool, but are hidden from users of this app specifically */
+  hiddenSupportedPolicies?: string[];
 };
 export type Tool = {
   /** Timestamp when this was last modified */
@@ -907,6 +930,7 @@ export const {
   useListAppVersionToolsQuery,
   useLazyListAppVersionToolsQuery,
   useCreateAppVersionToolMutation,
+  useEditAppVersionToolMutation,
   useListAllToolsQuery,
   useLazyListAllToolsQuery,
   useCreateToolMutation,

--- a/packages/libs/registry-sdk/src/lib/openApi/app.ts
+++ b/packages/libs/registry-sdk/src/lib/openApi/app.ts
@@ -6,6 +6,7 @@ import {
   appVersionCreate,
   appVersionEdit,
   appVersionToolCreate,
+  appVersionToolEdit,
   appVersionToolDoc,
 } from '../schemas/appVersion';
 import { DeleteResponse, ErrorResponse } from './baseRegistry';
@@ -33,6 +34,7 @@ export function addToRegistry(registry: OpenAPIRegistry) {
   const AppVersionRead = registry.register('AppVersion', appVersionDoc);
 
   const AppVersionToolCreate = registry.register('AppVersionToolCreate', appVersionToolCreate);
+  const AppVersionToolEdit = registry.register('AppVersionToolEdit', appVersionToolEdit);
   const AppVersionToolRead = registry.register('AppVersionTool', appVersionToolDoc);
 
   // GET /apps - List all applications
@@ -538,6 +540,58 @@ export function addToRegistry(registry: OpenAPIRegistry) {
       },
       400: {
         description: 'Invalid input',
+      },
+      422: {
+        description: 'Validation exception',
+      },
+      default: {
+        description: 'Unexpected error',
+        content: {
+          'application/json': {
+            schema: ErrorResponse,
+          },
+        },
+      },
+    },
+  });
+
+  // PUT /app/{appId}/version/{appVersion}/tool/{toolPackageName} - Edit a tool for an application version
+  registry.registerPath({
+    method: 'put',
+    path: '/app/{appId}/version/{appVersion}/tool/{toolPackageName}',
+    tags: ['app/version/tool'],
+    summary: 'Edits a tool for an application version',
+    operationId: 'editAppVersionTool',
+    request: {
+      params: z.object({
+        appId: appIdParam,
+        appVersion: appVersionParam,
+        toolPackageName: packageNameParam,
+      }),
+      body: {
+        content: {
+          'application/json': {
+            schema: AppVersionToolEdit,
+          },
+        },
+        description: 'Updated tool configuration for the application version',
+        required: true,
+      },
+    },
+    responses: {
+      200: {
+        description: 'Successful operation',
+        content: {
+          'application/json': {
+            schema: AppVersionToolRead,
+          },
+        },
+      },
+      400: {
+        description: 'Invalid input',
+      },
+      404: {
+        description: 'Application, version, or tool not found',
       },
       422: {
         description: 'Validation exception',

--- a/packages/libs/registry-sdk/src/lib/schemas/appVersion.ts
+++ b/packages/libs/registry-sdk/src/lib/schemas/appVersion.ts
@@ -103,6 +103,20 @@ function buildCreateAppVersionToolSchema() {
 
 export const appVersionToolCreate = buildCreateAppVersionToolSchema();
 
+// Avoiding using z.omit() or z.pick() due to excessive TS type inference costs
+function buildEditAppVersionToolSchema() {
+  const { hiddenSupportedPolicies } = appVersionTool.shape;
+
+  return z
+    .object({
+      // Only hiddenSupportedPolicies can be edited
+      hiddenSupportedPolicies,
+    })
+    .strict();
+}
+
+export const appVersionToolEdit = buildEditAppVersionToolSchema();
+
 /** appVersionToolDoc describes a complete application version's tool document, with all properties including those that are database-backend
  * specific like _id and updated/created at timestamps.
  *

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -196,8 +196,8 @@ importers:
         specifier: 1.0.1
         version: 1.0.1(@walletconnect/modal@2.7.0(@types/react@19.1.8)(react@19.1.0))(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)
       '@lit-protocol/vincent-registry-sdk':
-        specifier: ^2.0.0
-        version: 2.0.0(react-redux@9.2.0(@types/react@19.1.8)(react@19.1.0)(redux@5.0.1))(react@19.1.0)
+        specifier: ^2.1.0
+        version: 2.1.0(react-redux@9.2.0(@types/react@19.1.8)(react@19.1.0)(redux@5.0.1))(react@19.1.0)
       '@radix-ui/react-checkbox':
         specifier: ^1.2.3
         version: 1.3.2(@types/react-dom@19.1.6(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
@@ -2203,8 +2203,8 @@ packages:
     resolution: {integrity: sha512-ibDdrZWdrd7RkrJhqLhio/mZPACn0Hc5W7GRNzfTdFr88xu9KRjr0YwfHyc4Q1qevq6nXltZQpuno7pBKUEcxg==}
     engines: {node: ^20.11.1, pnpm: 10.7.0}
 
-  '@lit-protocol/vincent-registry-sdk@2.0.0':
-    resolution: {integrity: sha512-bRk/4KnPhBvZ6DeVJVX9K2nqqAOfitBrMUzk6n2KeXIHhwLxMmUWEZw1/gLYsKa34wFvbsWmH9XmlpAklRdKxg==}
+  '@lit-protocol/vincent-registry-sdk@2.1.0':
+    resolution: {integrity: sha512-Hbsx58P3wlGQyIoRCiQoN816EitYzBLoqaUWGYMc5AhymIaqAArKOphIbIhD1lDSkOwiA6+mC+TW6z+Emax8Ug==}
 
   '@lit-protocol/vincent-tool-sdk@1.0.1':
     resolution: {integrity: sha512-wSGlLCFnL/uTqWnK3N4pQvOhPniKTG1Te3UAs+lOj+hjiiFfDQ7WPpTMqEZ7koMz8Xviq4bZTCeMOPdX5exFvA==}
@@ -12981,7 +12981,7 @@ snapshots:
       - uploadthing
       - utf-8-validate
 
-  '@lit-protocol/vincent-registry-sdk@2.0.0(react-redux@9.2.0(@types/react@19.1.8)(react@19.1.0)(redux@5.0.1))(react@19.1.0)':
+  '@lit-protocol/vincent-registry-sdk@2.1.0(react-redux@9.2.0(@types/react@19.1.8)(react@19.1.0)(redux@5.0.1))(react@19.1.0)':
     dependencies:
       '@asteasolutions/zod-to-openapi': 7.3.4(zod@3.25.64)
       '@reduxjs/toolkit': 2.8.2(react-redux@9.2.0(@types/react@19.1.8)(react@19.1.0)(redux@5.0.1))(react@19.1.0)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -22,8 +22,8 @@ importers:
         specifier: ^9.25.1
         version: 9.29.0
       '@lit-protocol/flags':
-        specifier: ^2.0.0
-        version: 2.0.0
+        specifier: ^2.1.0
+        version: 2.1.0
       '@nx/esbuild':
         specifier: 21.2.1
         version: 21.2.1(@babel/traverse@7.27.4)(@swc-node/register@1.9.2(@swc/core@1.5.29(@swc/helpers@0.5.17))(@swc/types@0.1.23)(typescript@5.8.3))(@swc/core@1.5.29(@swc/helpers@0.5.17))(esbuild@0.19.12)(nx@21.2.1(@swc-node/register@1.9.2(@swc/core@1.5.29(@swc/helpers@0.5.17))(@swc/types@0.1.23)(typescript@5.8.3))(@swc/core@1.5.29(@swc/helpers@0.5.17)))
@@ -408,8 +408,8 @@ importers:
   packages/apps/registry-backend:
     dependencies:
       '@lit-protocol/flags':
-        specifier: 2.0.0
-        version: 2.0.0
+        specifier: ^2.1.0
+        version: 2.1.0
       '@lit-protocol/vincent-registry-sdk':
         specifier: workspace:*
         version: link:../../libs/registry-sdk
@@ -2154,11 +2154,6 @@ packages:
 
   '@lit-protocol/crypto@7.2.0':
     resolution: {integrity: sha512-Y1UyofhMXAHwbu6R14CZIHoEbXvVHrvD8kiL6C4LX0bYvfCsm73XEvTAQc80uRIg6GhfZHNBgqdaGpwJ2YjX8A==}
-
-  '@lit-protocol/flags@2.0.0':
-    resolution: {integrity: sha512-EbeNHZQgNxwPADrLOXHW5GP6HaXGjlMDq6FYvQiX5mG5ogYouu1CdWzfIv8oRqKmHlg/RUgU/8OWn9gBR9afZw==}
-    engines: {node: ^20.11.1, pnpm: 10.7.0}
-    hasBin: true
 
   '@lit-protocol/flags@2.1.0':
     resolution: {integrity: sha512-rb3jtVLAWBL074M1dqexpprdUvUmrFbMOGQ0rbEYoWT+ZRH+6aaO0G3k/kKnqVVva6nv2TBnibr5bBrVo1p28g==}
@@ -12472,8 +12467,6 @@ snapshots:
       - bufferutil
       - typescript
       - utf-8-validate
-
-  '@lit-protocol/flags@2.0.0': {}
 
   '@lit-protocol/flags@2.1.0': {}
 


### PR DESCRIPTION
# Description
#### registry-sdk
- Adds edit appVersionTool endpoint definition to facilitate modification of `hiddenSupportedPolicies`

#### registry-backend
- Implements missing AppTool management routes along with the new edit route
- Adds an integration test suite to verify that the routes are working as expected
- Added `registry-backend` to `nx release` awareness so we can start generating changelogs for the service from now on, and keep track of deployments by semver
- Fixed missing `bin` entry in the package.json 🤦 🤦‍♂️ 😶‍🌫️ 
- Fixed mismatched `@lit-protocol/flags` version. Syncpack, here we come 💯 🥇 
- Fixed incorrect configuration in tsconfig.app.json -- it wasn't including the featureState.json file 🤦 😓 

#### Updated `app-dashboard` dependency
- Now using explicit `vincent-registry-sdk@^2.1.0`


## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [X] Ran all tests

# Checklist:

- [x] I created a [release plan](https://nx.dev/recipes/nx-release/file-based-versioning-version-plans) (`nx release plan`) describing my changes and the version bump
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
