### PR TITLE
Feature/node 4328 move react auth components to vincent sdk

### DIFF
--- a/packages/libs/app-sdk/package.json
+++ b/packages/libs/app-sdk/package.json
@@ -33,6 +33,7 @@
     "@noble/secp256k1": "^2.2.3",
     "did-jwt": "^8.0.8",
     "ethers": "5.8.0",
+    "react": "^19.0.0",
     "tslib": "^2.8.1",
     "zod": "3.25.64"
   },
@@ -45,6 +46,7 @@
     "@lit-protocol/pkp-ethers": "^7.2.0",
     "@lit-protocol/types": "^7.0.8",
     "@types/express": "^5.0.1",
+    "@types/react": "^19.0.10",
     "chokidar-cli": "^3.0.0",
     "live-server": "^1.2.2",
     "typedoc": "0.27.9",

--- a/packages/libs/app-sdk/src/express-authentication-middleware/express.ts
+++ b/packages/libs/app-sdk/src/express-authentication-middleware/express.ts
@@ -34,7 +34,7 @@ function assertAuthenticatedRequest(req: Request): asserts req is AuthenticatedR
  * If the `req.user` property isn't the correct shape, it sends a `401 Unauthorized` response to the client.
  *
  * NOTE: This does not verify signatures or any other content -- use `getAuthenticateUserExpressHandler` to create a
- * middleware that does those things and ensure that your routes use it.
+ * middleware that does those things and ensures that your routes use it.
  *
  * See [express.js documentation](https://expressjs.com/en/guide/writing-middleware.html) for details on writing your route handler
  * @example
@@ -72,7 +72,7 @@ export const authenticatedRequestHandler =
  * Creates an Express middleware function to authenticate a user using a JWT token.
  *
  * This middleware checks the `Authorization` header for a Bearer token, verifies the token, and checks its audience.
- * If the token is valid, it attaches the user information (decoded JWT, raw token, and PKP address) to the request object as `req.user`.
+ * If the token is valid, it attaches the user information (raw token and decoded JWT with PKP, app, and authentication info) to the request object as `req.user`.
  * If the token is missing or invalid, it returns a 401 Unauthorized response with an error message.
  *
  * NOTE: Wrap your route handler functions with `authenticatedRequestHandler()` to assert the type of `Request` and to

--- a/packages/libs/app-sdk/src/index.ts
+++ b/packages/libs/app-sdk/src/index.ts
@@ -33,3 +33,6 @@ export type { BaseToolContext } from './toolClient';
 import * as expressAuthHelpers from './express-authentication-middleware';
 export { expressAuthHelpers };
 export type { ExpressAuthHelpers } from './express-authentication-middleware/types';
+
+import * as reactHelpers from './react';
+export { reactHelpers };

--- a/packages/libs/app-sdk/src/jwt/types.ts
+++ b/packages/libs/app-sdk/src/jwt/types.ts
@@ -2,6 +2,16 @@ import type { PKPEthersWallet } from '@lit-protocol/pkp-ethers';
 import type { IRelayPKP } from '@lit-protocol/types';
 import type { JWTHeader, JWTPayload } from 'did-jwt';
 
+export interface AppInfo {
+  id: string;
+  version: number;
+}
+
+export interface AuthenticationInfo {
+  type: string;
+  value?: string;
+}
+
 // Copied interface from did-jwt that is not exposed publicly
 interface JWTDecoded {
   header: JWTHeader;
@@ -28,14 +38,8 @@ export interface JWTConfig {
   payload: Record<string, unknown>;
   expiresInMinutes: number;
   audience: string | string[];
-  app: {
-    id: string;
-    version: number;
-  };
-  authentication: {
-    type: string;
-    value?: string;
-  };
+  app: AppInfo;
+  authentication: AuthenticationInfo;
 }
 
 /**
@@ -51,14 +55,8 @@ export interface JWTConfig {
  */
 export interface VincentJWTPayload extends JWTPayload {
   pkp: IRelayPKP;
-  app: {
-    id: string;
-    version: number;
-  };
-  authentication: {
-    type: string;
-    value?: string;
-  };
+  app: AppInfo;
+  authentication: AuthenticationInfo;
 }
 
 /**

--- a/packages/libs/app-sdk/src/react/index.ts
+++ b/packages/libs/app-sdk/src/react/index.ts
@@ -1,0 +1,2 @@
+export * from './jwtProvider';
+export * from './useVincentWebAppClient';

--- a/packages/libs/app-sdk/src/react/jwtProvider.tsx
+++ b/packages/libs/app-sdk/src/react/jwtProvider.tsx
@@ -1,0 +1,266 @@
+import React, {
+  createContext,
+  useCallback,
+  useContext,
+  useMemo,
+  useState,
+  useEffect,
+  FC,
+  ReactNode,
+} from 'react';
+import { IRelayPKP } from '@lit-protocol/types';
+
+import { verify } from '../jwt';
+import type { AppInfo, AuthenticationInfo } from '../jwt/types';
+import { useVincentWebAppClient } from './useVincentWebAppClient';
+
+/**
+ * Interface representing the authenticated user information.
+ *
+ * Contains details about the application, authentication method, JWT token,
+ * and the PKP (Programmable Key Pair) associated with the authenticated user.
+ */
+export interface AuthInfo {
+  app: AppInfo;
+  authentication: AuthenticationInfo;
+  jwt: string;
+  pkp: IRelayPKP;
+}
+
+interface JwtContextType {
+  authInfo: AuthInfo | null;
+  loading: boolean;
+  connect: (redirectUri: string) => void;
+  loginWithJwt: () => void;
+  logOut: () => void;
+}
+
+function jwtContextNotInitialized() {
+  throw new Error('JwtContext must be used within an JwtProvider');
+}
+
+export const JwtContext = createContext<JwtContextType>({
+  authInfo: null,
+  loading: false,
+  connect: jwtContextNotInitialized,
+  loginWithJwt: jwtContextNotInitialized,
+  logOut: jwtContextNotInitialized,
+});
+
+/**
+ * React hook to access the JWT authentication context.
+ *
+ * This hook provides access to authentication state and methods for managing JWT-based
+ * authentication in Vincent applications. It must be used within a component that is a
+ * descendant of JwtProvider.
+ *
+ * @example
+ * ```tsx
+ * import { useJwtContext } from '@lit-protocol/vincent-sdk';
+ *
+ * function AuthenticatedComponent() {
+ *   const { authInfo, loading, loginWithJwt, logOut } = useJwtContext();
+ *
+ *   if (loading) {
+ *     return <div>Loading authentication...</div>;
+ *   }
+ *
+ *   if (!authInfo) {
+ *     return (
+ *       <button onClick={loginWithJwt}>
+ *         Login
+ *       </button>
+ *     );
+ *   }
+ *
+ *   return (
+ *     <div>
+ *       <p>Logged in with PKP: {authInfo.pkp.ethAddress}</p>
+ *       <button onClick={logOut}>Logout</button>
+ *     </div>
+ *   );
+ * }
+ * ```
+ *
+ * @returns The JWT context containing authentication state and methods
+ */
+export function useJwtContext(): JwtContextType {
+  return useContext(JwtContext);
+}
+
+/**
+ * Interface for storage providers that can be used with JwtProvider.
+ *
+ * This allows you to use custom storage solutions (like AsyncStorage in React Native)
+ * instead of the default localStorage.
+ */
+export interface AsyncStorage {
+  getItem: (key: string) => Promise<string | null>;
+  setItem: (key: string, value: string) => Promise<void>;
+  removeItem: (key: string) => Promise<void>;
+}
+
+interface JwtProviderProps {
+  children: ReactNode;
+  appId: string;
+  storage?: AsyncStorage;
+  storageKeyBuilder?: (appId: string) => string;
+}
+
+/**
+ * React component that provides JWT authentication capabilities for Vincent applications.
+ *
+ * The JwtProvider handles JWT token management, including
+ * - Retrieving and validating JWTs from the Vincent consent page
+ * - Storing and retrieving JWTs from persistent storage
+ * - Providing authentication state and methods to child components
+ * - Managing login/logout flows
+ *
+ * It uses the Context API to make authentication information and methods available
+ * throughout your application without prop drilling.
+ *
+ * @example
+ * ```tsx
+ * import { JwtProvider } from '@lit-protocol/vincent-sdk';
+ *
+ * function App() {
+ *   return (
+ *     <JwtProvider appId="your-vincent-app-id">
+ *       <YourApplication />
+ *     </JwtProvider>
+ *   );
+ * }
+ *
+ * // In a child component:
+ * function LoginButton() {
+ *   const { authInfo, loading, connect, logOut } = useJwtContext();
+ *
+ *   if (loading) return <div>Loading...</div>;
+ *
+ *   if (authInfo) {
+ *     return (
+ *       <div>
+ *         <p>Logged in as: {authInfo.pkp.ethAddress}</p>
+ *         <button onClick={logOut}>Log out</button>
+ *       </div>
+ *     );
+ *   }
+ *
+ *   return (
+ *     <button
+ *       onClick={() => connect(window.location.href)}
+ *     >
+ *       Login with Vincent
+ *     </button>
+ *   );
+ * }
+ * ```
+ *
+ * @param props - Props for the JwtProvider component
+ * @param props.children - Child components that will have access to the JWT context
+ * @param props.appId - Your Vincent App Id
+ * @param props.storage - Optional custom storage implementation (defaults to localStorage)
+ * @param props.storageKeyBuilder - Optional function to customize the storage key for JWT tokens
+ */
+export const JwtProvider: FC<JwtProviderProps> = ({
+  children,
+  appId,
+  storage = localStorage,
+  storageKeyBuilder = (appId) => `vincent-${appId}-jwt`,
+}) => {
+  const appJwtKey = storageKeyBuilder(appId);
+  const vincentWebAppClient = useVincentWebAppClient(appId);
+  const [authInfo, setAuthInfo] = useState<AuthInfo | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  const logOut = useCallback(async () => {
+    try {
+      setLoading(true);
+      await storage.removeItem(appJwtKey);
+      setAuthInfo(null);
+    } catch (error) {
+      console.error(
+        `Error logging out. Could not remove your JWT from storage: ${(error as Error).message}`
+      );
+    } finally {
+      setLoading(false);
+    }
+  }, [appJwtKey, storage]);
+
+  const connect = useCallback(
+    (redirectUri: string) => {
+      // Redirect to Vincent Auth consent page with appId and version
+      vincentWebAppClient.redirectToConsentPage({
+        // consentPageUrl: `http://localhost:5173/`,
+        redirectUri,
+      });
+    },
+    [vincentWebAppClient]
+  );
+
+  const getJwt = useCallback(async () => {
+    if (vincentWebAppClient.isLogin()) {
+      const jwtResult = vincentWebAppClient.decodeVincentLoginJWT(window.location.origin);
+
+      if (!jwtResult) {
+        return null;
+      }
+
+      const { decodedJWT, jwtStr } = jwtResult;
+      await storage.setItem(appJwtKey, jwtStr);
+      vincentWebAppClient.removeLoginJWTFromURI();
+
+      return { jwtStr, decodedJWT };
+    }
+
+    const existingJwtStr = await storage.getItem(appJwtKey);
+    if (!existingJwtStr) {
+      return null;
+    }
+
+    const decodedJWT = verify(existingJwtStr, window.location.origin);
+
+    return { jwtStr: existingJwtStr, decodedJWT };
+  }, [appJwtKey, storage, vincentWebAppClient]);
+
+  const loginWithJwt = useCallback(async () => {
+    try {
+      setLoading(true);
+
+      const jwtResult = await getJwt();
+      if (!jwtResult) {
+        throw new Error('Could not get JWT');
+      }
+
+      const { decodedJWT, jwtStr } = jwtResult;
+      setAuthInfo({
+        app: decodedJWT.payload.app,
+        authentication: decodedJWT.payload.authentication,
+        jwt: jwtStr,
+        pkp: decodedJWT.payload.pkp,
+      });
+    } catch (error) {
+      console.error(`Error logging in with JWT. Need to relogin: ${(error as Error).message}`);
+      await logOut();
+    } finally {
+      setLoading(false);
+    }
+  }, [getJwt, logOut]);
+
+  const value = useMemo<JwtContextType>(
+    () => ({
+      authInfo,
+      connect,
+      loading,
+      loginWithJwt,
+      logOut,
+    }),
+    [authInfo, connect, loading, loginWithJwt, logOut]
+  );
+
+  useEffect(() => {
+    loginWithJwt();
+  }, [loginWithJwt]);
+
+  return <JwtContext.Provider value={value}>{children}</JwtContext.Provider>;
+};

--- a/packages/libs/app-sdk/src/react/useVincentWebAppClient.ts
+++ b/packages/libs/app-sdk/src/react/useVincentWebAppClient.ts
@@ -1,0 +1,51 @@
+import { useMemo } from 'react';
+
+import { getVincentWebAppClient } from '../app';
+
+/**
+ * React hook that provides a memoized VincentWebAppClient instance.
+ *
+ * This hook creates a VincentWebAppClient instance using the provided App ID and memoizes it
+ * to prevent unnecessary re-creation of the client on each render. The client is only
+ * re-created when the App ID changes.
+ *
+ * The VincentWebAppClient provides methods for authentication, JWT handling, and redirecting
+ * to consent pages in Vincent applications.
+ *
+ * @example
+ * ```typescript
+ * import { useVincentWebAppClient } from '@lit-protocol/vincent-sdk';
+ *
+ * function MyComponent() {
+ *   // Create a memoized Vincent Web App client
+ *   const vincentClient = useVincentWebAppClient('my-app-id');
+ *
+ *   // Check if the user is logging in
+ *   useEffect(() => {
+ *     if (vincentClient.isLogin()) {
+ *       const jwtResult = vincentClient.decodeVincentLoginJWT(window.location.origin);
+ *       // Handle successful login
+ *       console.log('User logged in with PKP address:', jwtResult.pkpAddress);
+ *
+ *       // Remove JWT from URI to prevent issues with browser history
+ *       vincentClient.removeLoginJWTFromURI();
+ *     }
+ *   }, [vincentClient]);
+ *
+ *   // Function to handle the login button click
+ *   const handleLogin = () => {
+ *     vincentClient.redirectToConsentPage({
+ *       redirectUri: window.location.href,
+ *     });
+ *   };
+ *
+ *   return <button onClick={handleLogin}>Login with Vincent</button>;
+ * }
+ * ```
+ *
+ * @param appId - The unique identifier for your Vincent application
+ * @returns A memoized VincentWebAppClient instance
+ */
+export const useVincentWebAppClient = (appId: string) => {
+  return useMemo(() => getVincentWebAppClient({ appId }), [appId]);
+};

--- a/packages/libs/app-sdk/tsconfig.lib.json
+++ b/packages/libs/app-sdk/tsconfig.lib.json
@@ -17,7 +17,8 @@
     "esModuleInterop": true,
     "resolveJsonModule": true,
     "skipLibCheck": true,
-    "composite": true
+    "composite": true,
+    "jsx": "react"
   },
   "include": ["src"],
   "exclude": ["node_modules", "dist", "tests", "**/*.spec.ts", "**/*.test.ts", "toolClient"],

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -188,7 +188,7 @@ importers:
         version: 7.2.0(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)
       '@lit-protocol/pkp-ethers':
         specifier: ^7.2.0
-        version: 7.2.0(@walletconnect/modal@2.7.0)(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)
+        version: 7.2.0(@walletconnect/modal@2.7.0(@types/react@19.1.8)(react@19.1.0))(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)
       '@lit-protocol/types':
         specifier: ^7.0.8
         version: 7.2.0(bufferutil@4.0.9)(utf-8-validate@5.0.10)
@@ -491,7 +491,7 @@ importers:
         version: 5.8.0(bufferutil@4.0.9)(utf-8-validate@5.0.10)
       jest:
         specifier: ^29.5.0
-        version: 29.7.0(@types/node@20.19.1)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.5.29(@swc/helpers@0.5.17))(@types/node@20.19.1)(typescript@5.8.3))
+        version: 29.7.0(@types/node@20.19.1)(babel-plugin-macros@3.1.0)(ts-node@10.9.1(@swc/core@1.5.29(@swc/helpers@0.5.17))(@types/node@20.19.1)(typescript@5.8.3))
       jest-process-manager:
         specifier: ^0.2.9
         version: 0.2.9(debug@4.4.1)
@@ -500,7 +500,7 @@ importers:
         version: 10.1.4
       ts-jest:
         specifier: ^29.1.0
-        version: 29.4.0(@babel/core@7.27.4)(@jest/transform@30.0.2)(@jest/types@30.0.1)(babel-jest@29.7.0(@babel/core@7.27.4))(esbuild@0.19.12)(jest-util@30.0.2)(jest@29.7.0(@types/node@20.19.1)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.5.29(@swc/helpers@0.5.17))(@types/node@20.19.1)(typescript@5.8.3)))(typescript@5.8.3)
+        version: 29.4.0(@babel/core@7.27.4)(@jest/transform@30.0.2)(@jest/types@30.0.1)(babel-jest@29.7.0(@babel/core@7.27.4))(esbuild@0.19.12)(jest-util@30.0.2)(jest@29.7.0(@types/node@20.19.1)(babel-plugin-macros@3.1.0)(ts-node@10.9.1(@swc/core@1.5.29(@swc/helpers@0.5.17))(@types/node@20.19.1)(typescript@5.8.3)))(typescript@5.8.3)
       unbuild:
         specifier: ^3.5.0
         version: 3.5.0(typescript@5.8.3)
@@ -648,6 +648,9 @@ importers:
       ethers:
         specifier: 5.8.0
         version: 5.8.0(bufferutil@4.0.9)(utf-8-validate@5.0.10)
+      react:
+        specifier: ^19.0.0
+        version: 19.1.0
       tslib:
         specifier: ^2.8.1
         version: 2.8.1
@@ -657,13 +660,16 @@ importers:
     devDependencies:
       '@lit-protocol/pkp-ethers':
         specifier: ^7.2.0
-        version: 7.2.0(@walletconnect/modal@2.7.0)(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)
+        version: 7.2.0(@walletconnect/modal@2.7.0(@types/react@19.1.8)(react@19.1.0))(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)
       '@lit-protocol/types':
         specifier: ^7.0.8
         version: 7.2.0(bufferutil@4.0.9)(utf-8-validate@5.0.10)
       '@types/express':
         specifier: ^5.0.1
         version: 5.0.3
+      '@types/react':
+        specifier: ^19.0.10
+        version: 19.1.8
       chokidar-cli:
         specifier: ^3.0.0
         version: 3.0.0
@@ -12148,41 +12154,6 @@ snapshots:
       - supports-color
       - ts-node
 
-  '@jest/core@29.7.0(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.5.29(@swc/helpers@0.5.17))(@types/node@20.19.1)(typescript@5.8.3))':
-    dependencies:
-      '@jest/console': 29.7.0
-      '@jest/reporters': 29.7.0
-      '@jest/test-result': 29.7.0
-      '@jest/transform': 29.7.0
-      '@jest/types': 29.6.3
-      '@types/node': 20.19.1
-      ansi-escapes: 4.3.2
-      chalk: 4.1.2
-      ci-info: 3.9.0
-      exit: 0.1.2
-      graceful-fs: 4.2.11
-      jest-changed-files: 29.7.0
-      jest-config: 29.7.0(@types/node@20.19.1)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.5.29(@swc/helpers@0.5.17))(@types/node@20.19.1)(typescript@5.8.3))
-      jest-haste-map: 29.7.0
-      jest-message-util: 29.7.0
-      jest-regex-util: 29.6.3
-      jest-resolve: 29.7.0
-      jest-resolve-dependencies: 29.7.0
-      jest-runner: 29.7.0
-      jest-runtime: 29.7.0
-      jest-snapshot: 29.7.0
-      jest-util: 29.7.0
-      jest-validate: 29.7.0
-      jest-watcher: 29.7.0
-      micromatch: 4.0.8
-      pretty-format: 29.7.0
-      slash: 3.0.0
-      strip-ansi: 6.0.1
-    transitivePeerDependencies:
-      - babel-plugin-macros
-      - supports-color
-      - ts-node
-
   '@jest/environment@29.7.0':
     dependencies:
       '@jest/fake-timers': 29.7.0
@@ -12865,7 +12836,7 @@ snapshots:
     dependencies:
       tslib: 1.14.1
 
-  '@lit-protocol/pkp-base@7.2.0(@walletconnect/modal@2.7.0)(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)':
+  '@lit-protocol/pkp-base@7.2.0(@walletconnect/modal@2.7.0(@types/react@19.1.8)(react@19.1.0))(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)':
     dependencies:
       '@ethersproject/abi': 5.7.0
       '@ethersproject/abstract-provider': 5.7.0
@@ -12939,7 +12910,7 @@ snapshots:
       - uploadthing
       - utf-8-validate
 
-  '@lit-protocol/pkp-ethers@7.2.0(@walletconnect/modal@2.7.0)(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)':
+  '@lit-protocol/pkp-ethers@7.2.0(@walletconnect/modal@2.7.0(@types/react@19.1.8)(react@19.1.0))(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)':
     dependencies:
       '@ethersproject/abi': 5.7.0
       '@ethersproject/abstract-provider': 5.7.0
@@ -12974,7 +12945,7 @@ snapshots:
       '@lit-protocol/misc': 7.2.0(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)
       '@lit-protocol/misc-browser': 7.2.0(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)
       '@lit-protocol/nacl': 7.2.0
-      '@lit-protocol/pkp-base': 7.2.0(@walletconnect/modal@2.7.0)(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)
+      '@lit-protocol/pkp-base': 7.2.0(@walletconnect/modal@2.7.0(@types/react@19.1.8)(react@19.1.0))(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)
       '@lit-protocol/types': 7.2.0(bufferutil@4.0.9)(utf-8-validate@5.0.10)
       '@lit-protocol/uint8arrays': 7.2.0(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)
       '@lit-protocol/wasm': 7.2.0(bufferutil@4.0.9)(utf-8-validate@5.0.10)
@@ -17150,21 +17121,6 @@ snapshots:
       - supports-color
       - ts-node
 
-  create-jest@29.7.0(@types/node@20.19.1)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.5.29(@swc/helpers@0.5.17))(@types/node@20.19.1)(typescript@5.8.3)):
-    dependencies:
-      '@jest/types': 29.6.3
-      chalk: 4.1.2
-      exit: 0.1.2
-      graceful-fs: 4.2.11
-      jest-config: 29.7.0(@types/node@20.19.1)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.5.29(@swc/helpers@0.5.17))(@types/node@20.19.1)(typescript@5.8.3))
-      jest-util: 29.7.0
-      prompts: 2.4.2
-    transitivePeerDependencies:
-      - '@types/node'
-      - babel-plugin-macros
-      - supports-color
-      - ts-node
-
   create-require@1.1.1: {}
 
   cross-fetch@3.1.8:
@@ -19353,25 +19309,6 @@ snapshots:
       - supports-color
       - ts-node
 
-  jest-cli@29.7.0(@types/node@20.19.1)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.5.29(@swc/helpers@0.5.17))(@types/node@20.19.1)(typescript@5.8.3)):
-    dependencies:
-      '@jest/core': 29.7.0(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.5.29(@swc/helpers@0.5.17))(@types/node@20.19.1)(typescript@5.8.3))
-      '@jest/test-result': 29.7.0
-      '@jest/types': 29.6.3
-      chalk: 4.1.2
-      create-jest: 29.7.0(@types/node@20.19.1)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.5.29(@swc/helpers@0.5.17))(@types/node@20.19.1)(typescript@5.8.3))
-      exit: 0.1.2
-      import-local: 3.2.0
-      jest-config: 29.7.0(@types/node@20.19.1)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.5.29(@swc/helpers@0.5.17))(@types/node@20.19.1)(typescript@5.8.3))
-      jest-util: 29.7.0
-      jest-validate: 29.7.0
-      yargs: 17.7.2
-    transitivePeerDependencies:
-      - '@types/node'
-      - babel-plugin-macros
-      - supports-color
-      - ts-node
-
   jest-config@29.7.0(@types/node@20.19.1)(babel-plugin-macros@3.1.0)(ts-node@10.9.1(@swc/core@1.5.29(@swc/helpers@0.5.17))(@types/node@20.19.1)(typescript@5.8.3)):
     dependencies:
       '@babel/core': 7.27.4
@@ -19399,37 +19336,6 @@ snapshots:
     optionalDependencies:
       '@types/node': 20.19.1
       ts-node: 10.9.1(@swc/core@1.5.29(@swc/helpers@0.5.17))(@types/node@20.19.1)(typescript@5.8.3)
-    transitivePeerDependencies:
-      - babel-plugin-macros
-      - supports-color
-
-  jest-config@29.7.0(@types/node@20.19.1)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.5.29(@swc/helpers@0.5.17))(@types/node@20.19.1)(typescript@5.8.3)):
-    dependencies:
-      '@babel/core': 7.27.4
-      '@jest/test-sequencer': 29.7.0
-      '@jest/types': 29.6.3
-      babel-jest: 29.7.0(@babel/core@7.27.4)
-      chalk: 4.1.2
-      ci-info: 3.9.0
-      deepmerge: 4.3.1
-      glob: 7.2.3
-      graceful-fs: 4.2.11
-      jest-circus: 29.7.0(babel-plugin-macros@3.1.0)
-      jest-environment-node: 29.7.0
-      jest-get-type: 29.6.3
-      jest-regex-util: 29.6.3
-      jest-resolve: 29.7.0
-      jest-runner: 29.7.0
-      jest-util: 29.7.0
-      jest-validate: 29.7.0
-      micromatch: 4.0.8
-      parse-json: 5.2.0
-      pretty-format: 29.7.0
-      slash: 3.0.0
-      strip-json-comments: 3.1.1
-    optionalDependencies:
-      '@types/node': 20.19.1
-      ts-node: 10.9.2(@swc/core@1.5.29(@swc/helpers@0.5.17))(@types/node@20.19.1)(typescript@5.8.3)
     transitivePeerDependencies:
       - babel-plugin-macros
       - supports-color
@@ -19724,18 +19630,6 @@ snapshots:
       '@jest/types': 29.6.3
       import-local: 3.2.0
       jest-cli: 29.7.0(@types/node@20.19.1)(babel-plugin-macros@3.1.0)(ts-node@10.9.1(@swc/core@1.5.29(@swc/helpers@0.5.17))(@types/node@20.19.1)(typescript@5.8.3))
-    transitivePeerDependencies:
-      - '@types/node'
-      - babel-plugin-macros
-      - supports-color
-      - ts-node
-
-  jest@29.7.0(@types/node@20.19.1)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.5.29(@swc/helpers@0.5.17))(@types/node@20.19.1)(typescript@5.8.3)):
-    dependencies:
-      '@jest/core': 29.7.0(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.5.29(@swc/helpers@0.5.17))(@types/node@20.19.1)(typescript@5.8.3))
-      '@jest/types': 29.6.3
-      import-local: 3.2.0
-      jest-cli: 29.7.0(@types/node@20.19.1)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.5.29(@swc/helpers@0.5.17))(@types/node@20.19.1)(typescript@5.8.3))
     transitivePeerDependencies:
       - '@types/node'
       - babel-plugin-macros
@@ -22510,27 +22404,6 @@ snapshots:
       ejs: 3.1.10
       fast-json-stable-stringify: 2.1.0
       jest: 29.7.0(@types/node@20.19.1)(babel-plugin-macros@3.1.0)(ts-node@10.9.1(@swc/core@1.5.29(@swc/helpers@0.5.17))(@types/node@20.19.1)(typescript@5.8.3))
-      json5: 2.2.3
-      lodash.memoize: 4.1.2
-      make-error: 1.3.6
-      semver: 7.7.2
-      type-fest: 4.41.0
-      typescript: 5.8.3
-      yargs-parser: 21.1.1
-    optionalDependencies:
-      '@babel/core': 7.27.4
-      '@jest/transform': 30.0.2
-      '@jest/types': 30.0.1
-      babel-jest: 29.7.0(@babel/core@7.27.4)
-      esbuild: 0.19.12
-      jest-util: 30.0.2
-
-  ts-jest@29.4.0(@babel/core@7.27.4)(@jest/transform@30.0.2)(@jest/types@30.0.1)(babel-jest@29.7.0(@babel/core@7.27.4))(esbuild@0.19.12)(jest-util@30.0.2)(jest@29.7.0(@types/node@20.19.1)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.5.29(@swc/helpers@0.5.17))(@types/node@20.19.1)(typescript@5.8.3)))(typescript@5.8.3):
-    dependencies:
-      bs-logger: 0.2.6
-      ejs: 3.1.10
-      fast-json-stable-stringify: 2.1.0
-      jest: 29.7.0(@types/node@20.19.1)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.5.29(@swc/helpers@0.5.17))(@types/node@20.19.1)(typescript@5.8.3))
       json5: 2.2.3
       lodash.memoize: 4.1.2
       make-error: 1.3.6


### PR DESCRIPTION
# Description

This adds jwt context, provider and hooks into the sdk for standarized jwt management in react apps. This gives a standard implementation we know works as we were using it in the DCA app
It also improves on that one allowing any type of persistence , not just `localstorage`

For updated usage, check DCA [PR#18](https://github.com/LIT-Protocol/vincent-dca/pull/18)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

# Checklist:

- [ ] I created a [release plan](https://nx.dev/recipes/nx-release/file-based-versioning-version-plans) (`nx release plan`) describing my changes and the version bump
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
