### PR TITLE
Update broken documentation links in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,13 +14,13 @@ Powered by Lit’s [decentralized key management network](https://developer.litp
 
 Non-custodial accounts controlled by users and backed by Lit [Programmable Key Pairs (PKPs)](https://developer.litprotocol.com/user-wallets/pkps/overview), used to delegate signing authority to Vincent Apps during Tool execution.
 
-[Learn more](https://docs.heyvincent.ai/documents/Vincent_Docs.Concepts.html#vincent-agent-wallet)
+[Learn more](https://docs.heyvincent.ai/documents/Concepts.html#vincent-agent-wallet)
 
 ## Vincent Tools
 
 Vincent Tools are immutable functions, built with [Lit Actions](https://developer.litprotocol.com/sdk/serverless-signing/overview), that define the specific operations a Vincent App can perform on behalf of users. Tools can interact with blockchains, APIs, and databases but only execute when permitted by all active Vincent Policies configured by the user.
 
-[Learn more](https://docs.heyvincent.ai/documents/Vincent_Docs.Tool_Developers.html)
+[Learn more](https://docs.heyvincent.ai/documents/Tool_Developers.html)
 
 ## Vincent Policies
 
@@ -28,7 +28,7 @@ Vincent Policies are programmable guardrails that govern how and when Tools can 
 
 Each Policy has user-configurable parameters, supports on/off-chain data access, and can persist state across executions. Users define the exact conditions under which a Vincent App can act on their behalf and can update or revoke those conditions at any time.
 
-[Learn more](https://docs.heyvincent.ai/documents/Vincent_Docs.Policy_Developers.html)
+[Learn more](https://docs.heyvincent.ai/documents/Policy_Developers.html)
 
 ## Vincent App
 
@@ -36,7 +36,7 @@ Vincent Apps enable secure, policy-governed automation on behalf of users—with
 
 Apps are bundled as versioned packages and must be approved via the Consent Page before they can execute any actions.
 
-[Learn more](https://docs.heyvincent.ai/documents/Vincent_Docs.App___Agent_Developers.html)
+[Learn more](https://docs.heyvincent.ai/documents/App___Agent_Developers.html)
 
 ## Consent Page
 
@@ -73,7 +73,7 @@ Vincent optimizes for security, interoperability, and user-control to redefine h
 
 # Useful Links
 
-- [Vincent Docs](https://docs.heyvincent.ai/modules/Vincent_Docs.html)
+- [Vincent Docs](https://docs.heyvincent.ai/modules.html)
 - [Automated Dollar-Cost Averaging Demo](https://demo.heyvincent.ai/)
 - [Telegram Community](https://t.me/+aa73FAF9Vp82ZjJh)
 


### PR DESCRIPTION
# Description

This PR fixes multiple broken or outdated links in the README file, updating them to point to the correct, current URLs on [https://docs.heyvincent.ai](https://docs.heyvincent.ai).

No code or functionality is changed — only documentation (README).

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# How Has This Been Tested?

All the updated links were manually checked in a browser to confirm they point to valid and correct pages.

Steps:

* Opened README in a browser/preview
* Clicked each updated link and verified it leads to the intended documentation page without error


# Checklist:

I created a [release plan](https://nx.dev/recipes/nx-release/file-based-versioning-version-plans) (`nx release plan`) describing my changes and the version bump (N/A — docs only)
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas (N/A — no code)
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works (N/A — docs only)
- [x] New and existing unit tests pass locally with my changes (N/A — no code)
- [ ] Any dependent changes have been merged and published in downstream modules (N/A)
