### PR TITLE
Feat: Follow up contracts sdk simplification

### DIFF
--- a/packages/libs/contracts-sdk/src/facets/AppView.ts
+++ b/packages/libs/contracts-sdk/src/facets/AppView.ts
@@ -153,6 +153,30 @@ export async function getAppByDelegatee({ signer, args }: GetAppByDelegateeOptio
 }
 
 /**
+ * Get the app ID associated with a delegatee address
+ * @param signer - The ethers signer to use for the transaction. Could be a standard Ethers Signer or a PKPEthersWallet
+ * @param args - Object containing delegatee address
+ * @returns The app ID if the delegatee is registered, null otherwise
+ */
+export async function getAppIdByDelegatee({
+  signer,
+  args,
+}: GetAppByDelegateeOptions): Promise<string | null> {
+  try {
+    const app = await getAppByDelegatee({ signer, args });
+    return app.id;
+  } catch (error: unknown) {
+    const decodedError = error instanceof Error ? error.message : String(error);
+
+    if (decodedError.includes('DelegateeNotRegistered')) {
+      return null;
+    }
+
+    throw new Error(`Failed to Get App ID By Delegatee: ${decodedError}`);
+  }
+}
+
+/**
  * Get delegated agent PKP token IDs for a specific app version with pagination
  * @param signer - The ethers signer to use for the transaction. Could be a standard Ethers Signer or a PKPEthersWallet
  * @param args - Object containing appId, version, offset, and limit

--- a/packages/libs/contracts-sdk/test/VincentContracts.spec.ts
+++ b/packages/libs/contracts-sdk/test/VincentContracts.spec.ts
@@ -18,6 +18,7 @@ import {
   getAllToolsAndPoliciesForApp,
   setToolPolicyParameters,
   unPermitApp,
+  getAppIdByDelegatee,
 } from '../src/index';
 import { AppVersionTools } from '../src/index';
 import { ethers, providers } from 'ethers';
@@ -163,6 +164,27 @@ describe('VincentContracts', () => {
     expect(appByDelegateeResult.manager).toBe(appManagerSigner.address);
     expect(appByDelegateeResult.latestVersion).toBe(initialAppVersion.newAppVersion);
     expect(appByDelegateeResult.delegatees).toEqual(delegatees);
+
+    // Get app ID by delegatee
+    const appIdByDelegateeResult = await getAppIdByDelegatee({
+      signer: appManagerSigner,
+      args: {
+        delegatee: delegatees[0],
+      },
+    });
+    console.log('App ID by delegatee result:', appIdByDelegateeResult);
+    expect(appIdByDelegateeResult).toBe(appId.toString());
+
+    // Test getAppIdByDelegatee with non-registered delegatee
+    const nonRegisteredDelegatee = ethers.Wallet.createRandom().address;
+    const nonRegisteredAppIdResult = await getAppIdByDelegatee({
+      signer: appManagerSigner,
+      args: {
+        delegatee: nonRegisteredDelegatee,
+      },
+    });
+    console.log('Non-registered delegatee app ID result:', nonRegisteredAppIdResult);
+    expect(nonRegisteredAppIdResult).toBe(null);
 
     // Register next app version
     const nextVersionTools: AppVersionTools = {


### PR DESCRIPTION
# Description

Add more utility functions and API simplifications to the new Contracts-SDK

1. Utility `getAppIdByDelegatee`
2. Graceful empty return value handling instead of throwing an error to differentiate between actual contract errors and empty return values

# Tests

1. New test for `getAppIdByDelegatee