### PR TITLE
fix: Registry backend `mkdtemp` not found

### DIFF
--- a/.nx/version-plans/version-plan-1750973463839.md
+++ b/.nx/version-plans/version-plan-1750973463839.md
@@ -1,0 +1,8 @@
+---
+registry-backend: patch
+---
+
+Fix mkdtemp not found in production deployment to Heroku
+
+- The ESM version of `fs-extra` doesn't pass through methods through; when we deploy to production, that's the package that gets used
+- This was working coincidentally for local dev because of transpilation / CJS references. :sad_panda:

--- a/.nx/version-plans/version-plan-1750973463839.md
+++ b/.nx/version-plans/version-plan-1750973463839.md
@@ -1,8 +1,0 @@
----
-registry-backend: patch
----
-
-Fix mkdtemp not found in production deployment to Heroku
-
-- The ESM version of `fs-extra` doesn't pass through methods through; when we deploy to production, that's the package that gets used
-- This was working coincidentally for local dev because of transpilation / CJS references. :sad_panda:

--- a/packages/apps/registry-backend/CHANGELOG.md
+++ b/packages/apps/registry-backend/CHANGELOG.md
@@ -1,3 +1,16 @@
+## 0.2.1 (2025-06-26)
+
+### 🩹 Fixes
+
+- Fix mkdtemp not found in production deployment to Heroku ([92733bbd](https://github.com/LIT-Protocol/Vincent/commit/92733bbd))
+
+  - The ESM version of `fs-extra` doesn't pass through methods through; when we deploy to production, that's the package that gets used
+  - This was working coincidentally for local dev because of transpilation / CJS references. :sad_panda:
+
+### ❤️ Thank You
+
+- Daryl Collins
+
 ## 0.2.0 (2025-06-25)
 
 ### 🚀 Features

--- a/packages/apps/registry-backend/package.json
+++ b/packages/apps/registry-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lit-protocol/registry-backend",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "private": true,
   "type:": "module",
   "scripts": {

--- a/packages/libs/registry-sdk/src/test.mjs
+++ b/packages/libs/registry-sdk/src/test.mjs
@@ -1,0 +1,116 @@
+import { z } from 'zod';
+
+// Define the schema for an array of valid URLs
+const urlArraySchema = z.array(z.string().url());
+
+console.log('=== Zod URL Array Validation Demo ===\n');
+
+// Test 1: Valid URLs
+console.log('1. Testing with valid URLs:');
+const validUrls = ['https://example.com', 'http://google.com', 'https://github.com/user/repo'];
+
+console.log('Input:', validUrls);
+const validResult = urlArraySchema.safeParse(validUrls);
+console.log('Success:', validResult.success);
+if (validResult.success) {
+  console.log('Parsed data:', validResult.data);
+}
+console.log('\n---\n');
+
+// Test 2: Mixed valid and invalid URLs
+console.log('2. Testing with mixed valid/invalid URLs:');
+const mixedUrls = [
+  'https://example.com', // valid
+  'not-a-url', // invalid
+  'http://valid.com', // valid
+  'invalid-url-2', // invalid
+  'ftp://files.com', // valid
+];
+
+console.log('Input:', mixedUrls);
+const mixedResult = urlArraySchema.safeParse(mixedUrls);
+console.log('Success:', mixedResult.success);
+
+if (!mixedResult.success) {
+  const error = mixedResult.error;
+
+  console.log('\n--- ERROR SHAPE DEMONSTRATION ---');
+
+  // Show the raw error structure
+  console.log('\nRaw error issues:');
+  error.issues.forEach((issue, index) => {
+    console.log(`Issue ${index + 1}:`, {
+      code: issue.code,
+      validation: issue.validation,
+      path: issue.path,
+      message: issue.message,
+      received: issue.received,
+    });
+  });
+
+  // Show formatted errors
+  console.log('\nFormatted errors:');
+  const formatted = error.format();
+  console.log(JSON.stringify(formatted, null, 2));
+
+  // Show flattened errors
+  console.log('\nFlattened errors:');
+  const flattened = error.flatten();
+  console.log('Form errors:', flattened.formErrors);
+  console.log('Field errors:', flattened.fieldErrors);
+
+  // Show the main error message
+  console.log('\nMain error message:');
+  console.log(error.message);
+
+  // Demonstrate accessing specific errors by index
+  console.log('\nAccessing errors by array index:');
+  error.issues.forEach((issue) => {
+    const arrayIndex = issue.path[0];
+    console.log(`Array index ${arrayIndex}: "${mixedUrls[arrayIndex]}" - ${issue.message}`);
+  });
+}
+
+console.log('\n---\n');
+
+// Test 3: All invalid URLs
+console.log('3. Testing with all invalid URLs:');
+const allInvalidUrls = ['not-a-url', 'also-invalid', 'still-not-valid'];
+
+console.log('Input:', allInvalidUrls);
+const allInvalidResult = urlArraySchema.safeParse(allInvalidUrls);
+console.log('Success:', allInvalidResult.success);
+
+if (!allInvalidResult.success) {
+  console.log(`\nNumber of validation errors: ${allInvalidResult.error.issues.length}`);
+  console.log('All errors:');
+  allInvalidResult.error.issues.forEach((issue, index) => {
+    console.log(`  ${index + 1}. Index ${issue.path[0]}: ${issue.message}`);
+  });
+}
+
+console.log('\n---\n');
+
+// Test 4: Empty array
+console.log('4. Testing with empty array:');
+const emptyArray = [];
+console.log('Input:', emptyArray);
+const emptyResult = urlArraySchema.safeParse(emptyArray);
+console.log('Success:', emptyResult.success);
+console.log('Data:', emptyResult.success ? emptyResult.data : 'N/A');
+
+console.log('\n---\n');
+
+// Test 5: Non-array input
+console.log('5. Testing with non-array input:');
+const nonArray = 'https://example.com';
+console.log('Input:', nonArray);
+const nonArrayResult = urlArraySchema.safeParse(nonArray);
+console.log('Success:', nonArrayResult.success);
+
+if (!nonArrayResult.success) {
+  console.log('Error type:', nonArrayResult.error.issues[0].code);
+  console.log('Error message:', nonArrayResult.error.issues[0].message);
+}
+
+console.log('\n=== Demo Complete ===');


### PR DESCRIPTION
# Description

Problem was that ESM `fs-extra` doesn't pass-through native `node:fs` methods.
It works fine in local dev because the CJS version was being used, but Heroku is using the native ESM. 🤦 

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

# Checklist:

- [X] I created a [release plan](https://nx.dev/recipes/nx-release/file-based-versioning-version-plans) (`nx release plan`) describing my changes and the version bump
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
