### PR TITLE
Fix nav menu item title being truncated when screen size got too small

### DIFF
--- a/docs/custom.css
+++ b/docs/custom.css
@@ -125,3 +125,30 @@
 .warning-icon {
   background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' width='24' height='24'%3E%3Cpath d='M12 2L1.5 21h21L12 2z' fill='%23f39c12'/%3E%3Cpath d='M12 8v6' stroke='white' stroke-width='2' stroke-linecap='round'/%3E%3Ccircle cx='12' cy='18' r='1' fill='white'/%3E%3C/svg%3E");
 }
+
+/* TypeDoc Navigation Fixes */
+/* Fix text truncation - target all navigation text elements */
+.tsd-navigation a,
+.tsd-navigation summary > span,
+.tsd-kind-icon ~ span,
+.title {
+  white-space: normal !important;
+  overflow: visible !important;
+  text-overflow: initial !important;
+  word-break: break-word !important;
+}
+
+/* Keep icon and text on same line while allowing text to wrap */
+.tsd-navigation a,
+.tsd-navigation summary > span {
+  align-items: flex-start !important;
+}
+
+.tsd-kind-icon {
+  flex-shrink: 0 !important;
+}
+
+.tsd-kind-icon ~ span {
+  flex: 1 1 auto !important;
+  min-width: 0 !important;
+}


### PR DESCRIPTION
# Description

Small bug fix to fix:

<img width="358" height="719" alt="image" src="https://github.com/user-attachments/assets/03226bed-fab1-478e-aeed-2cc570b18a19" />

now the titles word wrap as the screen gets smaller until it's too small that the sidebar is replaced by a hamburger menu. Now the page looks like:

<img width="250" height="898" alt="image" src="https://github.com/user-attachments/assets/275a46eb-c638-4d93-8822-44a77d0ec04a" />

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [ ] I created a [release plan](https://nx.dev/recipes/nx-release/file-based-versioning-version-plans) (`nx release plan`) describing my changes and the version bump
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
