### PR TITLE
feat: Ensure error responses from tools/policies are unambiguous

### DIFF
--- a/.nx/version-plans/version-plan-1752895459475.md
+++ b/.nx/version-plans/version-plan-1752895459475.md
@@ -1,0 +1,12 @@
+---
+tool-sdk: major
+---
+
+### `error` is now `runtimeError` and can only be set by `throw ...`
+
+- Previously, if you had not defined a `deny` or `fail` schema, you could call `deny()` or `fail()` with a string
+- That string would end up in the tool/policy response as the `error` property instead of `result`
+- This was problematic because there was no consistent way to identify _un-handled_ error vs. _explicitly returned fail/deny results_
+- If you don't define a deny or fail schema, you can no longer call those methods with a string.
+- `error` is now `runtimeError`, and is _only_ set if a lifecycle method `throw`s an Error - in that case it will be the `message` property of the error
+- If you want to be able to return simple errors in your _result_, you can define a simple deny or fail schema like `z.object({ error: z.string() }`

--- a/.nx/version-plans/version-plan-1752897136044.md
+++ b/.nx/version-plans/version-plan-1752897136044.md
@@ -1,0 +1,16 @@
+---
+tool-sdk: major
+---
+
+### Add support for explicit `schemaValidationError`
+
+- Previously, a failure to validate either input or results of lifecycle method would result in `result: { zodError }` being returned
+- Now, `result` will be `undefined` and there will be an explicit `schemaValidationError` in the result of the tool / policy
+
+```typescript
+export interface SchemaValidationError {
+  zodError: ZodError<unknown>; // The result of `zod.safeParse().error`
+  phase: string; // Policies: `precheck`|`evaluate`|`commit` - Tools: `precheck` | `execute`
+  stage: string; // `input` | `output`
+}
+```

--- a/.nx/version-plans/version-plan-1752899270846.md
+++ b/.nx/version-plans/version-plan-1752899270846.md
@@ -1,0 +1,16 @@
+---
+app-sdk: major
+---
+
+### Add support for explicit `schemaValidationError`
+
+- Previously, a failure to validate either input or results of lifecycle method would result in `result: { zodError }` being returned
+- Now, `result` will be `undefined` and there will be an explicit `schemaValidationError` in the result of the tool / policy
+
+```typescript
+export interface SchemaValidationError {
+  zodError: ZodError<unknown>; // The result of `zod.safeParse().error`
+  phase: string; // Policies: `precheck`|`evaluate`|`commit` - Tools: `precheck` | `execute`
+  stage: string; // `input` | `output`
+}
+```

--- a/.nx/version-plans/version-plan-1752899318978.md
+++ b/.nx/version-plans/version-plan-1752899318978.md
@@ -1,0 +1,12 @@
+---
+app-sdk: major
+---
+
+### `error` is now `runtimeError` and can only be set by `throw ...`
+
+- Previously, if you had not defined a `deny` or `fail` schema, you could call `deny()` or `fail()` with a string
+- That string would end up in the tool/policy response as the `error` property instead of `result`
+- This was problematic because there was no consistent way to identify _un-handled_ error vs. _explicitly returned fail/deny results_
+- If you don't define a deny or fail schema, you can no longer call those methods with a string.
+- `error` is now `runtimeError`, and is _only_ set if a lifecycle method `throw`s an Error - in that case it will be the `message` property of the error
+- If you want to be able to return simple errors in your _result_, you can define a simple deny or fail schema like `z.object({ error: z.string() }`

--- a/packages/libs/app-sdk/src/toolClient/execute/resultCreators.ts
+++ b/packages/libs/app-sdk/src/toolClient/execute/resultCreators.ts
@@ -5,6 +5,7 @@ import type { z } from 'zod';
 import type {
   BaseToolContext,
   PolicyEvaluationResultContext,
+  SchemaValidationError,
 } from '@lit-protocol/vincent-tool-sdk';
 
 import type {
@@ -64,15 +65,15 @@ export function createDenyEvaluationResult<PoliciesByPackageName extends Record<
   },
   deniedPolicy: {
     packageName: keyof PoliciesByPackageName;
-    result: {
-      error?: string;
-    } & (PoliciesByPackageName[keyof PoliciesByPackageName]['__schemaTypes'] extends {
+    runtimeError?: string;
+    schemaValidationError?: SchemaValidationError;
+    result: PoliciesByPackageName[keyof PoliciesByPackageName]['__schemaTypes'] extends {
       evalDenyResultSchema: infer Schema;
     }
       ? Schema extends z.ZodType
         ? z.infer<Schema>
         : undefined
-      : undefined);
+      : undefined;
   }
 ): {
   allow: false;
@@ -90,15 +91,15 @@ export function createDenyEvaluationResult<PoliciesByPackageName extends Record<
   };
   deniedPolicy: {
     packageName: keyof PoliciesByPackageName;
-    result: {
-      error?: string;
-    } & (PoliciesByPackageName[keyof PoliciesByPackageName]['__schemaTypes'] extends {
+    runtimeError?: string;
+    schemaValidationError?: SchemaValidationError;
+    result: PoliciesByPackageName[keyof PoliciesByPackageName]['__schemaTypes'] extends {
       evalDenyResultSchema: infer Schema;
     }
       ? Schema extends z.ZodType
         ? z.infer<Schema>
         : undefined
-      : undefined);
+      : undefined;
   };
 } {
   return {
@@ -137,13 +138,15 @@ export function createToolExecuteResponseSuccessNoResult<
 
 export function createToolExecuteResponseFailure<Fail, Policies extends Record<any, any>>(params: {
   result: Fail;
-  message?: string;
+  runtimeError?: string;
+  schemaValidationError?: SchemaValidationError;
   context?: BaseToolContext<PolicyEvaluationResultContext<Policies>>;
 }): ToolExecuteResponseFailure<Fail, Policies> {
   return {
     success: false,
+    runtimeError: params.runtimeError,
+    schemaValidationError: params.schemaValidationError,
     result: params.result,
-    error: params.message,
     context: params.context,
   };
 }
@@ -151,13 +154,15 @@ export function createToolExecuteResponseFailure<Fail, Policies extends Record<a
 export function createToolExecuteResponseFailureNoResult<
   Policies extends Record<any, any>,
 >(params: {
-  message?: string;
+  runtimeError?: string;
+  schemaValidationError?: SchemaValidationError;
   context?: BaseToolContext<PolicyEvaluationResultContext<Policies>>;
 }): ToolExecuteResponseFailureNoResult<Policies> {
   return {
     success: false,
+    runtimeError: params.runtimeError,
+    schemaValidationError: params.schemaValidationError,
     result: undefined,
-    error: params.message,
     context: params.context,
   };
 }

--- a/packages/libs/app-sdk/src/toolClient/execute/types.ts
+++ b/packages/libs/app-sdk/src/toolClient/execute/types.ts
@@ -5,6 +5,7 @@ import type { z } from 'zod';
 import type {
   BaseToolContext,
   PolicyEvaluationResultContext,
+  SchemaValidationError,
 } from '@lit-protocol/vincent-tool-sdk';
 
 /** @category Interfaces */
@@ -24,7 +25,8 @@ export interface ToolExecuteResponseSuccessNoResult<Policies extends Record<stri
 /** @category Interfaces */
 export interface ToolExecuteResponseFailure<Result, Policies extends Record<string, any>> {
   success: false;
-  error?: string;
+  runtimeError?: string;
+  schemaValidationError?: SchemaValidationError;
   result: Result;
   context?: BaseToolContext<PolicyEvaluationResultContext<Policies>>;
 }
@@ -32,7 +34,8 @@ export interface ToolExecuteResponseFailure<Result, Policies extends Record<stri
 /** @category Interfaces */
 export interface ToolExecuteResponseFailureNoResult<Policies extends Record<string, any>> {
   success: false;
-  error?: string;
+  runtimeError?: string;
+  schemaValidationError?: SchemaValidationError;
   result?: never;
   context?: BaseToolContext<PolicyEvaluationResultContext<Policies>>;
 }

--- a/packages/libs/app-sdk/src/toolClient/precheck/resultCreators.ts
+++ b/packages/libs/app-sdk/src/toolClient/precheck/resultCreators.ts
@@ -63,13 +63,16 @@ export function createDenyPrecheckResult<PoliciesByPackageName extends Record<st
   deniedPolicy: {
     packageName: keyof PoliciesByPackageName;
     runtimeError?: string;
-    result: PoliciesByPackageName[keyof PoliciesByPackageName]['__schemaTypes'] extends {
-      precheckDenyResultSchema: infer Schema;
-    }
-      ? Schema extends z.ZodType
-        ? z.infer<Schema>
-        : undefined
-      : undefined;
+    schemaValidationError?: SchemaValidationError;
+    result:
+      | (PoliciesByPackageName[keyof PoliciesByPackageName]['__schemaTypes'] extends {
+          precheckDenyResultSchema: infer Schema;
+        }
+          ? Schema extends z.ZodType
+            ? z.infer<Schema>
+            : undefined
+          : undefined)
+      | undefined;
   }
 ): {
   allow: false;
@@ -88,13 +91,17 @@ export function createDenyPrecheckResult<PoliciesByPackageName extends Record<st
   deniedPolicy: {
     packageName: keyof PoliciesByPackageName;
     runtimeError?: string;
-    result: PoliciesByPackageName[keyof PoliciesByPackageName]['__schemaTypes'] extends {
-      precheckDenyResultSchema: infer Schema;
-    }
-      ? Schema extends z.ZodType
-        ? z.infer<Schema>
-        : undefined
-      : undefined;
+    schemaValidationError?: SchemaValidationError;
+
+    result:
+      | (PoliciesByPackageName[keyof PoliciesByPackageName]['__schemaTypes'] extends {
+          precheckDenyResultSchema: infer Schema;
+        }
+          ? Schema extends z.ZodType
+            ? z.infer<Schema>
+            : undefined
+          : undefined)
+      | undefined;
   };
 } {
   return {

--- a/packages/libs/app-sdk/src/toolClient/precheck/resultCreators.ts
+++ b/packages/libs/app-sdk/src/toolClient/precheck/resultCreators.ts
@@ -2,7 +2,7 @@
 
 import type { z } from 'zod';
 
-import type { BaseToolContext } from '@lit-protocol/vincent-tool-sdk';
+import type { BaseToolContext, SchemaValidationError } from '@lit-protocol/vincent-tool-sdk';
 
 import type {
   ToolPrecheckResponseFailure,
@@ -62,7 +62,7 @@ export function createDenyPrecheckResult<PoliciesByPackageName extends Record<st
   },
   deniedPolicy: {
     packageName: keyof PoliciesByPackageName;
-    error?: string;
+    runtimeError?: string;
     result: PoliciesByPackageName[keyof PoliciesByPackageName]['__schemaTypes'] extends {
       precheckDenyResultSchema: infer Schema;
     }
@@ -87,7 +87,7 @@ export function createDenyPrecheckResult<PoliciesByPackageName extends Record<st
   };
   deniedPolicy: {
     packageName: keyof PoliciesByPackageName;
-    error?: string;
+    runtimeError?: string;
     result: PoliciesByPackageName[keyof PoliciesByPackageName]['__schemaTypes'] extends {
       precheckDenyResultSchema: infer Schema;
     }
@@ -132,14 +132,16 @@ export function createToolPrecheckResponseSuccessNoResult<
 }
 
 export function createToolPrecheckResponseFailure<Fail, Policies extends Record<any, any>>(params: {
+  runtimeError?: string;
+  schemaValidationError?: SchemaValidationError;
   result: Fail;
-  message?: string;
   context?: BaseToolContext<PolicyPrecheckResultContext<Policies>>;
 }): ToolPrecheckResponseFailure<Fail, Policies> {
   return {
     success: false,
+    schemaValidationError: params.schemaValidationError,
+    runtimeError: params.runtimeError,
     result: params.result,
-    error: params.message,
     context: params.context,
   };
 }
@@ -147,13 +149,15 @@ export function createToolPrecheckResponseFailure<Fail, Policies extends Record<
 export function createToolPrecheckResponseFailureNoResult<
   Policies extends Record<any, any>,
 >(params: {
-  message?: string;
+  runtimeError?: string;
+  schemaValidationError?: SchemaValidationError;
   context?: BaseToolContext<PolicyPrecheckResultContext<Policies>>;
 }): ToolPrecheckResponseFailureNoResult<Policies> {
   return {
     success: false,
+    runtimeError: params.runtimeError,
+    schemaValidationError: params.schemaValidationError,
     result: undefined,
-    error: params.message,
     context: params.context,
   };
 }

--- a/packages/libs/app-sdk/src/toolClient/precheck/types.ts
+++ b/packages/libs/app-sdk/src/toolClient/precheck/types.ts
@@ -2,7 +2,7 @@
 
 import type { z } from 'zod';
 
-import type { BaseToolContext } from '@lit-protocol/vincent-tool-sdk';
+import type { BaseToolContext, SchemaValidationError } from '@lit-protocol/vincent-tool-sdk';
 import type { VincentPolicy } from '@lit-protocol/vincent-tool-sdk/internal';
 
 /* eslint-disable @typescript-eslint/no-unsafe-function-type */
@@ -24,7 +24,8 @@ export interface ToolPrecheckResponseSuccessNoResult<Policies extends Record<str
 /** @category Interfaces */
 export interface ToolPrecheckResponseFailure<Result, Policies extends Record<string, any>> {
   success: false;
-  error?: string;
+  runtimeError?: string;
+  schemaValidationError?: SchemaValidationError;
   result: Result;
   context?: BaseToolContext<PolicyPrecheckResultContext<Policies>>;
 }
@@ -32,7 +33,8 @@ export interface ToolPrecheckResponseFailure<Result, Policies extends Record<str
 /** @category Interfaces */
 export interface ToolPrecheckResponseFailureNoResult<Policies extends Record<string, any>> {
   success: false;
-  error?: string;
+  runtimeError?: string;
+  schemaValidationError?: SchemaValidationError;
   result?: never;
   context?: BaseToolContext<PolicyPrecheckResultContext<Policies>>;
 }
@@ -100,7 +102,7 @@ export type PolicyPrecheckResultContext<
   | {
       allow: false;
       deniedPolicy: {
-        error?: string;
+        runtimeError?: string;
         packageName: keyof Policies;
         result: Policies[Extract<keyof Policies, string>]['__schemaTypes'] extends {
           precheckDenyResultSchema: infer Schema;

--- a/packages/libs/app-sdk/src/toolClient/precheck/types.ts
+++ b/packages/libs/app-sdk/src/toolClient/precheck/types.ts
@@ -104,13 +104,15 @@ export type PolicyPrecheckResultContext<
       deniedPolicy: {
         runtimeError?: string;
         packageName: keyof Policies;
-        result: Policies[Extract<keyof Policies, string>]['__schemaTypes'] extends {
-          precheckDenyResultSchema: infer Schema;
-        }
-          ? Schema extends z.ZodType
-            ? z.infer<Schema>
-            : undefined
-          : undefined;
+        result:
+          | (Policies[Extract<keyof Policies, string>]['__schemaTypes'] extends {
+              precheckDenyResultSchema: infer Schema;
+            }
+              ? Schema extends z.ZodType
+                ? z.infer<Schema>
+                : undefined
+              : undefined)
+          | undefined;
       };
       allowedPolicies?: {
         [PolicyKey in keyof Policies]?: {

--- a/packages/libs/app-sdk/src/toolClient/vincentToolClient.ts
+++ b/packages/libs/app-sdk/src/toolClient/vincentToolClient.ts
@@ -255,7 +255,7 @@ export function getVincentToolClient<
 
       if (success !== true) {
         return createToolExecuteResponseFailureNoResult({
-          message: `Remote tool failed with unknown error: ${JSON.stringify(response)}`,
+          runtimeError: `Remote tool failed with unknown error: ${JSON.stringify(response)}`,
         }) as ToolExecuteResponse<ExecuteSuccessSchema, ExecuteFailSchema, PoliciesByPackageName>;
       }
 
@@ -268,7 +268,7 @@ export function getVincentToolClient<
           // eslint-disable-next-line @typescript-eslint/no-unused-vars
         } catch (e) {
           return createToolExecuteResponseFailureNoResult({
-            message: `Remote tool failed with unknown error: ${JSON.stringify(response)}`,
+            runtimeError: `Remote tool failed with unknown error: ${JSON.stringify(response)}`,
           }) as ToolExecuteResponse<ExecuteSuccessSchema, ExecuteFailSchema, PoliciesByPackageName>;
         }
       }
@@ -280,7 +280,7 @@ export function getVincentToolClient<
         );
 
         return createToolExecuteResponseFailureNoResult({
-          message: `Remote tool failed with unknown error: ${JSON.stringify(parsedResult)}`,
+          runtimeError: `Remote tool failed with unknown error: ${JSON.stringify(parsedResult)}`,
         }) as ToolExecuteResponse<ExecuteSuccessSchema, ExecuteFailSchema, PoliciesByPackageName>;
       }
 
@@ -326,7 +326,7 @@ export function getVincentToolClient<
       // We parsed the result -- it may be a success or a failure; return appropriately.
       if (isToolResponseFailure(executionResult)) {
         return createToolExecuteResponseFailure({
-          ...(executionResult.error ? { message: executionResult.error } : {}),
+          ...(executionResult.runtimeError ? { runtimeError: executionResult.runtimeError } : {}),
           result: executeResult,
           context: resp.toolContext,
         }) as ToolExecuteResponse<ExecuteSuccessSchema, ExecuteFailSchema, PoliciesByPackageName>;

--- a/packages/libs/app-sdk/src/type-inference-verification/tool-client-inference.ts
+++ b/packages/libs/app-sdk/src/type-inference-verification/tool-client-inference.ts
@@ -119,7 +119,7 @@ export async function run() {
     console.log(fail.reason);
 
     // Can still access error message
-    precheckResult.error?.toUpperCase();
+    precheckResult.runtimeError?.toUpperCase();
 
     // Should still be optional policiesContext
     const deniedPolicy = precheckResult.context?.policiesContext?.deniedPolicy;

--- a/packages/libs/tool-sdk/src/index.ts
+++ b/packages/libs/tool-sdk/src/index.ts
@@ -24,6 +24,7 @@ export type {
   VincentTool,
   ToolConsumerContext,
   PolicyConsumerContext,
+  SchemaValidationError,
 } from './lib/types';
 
 export type { BaseToolContext } from './lib/toolCore/toolConfig/context/types';

--- a/packages/libs/tool-sdk/src/lib/handlers/evaluatePolicies.ts
+++ b/packages/libs/tool-sdk/src/lib/handlers/evaluatePolicies.ts
@@ -162,8 +162,13 @@ function parseAndValidateEvaluateResult<
   try {
     console.log('parseAndValidateEvaluateResult', JSON.stringify(parsedLitActionResponse));
 
-    if (isPolicyDenyResponse(parsedLitActionResponse)) {
-      console.log('parsedLitActionResponse is a deny response; returning it as-is.');
+    if (
+      isPolicyDenyResponse(parsedLitActionResponse) &&
+      (parsedLitActionResponse.schemaValidationError || parsedLitActionResponse.runtimeError)
+    ) {
+      console.log(
+        'parsedLitActionResponse is a deny response with a runtime error or schema validation error; skipping schema validation',
+      );
       return parsedLitActionResponse as PolicyResponse<EvalAllowResult, EvalDenyResult>;
     }
 

--- a/packages/libs/tool-sdk/src/lib/handlers/evaluatePolicies.ts
+++ b/packages/libs/tool-sdk/src/lib/handlers/evaluatePolicies.ts
@@ -12,7 +12,7 @@ import type {
   PolicyResponseDenyNoResult,
   VincentPolicy,
   VincentTool,
-  ZodValidationDenyResult,
+  SchemaValidationError,
 } from '../types';
 
 import {
@@ -106,7 +106,7 @@ export async function evaluatePolicies<
       }
     } catch (err) {
       const denyResult = createDenyResult({
-        message: err instanceof Error ? err.message : 'Unknown error',
+        runtimeError: err instanceof Error ? err.message : 'Unknown error',
       });
       policyDeniedResult = { ...denyResult, packageName: policyPackageName };
     }
@@ -189,7 +189,7 @@ function parseAndValidateEvaluateResult<
     return returnNoResultDeny<EvalDenyResult>(
       err instanceof Error ? err.message : 'Unknown error',
     ) as unknown as EvalDenyResult extends z.ZodType
-      ? PolicyResponseDeny<z.infer<EvalDenyResult> | ZodValidationDenyResult>
+      ? PolicyResponseDeny<z.infer<EvalDenyResult> | SchemaValidationError>
       : PolicyResponseDenyNoResult;
   }
 }

--- a/packages/libs/tool-sdk/src/lib/handlers/vincentPolicyHandler.ts
+++ b/packages/libs/tool-sdk/src/lib/handlers/vincentPolicyHandler.ts
@@ -121,7 +121,7 @@ export async function vincentPolicyHandler<
     Lit.Actions.setResponse({
       response: JSON.stringify(
         createDenyResult({
-          message: error instanceof Error ? error.message : String(error),
+          runtimeError: error instanceof Error ? error.message : String(error),
         }),
       ),
     });

--- a/packages/libs/tool-sdk/src/lib/handlers/vincentToolHandler.ts
+++ b/packages/libs/tool-sdk/src/lib/handlers/vincentToolHandler.ts
@@ -260,7 +260,7 @@ export const vincentToolHandler = <
           } as BaseToolContext<typeof policyEvalResults>,
           toolExecutionResult: {
             success: false,
-            error: err instanceof Error ? err.message : String(err),
+            runtimeError: err instanceof Error ? err.message : String(err),
           },
         }),
       });

--- a/packages/libs/tool-sdk/src/lib/policyCore/helpers/resultCreators.ts
+++ b/packages/libs/tool-sdk/src/lib/policyCore/helpers/resultCreators.ts
@@ -30,14 +30,14 @@ export function createDenyResult(params: {
  * Implementation
  */
 export function createDenyResult<T>(params: {
-  message?: string; // For backward compatibility
+  runtimeError?: string; // For backward compatibility
   result?: T;
   schemaValidationError?: SchemaValidationError;
 }): PolicyResponseDeny<T> | PolicyResponseDenyNoResult {
   if (params.result === undefined) {
     return {
       allow: false,
-      runtimeError: params.message,
+      runtimeError: params.runtimeError,
       result: undefined as never,
       ...(params.schemaValidationError
         ? { schemaValidationError: params.schemaValidationError }
@@ -47,7 +47,7 @@ export function createDenyResult<T>(params: {
 
   return {
     allow: false,
-    runtimeError: params.message,
+    runtimeError: params.runtimeError,
     result: params.result,
     ...(params.schemaValidationError
       ? { schemaValidationError: params.schemaValidationError }
@@ -56,10 +56,10 @@ export function createDenyResult<T>(params: {
 }
 
 export function createDenyNoResult(
-  message: string,
+  runtimeError: string,
   schemaValidationError?: SchemaValidationError,
 ): PolicyResponseDenyNoResult {
-  return createDenyResult({ runtimeError: message, schemaValidationError });
+  return createDenyResult({ runtimeError, schemaValidationError });
 }
 
 /**
@@ -128,19 +128,19 @@ export function wrapAllow<T extends ZodType<any, any, any>>(
 
 // Wraps a deny result as fully typed (for schema-defined denials)
 export function wrapDeny<T extends ZodType<any, any, any>>(
-  message: string,
+  runtimeError: string,
   result: z.infer<T>,
   schemaValidationError?: SchemaValidationError,
 ): PolicyResponseDeny<z.infer<T>> {
-  return createDenyResult({ runtimeError: message, result, schemaValidationError });
+  return createDenyResult({ runtimeError, result, schemaValidationError });
 }
 
 // Wraps a schema-less denial into a conditionally valid deny return
 export function returnNoResultDeny<T extends ZodType<any, any, any> | undefined>(
-  message: string,
+  runtimeError: string,
   schemaValidationError?: SchemaValidationError,
 ): T extends ZodType<any, any, any> ? PolicyResponseDeny<z.infer<T>> : PolicyResponseDenyNoResult {
-  return createDenyNoResult(message, schemaValidationError) as any;
+  return createDenyNoResult(runtimeError, schemaValidationError) as any;
 }
 
 // Optionally: type guard if needed

--- a/packages/libs/tool-sdk/src/lib/policyCore/helpers/resultCreators.ts
+++ b/packages/libs/tool-sdk/src/lib/policyCore/helpers/resultCreators.ts
@@ -28,14 +28,14 @@ export function createDenyResult<T>(params: {
   if (params.result === undefined) {
     return {
       allow: false,
-      error: params.message,
+      runtimeError: params.message,
       result: undefined as never,
     };
   }
 
   return {
     allow: false,
-    error: params.message,
+    runtimeError: params.message,
     result: params.result,
   };
 }

--- a/packages/libs/tool-sdk/src/lib/policyCore/helpers/typeGuards.ts
+++ b/packages/libs/tool-sdk/src/lib/policyCore/helpers/typeGuards.ts
@@ -7,10 +7,10 @@ import type {
   PolicyResponse,
   PolicyResponseAllow,
   PolicyResponseDeny,
-  ZodValidationDenyResult,
+  SchemaValidationError,
 } from '../../types';
 
-export function isZodValidationDenyResult(result: unknown): result is ZodValidationDenyResult {
+export function isZodValidationDenyResult(result: unknown): result is SchemaValidationError {
   return typeof result === 'object' && result !== null && 'zodError' in result;
 }
 

--- a/packages/libs/tool-sdk/src/lib/policyCore/policyConfig/context/policyConfigContext.ts
+++ b/packages/libs/tool-sdk/src/lib/policyCore/policyConfig/context/policyConfigContext.ts
@@ -11,8 +11,6 @@ import type {
   PolicyContext,
 } from './types';
 
-/* eslint-disable @typescript-eslint/no-unused-vars */
-
 /**
  * Creates a policy execution context to be passed into lifecycle methods
  * like `evaluate`, `precheck`, and `commit`. This context includes strongly
@@ -44,17 +42,16 @@ export function createPolicyContext<
     } as ContextAllowResponseNoResult;
   }
 
-  function denyWithSchema<T>(result: T, error?: string): ContextDenyResponse<T> {
+  function denyWithSchema<T>(result: T): ContextDenyResponse<T> {
     return {
       allow: false,
       result,
     } as ContextDenyResponse<T>;
   }
 
-  function denyWithoutSchema(error?: string): ContextDenyResponseNoResult {
+  function denyWithoutSchema(): ContextDenyResponseNoResult {
     return {
       allow: false,
-      ...(error ? { error } : {}),
       result: undefined as never,
     } as ContextDenyResponseNoResult;
   }
@@ -69,7 +66,7 @@ export function createPolicyContext<
       ? () => ContextAllowResponseNoResult
       : (result: z.infer<AllowSchema>) => ContextAllowResponse<z.infer<AllowSchema>>,
     deny: deny as DenySchema extends z.ZodUndefined
-      ? (error?: string) => ContextDenyResponseNoResult
-      : (result: z.infer<DenySchema>, error?: string) => ContextDenyResponse<z.infer<DenySchema>>,
+      ? () => ContextDenyResponseNoResult
+      : (result: z.infer<DenySchema>) => ContextDenyResponse<z.infer<DenySchema>>,
   };
 }

--- a/packages/libs/tool-sdk/src/lib/policyCore/policyConfig/context/types.ts
+++ b/packages/libs/tool-sdk/src/lib/policyCore/policyConfig/context/types.ts
@@ -47,6 +47,9 @@ export interface PolicyContext<
     : (result: z.infer<AllowSchema>) => ContextAllowResponse<z.infer<AllowSchema>>;
 
   deny: DenySchema extends z.ZodUndefined
-    ? (error?: string) => ContextDenyResponseNoResult
-    : (result: z.infer<DenySchema>, error?: string) => ContextDenyResponse<z.infer<DenySchema>>;
+    ? () => ContextDenyResponseNoResult
+    : (
+        result: z.infer<DenySchema>,
+        runtimeError?: string,
+      ) => ContextDenyResponse<z.infer<DenySchema>>;
 }

--- a/packages/libs/tool-sdk/src/lib/policyCore/vincentPolicy.ts
+++ b/packages/libs/tool-sdk/src/lib/policyCore/vincentPolicy.ts
@@ -10,7 +10,7 @@ import type {
   PolicyResponseDeny,
   PolicyResponseDenyNoResult,
   VincentPolicy,
-  ZodValidationDenyResult,
+  SchemaValidationError,
 } from '../types';
 import type { BundledVincentPolicy } from './bundledPolicy/types';
 import type {
@@ -110,7 +110,7 @@ export function createVincentPolicy<
 
       if (isPolicyDenyResponse(paramsOrDeny)) {
         return paramsOrDeny as EvalDenyResult extends z.ZodType
-          ? PolicyResponseDeny<z.infer<EvalDenyResult> | ZodValidationDenyResult>
+          ? PolicyResponseDeny<z.infer<EvalDenyResult> | SchemaValidationError>
           : PolicyResponseDenyNoResult;
       }
 
@@ -133,17 +133,17 @@ export function createVincentPolicy<
 
       if (isPolicyDenyResponse(resultOrDeny)) {
         return resultOrDeny as EvalDenyResult extends z.ZodType
-          ? PolicyResponseDeny<z.infer<EvalDenyResult> | ZodValidationDenyResult>
+          ? PolicyResponseDeny<z.infer<EvalDenyResult> | SchemaValidationError>
           : PolicyResponseDenyNoResult;
       }
 
       // We parsed the result -- it may be a success or a failure; return appropriately.
       if (isPolicyDenyResponse(result)) {
         return createDenyResult({
-          message: result.runtimeError,
+          runtimeError: result.runtimeError,
           result: resultOrDeny,
         }) as EvalDenyResult extends z.ZodType
-          ? PolicyResponseDeny<z.infer<EvalDenyResult> | ZodValidationDenyResult>
+          ? PolicyResponseDeny<z.infer<EvalDenyResult> | SchemaValidationError>
           : PolicyResponseDenyNoResult;
       }
 
@@ -154,7 +154,7 @@ export function createVincentPolicy<
       return returnNoResultDeny<EvalDenyResult>(
         err instanceof Error ? err.message : 'Unknown error',
       ) as unknown as EvalDenyResult extends z.ZodType
-        ? PolicyResponseDeny<z.infer<EvalDenyResult> | ZodValidationDenyResult>
+        ? PolicyResponseDeny<z.infer<EvalDenyResult> | SchemaValidationError>
         : PolicyResponseDenyNoResult;
     }
   };
@@ -212,7 +212,7 @@ export function createVincentPolicy<
           // We parsed the result -- it may be a success or a failure; return appropriately.
           if (isPolicyDenyResponse(result)) {
             return createDenyResult({
-              message: result.runtimeError,
+              runtimeError: result.runtimeError,
               result: resultOrDeny,
             });
           }
@@ -220,7 +220,7 @@ export function createVincentPolicy<
           return createAllowResult({ result: resultOrDeny });
         } catch (err) {
           return createDenyResult({
-            message: err instanceof Error ? err.message : 'Unknown error',
+            runtimeError: err instanceof Error ? err.message : 'Unknown error',
           });
         }
       }) as PolicyLifecycleFunction<
@@ -279,7 +279,7 @@ export function createVincentPolicy<
           // We parsed the result -- it may be a success or a failure; return appropriately.
           if (isPolicyDenyResponse(result)) {
             return createDenyResult({
-              message: result.runtimeError,
+              runtimeError: result.runtimeError,
               result: resultOrDeny,
             });
           }
@@ -287,7 +287,7 @@ export function createVincentPolicy<
           return createAllowResult({ result: resultOrDeny });
         } catch (err) {
           return createDenyResult({
-            message: err instanceof Error ? err.message : 'Unknown error',
+            runtimeError: err instanceof Error ? err.message : 'Unknown error',
           });
         }
       }) as CommitLifecycleFunction<CommitParams, CommitAllowResult, CommitDenyResult>)

--- a/packages/libs/tool-sdk/src/lib/policyCore/vincentPolicy.ts
+++ b/packages/libs/tool-sdk/src/lib/policyCore/vincentPolicy.ts
@@ -140,7 +140,7 @@ export function createVincentPolicy<
       // We parsed the result -- it may be a success or a failure; return appropriately.
       if (isPolicyDenyResponse(result)) {
         return createDenyResult({
-          message: result.error,
+          message: result.runtimeError,
           result: resultOrDeny,
         }) as EvalDenyResult extends z.ZodType
           ? PolicyResponseDeny<z.infer<EvalDenyResult> | ZodValidationDenyResult>
@@ -212,7 +212,7 @@ export function createVincentPolicy<
           // We parsed the result -- it may be a success or a failure; return appropriately.
           if (isPolicyDenyResponse(result)) {
             return createDenyResult({
-              message: result.error,
+              message: result.runtimeError,
               result: resultOrDeny,
             });
           }
@@ -279,7 +279,7 @@ export function createVincentPolicy<
           // We parsed the result -- it may be a success or a failure; return appropriately.
           if (isPolicyDenyResponse(result)) {
             return createDenyResult({
-              message: result.error,
+              message: result.runtimeError,
               result: resultOrDeny,
             });
           }

--- a/packages/libs/tool-sdk/src/lib/policyCore/vincentPolicy.ts
+++ b/packages/libs/tool-sdk/src/lib/policyCore/vincentPolicy.ts
@@ -27,7 +27,12 @@ import {
   isPolicyDenyResponse,
   validateOrDeny,
 } from './helpers';
-import { createAllowResult, returnNoResultDeny, wrapAllow } from './helpers/resultCreators';
+import {
+  createAllowResult,
+  createDenyNoResult,
+  returnNoResultDeny,
+  wrapAllow,
+} from './helpers/resultCreators';
 import { createPolicyContext } from './policyConfig/context/policyConfigContext';
 
 /**
@@ -140,7 +145,6 @@ export function createVincentPolicy<
       // We parsed the result -- it may be a success or a failure; return appropriately.
       if (isPolicyDenyResponse(result)) {
         return createDenyResult({
-          runtimeError: result.runtimeError,
           result: resultOrDeny,
         }) as EvalDenyResult extends z.ZodType
           ? PolicyResponseDeny<z.infer<EvalDenyResult> | SchemaValidationError>
@@ -212,16 +216,13 @@ export function createVincentPolicy<
           // We parsed the result -- it may be a success or a failure; return appropriately.
           if (isPolicyDenyResponse(result)) {
             return createDenyResult({
-              runtimeError: result.runtimeError,
               result: resultOrDeny,
             });
           }
 
           return createAllowResult({ result: resultOrDeny });
         } catch (err) {
-          return createDenyResult({
-            runtimeError: err instanceof Error ? err.message : 'Unknown error',
-          });
+          return createDenyNoResult(err instanceof Error ? err.message : 'Unknown error');
         }
       }) as PolicyLifecycleFunction<
         PolicyToolParams,
@@ -279,16 +280,13 @@ export function createVincentPolicy<
           // We parsed the result -- it may be a success or a failure; return appropriately.
           if (isPolicyDenyResponse(result)) {
             return createDenyResult({
-              runtimeError: result.runtimeError,
               result: resultOrDeny,
             });
           }
 
           return createAllowResult({ result: resultOrDeny });
         } catch (err) {
-          return createDenyResult({
-            runtimeError: err instanceof Error ? err.message : 'Unknown error',
-          });
+          return createDenyNoResult(err instanceof Error ? err.message : 'Unknown error');
         }
       }) as CommitLifecycleFunction<CommitParams, CommitAllowResult, CommitDenyResult>)
     : undefined;

--- a/packages/libs/tool-sdk/src/lib/toolCore/helpers/resultCreators.ts
+++ b/packages/libs/tool-sdk/src/lib/toolCore/helpers/resultCreators.ts
@@ -44,14 +44,14 @@ export function createToolFailureResult<T>({
   if (result === undefined) {
     return {
       success: false,
-      error: message,
+      runtimeError: message,
       result: undefined as never,
     };
   }
 
   return {
     success: false,
-    error: message,
+    runtimeError: message,
     result,
   };
 }

--- a/packages/libs/tool-sdk/src/lib/toolCore/helpers/resultCreators.ts
+++ b/packages/libs/tool-sdk/src/lib/toolCore/helpers/resultCreators.ts
@@ -7,6 +7,7 @@ import type {
   ToolResultFailureNoResult,
   ToolResultSuccess,
   ToolResultSuccessNoResult,
+  SchemaValidationError,
 } from '../../types';
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
@@ -23,29 +24,36 @@ export function createToolSuccessResult<T>(args?: {
 }
 
 export function createToolFailureResult({
-  message,
+  runtimeError,
+  schemaValidationError,
 }: {
-  message?: string;
+  runtimeError?: string;
+  schemaValidationError?: SchemaValidationError;
 }): ToolResultFailureNoResult;
 export function createToolFailureResult<T>({
   message,
   result,
+  schemaValidationError,
 }: {
   result: T;
   message?: string;
+  schemaValidationError?: SchemaValidationError;
 }): ToolResultFailure<T>;
 export function createToolFailureResult<T>({
   message,
   result,
+  schemaValidationError,
 }: {
   result?: T;
   message?: string;
+  schemaValidationError?: SchemaValidationError;
 }): ToolResultFailure<T> | ToolResultFailureNoResult {
   if (result === undefined) {
     return {
       success: false,
       runtimeError: message,
       result: undefined as never,
+      ...(schemaValidationError ? { schemaValidationError } : {}),
     };
   }
 
@@ -53,24 +61,30 @@ export function createToolFailureResult<T>({
     success: false,
     runtimeError: message,
     result,
+    ...(schemaValidationError ? { schemaValidationError } : {}),
   };
 }
 
-export function createToolFailureNoResult(message: string): ToolResultFailureNoResult {
-  return createToolFailureResult({ message });
+export function createToolFailureNoResult(
+  message: string,
+  schemaValidationError?: SchemaValidationError,
+): ToolResultFailureNoResult {
+  return createToolFailureResult({ runtimeError: message, schemaValidationError });
 }
 
 export function wrapFailure<T extends z.ZodType<any, any, any>>(
   value: z.infer<T>,
   message?: string,
+  schemaValidationError?: SchemaValidationError,
 ): ToolResultFailure<z.infer<T>> {
-  return createToolFailureResult({ result: value, message });
+  return createToolFailureResult({ result: value, message, schemaValidationError });
 }
 
 export function wrapNoResultFailure<T extends ZodType<any, any, any> | undefined>(
   message: string,
+  schemaValidationError?: SchemaValidationError,
 ): T extends ZodType<any, any, any> ? ToolResultFailure<z.infer<T>> : ToolResultFailureNoResult {
-  return createToolFailureNoResult(message) as any;
+  return createToolFailureNoResult(message, schemaValidationError) as any;
 }
 
 export function wrapSuccess<T extends z.ZodType<any, any, any>>(

--- a/packages/libs/tool-sdk/src/lib/toolCore/helpers/resultCreators.ts
+++ b/packages/libs/tool-sdk/src/lib/toolCore/helpers/resultCreators.ts
@@ -31,27 +31,27 @@ export function createToolFailureResult({
   schemaValidationError?: SchemaValidationError;
 }): ToolResultFailureNoResult;
 export function createToolFailureResult<T>({
-  message,
+  runtimeError,
   result,
   schemaValidationError,
 }: {
   result: T;
-  message?: string;
+  runtimeError?: string;
   schemaValidationError?: SchemaValidationError;
 }): ToolResultFailure<T>;
 export function createToolFailureResult<T>({
-  message,
+  runtimeError,
   result,
   schemaValidationError,
 }: {
   result?: T;
-  message?: string;
+  runtimeError?: string;
   schemaValidationError?: SchemaValidationError;
 }): ToolResultFailure<T> | ToolResultFailureNoResult {
   if (result === undefined) {
     return {
       success: false,
-      runtimeError: message,
+      runtimeError: runtimeError,
       result: undefined as never,
       ...(schemaValidationError ? { schemaValidationError } : {}),
     };
@@ -59,32 +59,32 @@ export function createToolFailureResult<T>({
 
   return {
     success: false,
-    runtimeError: message,
+    runtimeError: runtimeError,
     result,
     ...(schemaValidationError ? { schemaValidationError } : {}),
   };
 }
 
 export function createToolFailureNoResult(
-  message: string,
+  runtimeError: string,
   schemaValidationError?: SchemaValidationError,
 ): ToolResultFailureNoResult {
-  return createToolFailureResult({ runtimeError: message, schemaValidationError });
+  return createToolFailureResult({ runtimeError, schemaValidationError });
 }
 
 export function wrapFailure<T extends z.ZodType<any, any, any>>(
   value: z.infer<T>,
-  message?: string,
+  runtimeError?: string,
   schemaValidationError?: SchemaValidationError,
 ): ToolResultFailure<z.infer<T>> {
-  return createToolFailureResult({ result: value, message, schemaValidationError });
+  return createToolFailureResult({ result: value, runtimeError, schemaValidationError });
 }
 
 export function wrapNoResultFailure<T extends ZodType<any, any, any> | undefined>(
-  message: string,
+  runtimeError: string,
   schemaValidationError?: SchemaValidationError,
 ): T extends ZodType<any, any, any> ? ToolResultFailure<z.infer<T>> : ToolResultFailureNoResult {
-  return createToolFailureNoResult(message, schemaValidationError) as any;
+  return createToolFailureNoResult(runtimeError, schemaValidationError) as any;
 }
 
 export function wrapSuccess<T extends z.ZodType<any, any, any>>(

--- a/packages/libs/tool-sdk/src/lib/toolCore/helpers/zod.ts
+++ b/packages/libs/tool-sdk/src/lib/toolCore/helpers/zod.ts
@@ -38,7 +38,7 @@ export function validateOrFail<T extends ZodType<any, any, any>>(
   schema: T,
   phase: 'precheck' | 'execute',
   stage: 'input' | 'output',
-): z.infer<T> | ToolResultFailure | ToolResultFailureNoResult {
+): z.infer<T> | ToolResultFailure<never> | ToolResultFailureNoResult {
   const effectiveSchema = schema ?? mustBeUndefinedSchema;
   const parsed = effectiveSchema.safeParse(value);
 
@@ -46,8 +46,12 @@ export function validateOrFail<T extends ZodType<any, any, any>>(
     const descriptor = stage === 'input' ? 'parameters' : 'result';
     const message = `Invalid ${phase} ${descriptor}.`;
     return createToolFailureResult({
-      message,
-      result: { zodError: parsed.error },
+      runtimeError: message,
+      schemaValidationError: {
+        zodError: parsed.error,
+        phase,
+        stage,
+      },
     });
   }
 

--- a/packages/libs/tool-sdk/src/lib/toolCore/toolConfig/context/resultCreators.ts
+++ b/packages/libs/tool-sdk/src/lib/toolCore/toolConfig/context/resultCreators.ts
@@ -33,11 +33,10 @@ export function createSuccessNoResult(): ContextSuccessNoResult {
 /**
  * Wraps a failure result with payload
  */
-export function createFailure<T>(result: T, error?: string): ContextFailure<T> {
+export function createFailure<T>(result: T): ContextFailure<T> {
   return {
     success: false,
     result,
-    ...(error ? { error } : {}),
     [YouMustCallContextSucceedOrFail]: 'ToolResult',
   } as ContextFailure<T>;
 }
@@ -45,11 +44,10 @@ export function createFailure<T>(result: T, error?: string): ContextFailure<T> {
 /**
  * Wraps a failure result without payload
  */
-export function createFailureNoResult(error?: string): ContextFailureNoResult {
+export function createFailureNoResult(): ContextFailureNoResult {
   return {
     success: false,
     result: undefined as never,
-    ...(error ? { error } : {}),
     [YouMustCallContextSucceedOrFail]: 'ToolResult',
   } as ContextFailureNoResult;
 }

--- a/packages/libs/tool-sdk/src/lib/toolCore/toolConfig/context/types.ts
+++ b/packages/libs/tool-sdk/src/lib/toolCore/toolConfig/context/types.ts
@@ -63,6 +63,6 @@ export interface ToolContext<
     : (result: z.infer<SuccessSchema>) => ContextSuccess<z.infer<SuccessSchema>>;
 
   fail: FailSchema extends z.ZodUndefined
-    ? (error?: string) => ContextFailure
-    : (result: z.infer<FailSchema>, error?: string) => ContextFailure<z.infer<FailSchema>>;
+    ? () => ContextFailure
+    : (result: z.infer<FailSchema>, runtimeError?: string) => ContextFailure<z.infer<FailSchema>>;
 }

--- a/packages/libs/tool-sdk/src/lib/toolCore/vincentTool.ts
+++ b/packages/libs/tool-sdk/src/lib/toolCore/vincentTool.ts
@@ -166,7 +166,7 @@ export function createVincentTool<
 
       // We parsed the result -- it may be a success or a failure; return appropriately.
       if (isToolFailureResult(result)) {
-        return wrapFailure(resultOrFailure, result.error);
+        return wrapFailure(resultOrFailure, result.runtimeError);
       }
 
       return wrapSuccess(resultOrFailure);
@@ -217,7 +217,7 @@ export function createVincentTool<
 
           // We parsed the result successfully -- it may be a success or a failure, return appropriately
           if (isToolFailureResult(result)) {
-            return wrapFailure(resultOrFailure, result.error);
+            return wrapFailure(resultOrFailure, result.runtimeError);
           }
 
           return wrapSuccess(resultOrFailure);

--- a/packages/libs/tool-sdk/src/lib/toolCore/vincentTool.ts
+++ b/packages/libs/tool-sdk/src/lib/toolCore/vincentTool.ts
@@ -139,6 +139,7 @@ export function createVincentTool<
       );
 
       if (isToolFailureResult(parsedToolParams)) {
+        // In this case, we have an invalid input to the tool -- return { success: fail, runtimeError, schemaValidationError }
         return parsedToolParams;
       }
 
@@ -166,7 +167,7 @@ export function createVincentTool<
 
       // We parsed the result -- it may be a success or a failure; return appropriately.
       if (isToolFailureResult(result)) {
-        return wrapFailure(resultOrFailure, result.runtimeError);
+        return wrapFailure(resultOrFailure);
       }
 
       return wrapSuccess(resultOrFailure);

--- a/packages/libs/tool-sdk/src/lib/types.ts
+++ b/packages/libs/tool-sdk/src/lib/types.ts
@@ -17,20 +17,24 @@ export interface PolicyResponseAllowNoResult {
   result?: never;
 }
 
-export interface ZodValidationDenyResult {
+export interface SchemaValidationError {
   zodError: ZodError<unknown>;
+  phase: string;
+  stage: string;
 }
 
 export interface PolicyResponseDeny<DenyResult> {
   allow: false;
   runtimeError?: string;
-  result: DenyResult | ZodValidationDenyResult;
+  result: DenyResult;
+  schemaValidationError?: SchemaValidationError;
 }
 
 export interface PolicyResponseDenyNoResult {
   allow: false;
   runtimeError?: string;
   result: never;
+  schemaValidationError?: SchemaValidationError;
 }
 
 export type PolicyResponse<
@@ -41,7 +45,7 @@ export type PolicyResponse<
       ? PolicyResponseAllow<z.infer<AllowResult>>
       : PolicyResponseAllowNoResult)
   | (DenyResult extends z.ZodType
-      ? PolicyResponseDeny<z.infer<DenyResult> | ZodValidationDenyResult>
+      ? PolicyResponseDeny<z.infer<DenyResult>>
       : PolicyResponseDenyNoResult);
 
 // Type for the wrapped commit function that handles both with and without args
@@ -65,7 +69,7 @@ export type PolicyLifecycleFunction<
       ? PolicyResponseAllow<z.infer<AllowResult>>
       : PolicyResponseAllowNoResult)
   | (DenyResult extends z.ZodType
-      ? PolicyResponseDeny<z.infer<DenyResult> | ZodValidationDenyResult>
+      ? PolicyResponseDeny<z.infer<DenyResult>>
       : PolicyResponseDenyNoResult)
 >;
 
@@ -116,7 +120,7 @@ export type CommitLifecycleFunction<
       ? PolicyResponseAllow<z.infer<CommitAllowResult>>
       : PolicyResponseAllowNoResult)
   | (CommitDenyResult extends z.ZodType
-      ? PolicyResponseDeny<z.infer<CommitDenyResult> | ZodValidationDenyResult>
+      ? PolicyResponseDeny<z.infer<CommitDenyResult>>
       : PolicyResponseDenyNoResult)
 >;
 
@@ -337,14 +341,16 @@ export interface ToolResultSuccessNoResult {
 
 export interface ToolResultFailure<FailResult = never> {
   success: false;
-  result: FailResult | ZodValidationDenyResult;
+  result: FailResult;
   runtimeError?: string;
+  schemaValidationError?: SchemaValidationError;
 }
 
 export interface ToolResultFailureNoResult {
   success: false;
   runtimeError?: string;
   result?: never;
+  schemaValidationError?: SchemaValidationError;
 }
 export type ToolResult<SucceedResult, FailResults> =
   | (ToolResultSuccess<SucceedResult> | ToolResultSuccessNoResult)

--- a/packages/libs/tool-sdk/src/lib/types.ts
+++ b/packages/libs/tool-sdk/src/lib/types.ts
@@ -23,13 +23,13 @@ export interface ZodValidationDenyResult {
 
 export interface PolicyResponseDeny<DenyResult> {
   allow: false;
-  error?: string;
+  runtimeError?: string;
   result: DenyResult | ZodValidationDenyResult;
 }
 
 export interface PolicyResponseDenyNoResult {
   allow: false;
-  error?: string;
+  runtimeError?: string;
   result: never;
 }
 
@@ -203,7 +203,7 @@ export type PolicyEvaluationResultContext<
   | {
       allow: false;
       deniedPolicy: {
-        error?: string;
+        runtimeError?: string;
         packageName: keyof Policies;
         result: Policies[Extract<keyof Policies, string>]['__schemaTypes'] extends {
           evalDenyResultSchema: infer Schema;
@@ -338,12 +338,12 @@ export interface ToolResultSuccessNoResult {
 export interface ToolResultFailure<FailResult = never> {
   success: false;
   result: FailResult | ZodValidationDenyResult;
-  error?: string;
+  runtimeError?: string;
 }
 
 export interface ToolResultFailureNoResult {
   success: false;
-  error?: string;
+  runtimeError?: string;
   result?: never;
 }
 export type ToolResult<SucceedResult, FailResults> =

--- a/packages/libs/tool-sdk/src/type-inference-verification/allow-deny-test-cases-tool.ts
+++ b/packages/libs/tool-sdk/src/type-inference-verification/allow-deny-test-cases-tool.ts
@@ -67,7 +67,7 @@ export function testNoSchemas() {
       // Should allow succeed() with no arguments
       succeed();
 
-      // Should allow fail() with string error
+      // @ts-expect-error Should not allow fail() with string error
       fail('Error message');
 
       // @ts-expect-error - Should not allow succeed() with arguments when no schema
@@ -691,6 +691,7 @@ export const testExecuteTryCatchReturn = () => {
         return succeed();
       } catch (error) {
         // Missing return here
+        // @ts-expect-error Can't call fail w/ string when no schema
         fail('Error occurred');
       }
     },

--- a/packages/libs/tool-sdk/src/type-inference-verification/allow-deny-test-cases.ts
+++ b/packages/libs/tool-sdk/src/type-inference-verification/allow-deny-test-cases.ts
@@ -252,7 +252,7 @@ export function testDenyFunctionWithDifferentTypes() {
     // No schema defined
 
     evaluate: async (params, { deny }) => {
-      // Valid - string error is allowed with no schema
+      // @ts-expect-error Can't return a string when no schema defined
       deny('Error message');
 
       // Valid - undefined is allowed (no error message)
@@ -264,8 +264,8 @@ export function testDenyFunctionWithDifferentTypes() {
       // @ts-expect-error - Number not allowed when no schema
       deny(123);
 
-      // Valid case to return
-      return deny('Access denied');
+      // Good to go - returning deny with no result when no schema.
+      return deny();
     },
   });
   const test3 = createVincentToolPolicy({

--- a/packages/libs/tool-sdk/src/type-inference-verification/parameter-inference-tests-tool.ts
+++ b/packages/libs/tool-sdk/src/type-inference-verification/parameter-inference-tests-tool.ts
@@ -572,7 +572,7 @@ function testMissingTypes() {
       // Should be able to succeed with schema
       succeed({ result: 'test' });
 
-      // Should be able to fail with just an error string since no fail schema
+      // @ts-expect-error Can't return a string when no schema defined
       fail('Error message');
 
       // @ts-expect-error - Can't fail with an object when no fail schema defined

--- a/packages/libs/tool-sdk/src/type-inference-verification/parameter-inference-tests.ts
+++ b/packages/libs/tool-sdk/src/type-inference-verification/parameter-inference-tests.ts
@@ -77,6 +77,7 @@ function testNoSchemaValidation() {
       if (Math.random() > 0.5) {
         return context.allow();
       } else {
+        // @ts-expect-error Can't return a string when no schema defined
         return context.deny('Error message');
       }
     },

--- a/packages/libs/tool-sdk/src/type-inference-verification/playground.ts
+++ b/packages/libs/tool-sdk/src/type-inference-verification/playground.ts
@@ -328,7 +328,7 @@ export const myTool = createVincentTool({
       });
     } else {
       // Handle the denial case
-      const denyReason = deniedPolicy.error || 'Policy check failed';
+      const denyReason = deniedPolicy.runtimeError || 'Policy check failed';
 
       return fail({
         invalidField: 'policy',

--- a/packages/libs/tool-sdk/src/type-inference-verification/schema-test.ts
+++ b/packages/libs/tool-sdk/src/type-inference-verification/schema-test.ts
@@ -84,16 +84,13 @@ export const testRealPolicy = createVincentToolPolicy({
 export function testWithoutSchema() {
   // Function signature to test types on a PolicyContext
   function testContextSignature(context: PolicyContext<ZodUndefined, ZodUndefined>) {
-    // Valid - no schema means no args
-    context.allow();
-
     // @ts-expect-error Should error - no schema means no args allowed
     context.allow('no schema');
 
     // @ts-expect-error Should error - no schema means no args allowed
     context.allow({ no: 'schema' });
 
-    // Valid - string error is allowed with no schema
+    // @ts-expect-error Can't return a string when no schema defined
     context.deny('Error message');
 
     // Valid - no args is allowed
@@ -126,6 +123,7 @@ export function testWithoutSchema() {
       if (Math.random() > 0.5) {
         return allow();
       } else {
+        // @ts-expect-error Can't return a string when no schema defined
         return deny('Error message');
       }
     },


### PR DESCRIPTION
# Description

There were two issues with our existing Tool & Policy error result handling that were problematic, both from the consumer side and internally due to complexity in handling the ambiguity.

## Ambiguous reasons for receiving `error` in tool or policy responses
There were three cases where you might get an `error` property on a tool failure response or policy deny response.
1. Code inside the lifecycle methods defined by tool/policy authors called `throw()` and let the error bubble out of the lifecycle method.
2. Internal Vincent Tool SDK code that _wraps_ the lifecycle method encountered a critical failure and called `throw()` somewhere.
   - For these cases, if you got an `error` result, you could assume `result` would not be set and there was a runtime error encountered during execution of that tool or policy. Basically, `error` === `unhandled runtime error`.
3.  The `fail()` and `deny()` methods were overloaded so that if a tool/policy did not define a fail/deny schema, you could call `fail('This was an error!')` or `deny('Boom!')`.
    - If you did either of these things, the resulting string was put into the `error` property on the tool or policy response instead of setting the `result`.
    - This case is problematic as it blurred the reason why `error` was set; it could've been due to an intentional handling of an error inside of the tool or policy in cases where no schema was provided to validate the deny/fail case.

#### This PR changes the API for `deny()` and `fail()` so that if you don't define a schema for them, you _must_ call `deny()` or `fail()` with no value (undefined).
#### This removes the ambiguity about whether `error` is a runtime error; now you can be confident that if you got an `error` response from a tool or policy, it was because there was an unexpected, un-handled / runtime level error.
#### Finally, `error` has been renamed to `runtimeError` to make the expected cause for it existing more obvious 

## Ambiguous `result` values when params or return values fail schema validation
All lifecycle methods on both tools and policies can have schemas defined for both their inputs and outputs in both deny/fail and allow/success cases.  Schema validation is performed any time tool/policy lifecycle methods are called, both on the inputs and outputs of the tool or policy.
1. If inputs fail validation, the lifecycle method of the tool/policy is not executed, and a fail or deny response is immediately returned to the caller.
    - This ensures that tools & policies are not called with invalid data which would either cause cryptic runtime errors farther along tool/policy execution, or result in undefined and possibly undesired behaviour.
2. If outputs from calling a tool / policy lifecycle method fail validation, the response is converted to a `deny` or `fail` type response
    - This ensures that consuming code doesn't get arbitrary responses from a tool or policy that are unexpected and malformed.

Unfortunately, the mechanism by which the details of the schema validation failure back to the caller were sub-optimal and caused ambiguity in the expected shape of `result`.  The core issue was that any input/output schema validation errors caused `result` to be returned (not `error`) -- but with a shape of `result: { zodError }`, where `zodError` is the serialized result of calling `z.safeParse()` using the schema.  This effectively meant that _all_ result types were a union of the `DefinedSchema & { zodError }`, which made handling responses from tools / policies brittle and complex.

#### This PR changes the API for all tool & policy lifecycle method responses so that any input/output schema parsing failures are classified as `runtimeErrors`, and the details of the validation failure is always provided in the `validationError` property of the response.
Tool:
```
{
  success: false,
  runtimeError: `Invalid ${lifecycleMethodName} ${'parameters' | 'result'}`,
  validationError<ZodError>: {...}
}
```
Policy:
```
{
  allow: false,
  runtimeError: `Invalid ${lifecycleMethodName} ${'parameters' | 'result'}`,
  validationError<ZodError>: {...}
}
```

- Note that this extends to the shape of the `deniedPolicy` result that you get in the `policiesContext`.

#### With these changes, `result` types for lifecycle methods on tools & policies are no longer a union with `{ zodError }` :)

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [X] Rebuilt all tools/policies and re-ran all integration/e2e tests
- [X] Added new test cases to toolpolicies-e2e to verify the new behaviour works as expected.
 
# Checklist:
- [X] I created a [release plan](https://nx.dev/recipes/nx-release/file-based-versioning-version-plans) (`nx release plan`) describing my changes and the version bump
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
