### PR TITLE
fix: dashboard consent url in composeDelegationAuthUrl

### DIFF
--- a/packages/libs/app-sdk/src/webAuthClient/internal/uriHelpers.ts
+++ b/packages/libs/app-sdk/src/webAuthClient/internal/uriHelpers.ts
@@ -38,7 +38,7 @@ export function composeDelegationAuthUrl(
   delegationAuthPageUrl?: string
 ) {
   return new URL(
-    `/user/appId/${String(appId)}/consent?redirectUri=${redirectUri}`,
+    `/user/consent/appId/${String(appId)}?redirectUri=${redirectUri}`,
     delegationAuthPageUrl || PRODUCTION_VINCENT_DASHBOARD_URL
   );
 }

--- a/packages/libs/app-sdk/src/webAuthClient/internal/uriHelpers.ts
+++ b/packages/libs/app-sdk/src/webAuthClient/internal/uriHelpers.ts
@@ -38,7 +38,7 @@ export function composeDelegationAuthUrl(
   delegationAuthPageUrl?: string
 ) {
   return new URL(
-    `/appId/${String(appId)}/consent?redirectUri=${redirectUri}`,
+    `/user/appId/${String(appId)}/consent?redirectUri=${redirectUri}`,
     delegationAuthPageUrl || PRODUCTION_VINCENT_DASHBOARD_URL
   );
 }


### PR DESCRIPTION
# Description

This PR fixes the consent page url built in composeDelegationAuthUrl used in the updated dashboard

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Using that function in morphomax agent app to load consent screen in the updated dashboard

# Checklist:

- [ ] I created a [release plan](https://nx.dev/recipes/nx-release/file-based-versioning-version-plans) (`nx release plan`) describing my changes and the version bump
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
