### PR TITLE
fix: remove docs customTitle from `typedoc.site.config.js`

### DIFF
--- a/typedoc.site.config.js
+++ b/typedoc.site.config.js
@@ -31,7 +31,6 @@ module.exports = {
   entryPoints: ['./packages/libs/app-sdk/docs/json', './packages/libs/tool-sdk/docs/json'],
   name: 'Vincent Docs',
   out: './docs/dist/site',
-  customTitle: 'Why Vincent?',
   includeVersion: false,
   navigation: {
     includeCategories: true,


### PR DESCRIPTION
# Description

Remove `customTitle` attribute from `typedoc.site.config.js` so that the title of the docs are no longer `Why Vincent?` and are instead just `Vincent Docs`

# Checklist:

- [ ] I created a [release plan](https://nx.dev/recipes/nx-release/file-based-versioning-version-plans) (`nx release plan`) describing my changes and the version bump
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
