### PR TITLE
Feature/drel 806 fix version mismatch in the jwt

### DIFF
--- a/packages/apps/app-dashboard/src/components/consent/components/AuthenticatedConsentForm.tsx
+++ b/packages/apps/app-dashboard/src/components/consent/components/AuthenticatedConsentForm.tsx
@@ -123,10 +123,10 @@ export default function AuthenticatedConsentForm({
     agentPKP,
     appInfo,
     onStatusChange: showStatus,
-    permittedVersion,
   });
 
-  // Set the fetchExistingParameters ref after it's created
+  // Set the fetchExistingParameters ref after it's created. There is a circular dep between the
+  // useAppPermissionCheck hook and the useParameterManagement hook
   useEffect(() => {
     if (fetchExistingParameters && fetchExistingParametersRef.current !== fetchExistingParameters) {
       fetchExistingParametersRef.current = fetchExistingParameters;
@@ -161,7 +161,6 @@ export default function AuthenticatedConsentForm({
     agentPKP,
     userPKP,
     sessionSigs,
-    permittedVersion,
     onStatusChange: showStatus,
     onError: (error: unknown) => showErrorWithStatus(error as string),
   });
@@ -314,8 +313,7 @@ export default function AuthenticatedConsentForm({
     setSubmitting(true);
     showStatus('Processing approval...', 'info');
     try {
-      const appVersion = permittedVersion || Number(appInfo.latestVersion);
-      if (!agentPKP || !appId || !appVersion) {
+      if (!agentPKP || !appId || !versionInfo) {
         const errorMessage = 'Missing required data. Please try again.';
         setError(errorMessage);
         showErrorWithStatus(errorMessage, 'Missing Data');
@@ -331,6 +329,7 @@ export default function AuthenticatedConsentForm({
       }
 
       showStatus('Generating authentication token...', 'info');
+      const appVersion = Number(versionInfo.appVersion.version);
       const jwt = await generateJWT(appId, appVersion, appInfo);
       updateState({ showSuccess: true });
 
@@ -352,7 +351,6 @@ export default function AuthenticatedConsentForm({
     appInfo,
     showStatus,
     showErrorWithStatus,
-    permittedVersion,
     agentPKP,
     appId,
     useCurrentVersionOnly,
@@ -361,6 +359,7 @@ export default function AuthenticatedConsentForm({
     generateJWT,
     updateState,
     redirectWithJWT,
+    versionInfo,
   ]);
 
   /**

--- a/packages/apps/app-dashboard/src/components/consent/hooks/useConsentApproval.ts
+++ b/packages/apps/app-dashboard/src/components/consent/hooks/useConsentApproval.ts
@@ -49,7 +49,6 @@ interface UseConsentApprovalProps {
   agentPKP?: IRelayPKP;
   userPKP: IRelayPKP;
   sessionSigs: SessionSigs;
-  permittedVersion: number | null;
   onStatusChange?: (message: string, type: 'info' | 'warning' | 'success' | 'error') => void;
   onError?: (error: Error | unknown, title?: string, details?: string) => void;
 }
@@ -67,7 +66,6 @@ export const useConsentApproval = ({
   agentPKP,
   userPKP,
   sessionSigs,
-  permittedVersion,
   onStatusChange,
   onError,
 }: UseConsentApprovalProps) => {
@@ -75,7 +73,6 @@ export const useConsentApproval = ({
     appId,
     agentPKP,
     appInfo,
-    permittedVersion,
     onStatusChange: onStatusChange
       ? (message, type = 'info') => onStatusChange(message, type)
       : undefined,

--- a/packages/apps/app-dashboard/src/components/consent/hooks/useParameterManagement.ts
+++ b/packages/apps/app-dashboard/src/components/consent/hooks/useParameterManagement.ts
@@ -181,44 +181,6 @@ export const useParameterManagement = ({
   }, [fetchExistingParameters]);
 
   useEffect(() => {
-    if (permittedVersion !== null && appId && appInfo && !versionInfo && !useCurrentVersionOnly) {
-      if (updateState) {
-        updateState({ isLoading: true });
-      }
-
-      fetchVersionInfo(permittedVersion)
-        .then(() => {
-          if (updateState) {
-            updateState({ isLoading: false });
-          }
-
-          if (existingParameters.length === 0 && !isLoadingParameters) {
-            fetchExistingParameters();
-          }
-        })
-        .catch((error) => {
-          console.error(`Error fetching version ${permittedVersion} data:`, error);
-          if (updateState) {
-            updateState({ isLoading: false });
-          }
-          onStatusChange?.('Failed to load version data', 'error');
-        });
-    }
-  }, [
-    permittedVersion,
-    appId,
-    appInfo,
-    versionInfo,
-    fetchVersionInfo,
-    fetchExistingParameters,
-    existingParameters.length,
-    isLoadingParameters,
-    updateState,
-    onStatusChange,
-    useCurrentVersionOnly,
-  ]);
-
-  useEffect(() => {
     if (
       useCurrentVersionOnly &&
       existingParameters.length === 0 &&

--- a/packages/apps/app-dashboard/src/components/consent/hooks/useParameterManagement.ts
+++ b/packages/apps/app-dashboard/src/components/consent/hooks/useParameterManagement.ts
@@ -17,8 +17,6 @@ interface UseParameterManagementProps {
   agentPKP?: IRelayPKP;
   appInfo: AppView | null;
   onStatusChange?: (message: string, type?: 'info' | 'warning' | 'success' | 'error') => void;
-  updateState?: (state: any) => void;
-  permittedVersion: number | null;
   useCurrentVersionOnly?: boolean;
   checkingPermissions?: boolean;
   stabilityDelayMs?: number;
@@ -33,8 +31,6 @@ export const useParameterManagement = ({
   agentPKP,
   appInfo,
   onStatusChange,
-  updateState,
-  permittedVersion,
   useCurrentVersionOnly,
   checkingPermissions = false,
   stabilityDelayMs = 100,
@@ -80,7 +76,7 @@ export const useParameterManagement = ({
         );
       }
     },
-    [appId, appInfo, onStatusChange],
+    [appId, appInfo, onStatusChange, setVersionInfo],
   );
 
   /**


### PR DESCRIPTION
# Description

This PR fixes some issues on the consent screen:
- frequently old version data was still displayed (tools, policies, version, etc.)
- JWT was generated using old version of the app when updating

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

- [x] Manually with the repro steps in a lot of scenarios

1. Create and app, define a version
2. Consent to that version with some user
3. Update the app to a new version
4. Test scenarios when consenting again

Scenarios:
- maintaining everything as it is: should just redirect with a jwt with the SAME app version
- update policies: should show SAME version tools and policies and redirect with a jwt with the SAME app version
- update app version: should show UPDATED version tools and policies and redirect with a jwt with the UPDATED app version

# Checklist:

- [ ] I created a [release plan](https://nx.dev/recipes/nx-release/file-based-versioning-version-plans) (`nx release plan`) describing my changes and the version bump
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
