### PR TITLE
fix: typo in webAuthClient subtree export

### DIFF
--- a/packages/libs/app-sdk/package.json
+++ b/packages/libs/app-sdk/package.json
@@ -25,7 +25,7 @@
       "require": "./dist/src/toolClient/index.js",
       "types": "./dist/src/toolClient/index.d.ts"
     },
-    "./webAuthclient": {
+    "./webAuthClient": {
       "import": "./dist/src/webAuthClient/index.js",
       "require": "./dist/src/webAuthClient/index.js",
       "types": "./dist/src/webAuthClient/index.d.ts"

--- a/packages/libs/app-sdk/src/expressMiddleware/express.ts
+++ b/packages/libs/app-sdk/src/expressMiddleware/express.ts
@@ -53,7 +53,7 @@ function assertAuthenticatedRequest<const UserKey extends string>(
  * const { middleware, handler } = createVincentUserMiddleware({
  *  allowedAudience: ALLOWED_AUDIENCE,
  *  requiredAppId: VINCENT_APP_ID,
- *  userKey: 'vincentUser
+ *  userKey: 'vincentUser',
  * });
  *
  * // Apply to routes that require authentication; req is guaranteed authenticated because it is wrapped in `handler()`


### PR DESCRIPTION
# Description

Fixes the typo in webAuthClient subtree export
It was `import { getWebAuthClient } from '@lit-protocol/vincent-app-sdk/webAuthclient';` (lowercase 'c') and all docs and consistency says it was supposed to be `import { getWebAuthClient } from '@lit-protocol/vincent-app-sdk/webAuthClient';`

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Importing from morphomax project with a local link

# Checklist:

- [ ] I created a [release plan](https://nx.dev/recipes/nx-release/file-based-versioning-version-plans) (`nx release plan`) describing my changes and the version bump
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
