### PR TITLE
Bump Express Request Limit to 256KB

### DIFF
--- a/packages/apps/app-dashboard/src/components/developer-dashboard/form-fields/ImageUploadField.tsx
+++ b/packages/apps/app-dashboard/src/components/developer-dashboard/form-fields/ImageUploadField.tsx
@@ -124,7 +124,7 @@ export function ImageUploadField({
                   }`}
                 />
                 <div className="text-xs text-gray-600">
-                  Upload a square JPG, JPEG, or GIF image (max 100KB)
+                  Upload a square JPG, JPEG, or GIF image (max ~512KB)
                 </div>
 
                 {isUploading && (

--- a/packages/apps/app-dashboard/src/components/developer-dashboard/form-fields/ImageUploadField.tsx
+++ b/packages/apps/app-dashboard/src/components/developer-dashboard/form-fields/ImageUploadField.tsx
@@ -123,7 +123,7 @@ export function ImageUploadField({
                     isUploading ? 'opacity-50 cursor-not-allowed' : ''
                   }`}
                 />
-                <div className="text-xs text-gray-600">Upload an SVG (max ~512KB)</div>
+                <div className="text-xs text-gray-600">Upload an SVG (max ~128KB)</div>
 
                 {isUploading && (
                   <div className="flex items-center space-x-2 text-xs text-gray-600">

--- a/packages/apps/app-dashboard/src/components/developer-dashboard/form-fields/ImageUploadField.tsx
+++ b/packages/apps/app-dashboard/src/components/developer-dashboard/form-fields/ImageUploadField.tsx
@@ -82,7 +82,7 @@ export function ImageUploadField({
   const displayUrl =
     previewUrl ||
     (currentValue && !currentValue.startsWith('data:')
-      ? `data:image/jpeg;base64,${currentValue}`
+      ? `data:image/svg+xml;base64,${currentValue}`
       : currentValue) ||
     null;
 
@@ -116,16 +116,14 @@ export function ImageUploadField({
               <div className="space-y-2">
                 <input
                   type="file"
-                  accept="image/jpeg,image/jpg,image/gif"
+                  accept="image/svg+xml"
                   onChange={handleFileChange}
                   disabled={isUploading}
                   className={`w-full px-2 py-1.5 text-sm border rounded-md border-gray-300 file:mr-4 file:py-1 file:px-2 file:rounded file:border-0 file:text-xs file:bg-gray-50 file:text-gray-700 hover:file:bg-gray-100 ${
                     isUploading ? 'opacity-50 cursor-not-allowed' : ''
                   }`}
                 />
-                <div className="text-xs text-gray-600">
-                  Upload a square JPG, JPEG, or GIF image (max ~512KB)
-                </div>
+                <div className="text-xs text-gray-600">Upload an SVG (max ~512KB)</div>
 
                 {isUploading && (
                   <div className="flex items-center space-x-2 text-xs text-gray-600">

--- a/packages/apps/app-dashboard/src/utils/developer-dashboard/imageUtils.ts
+++ b/packages/apps/app-dashboard/src/utils/developer-dashboard/imageUtils.ts
@@ -11,7 +11,7 @@ export interface ImageUploadResult {
 
 export const DEFAULT_IMAGE_OPTIONS: ImageValidationOptions = {
   allowedTypes: ['image/jpeg', 'image/jpg', 'image/gif'],
-  maxSize: 100 * 1024, // 100KB
+  maxSize: 512 * 1024, // 512KB
   requireSquare: true,
 };
 
@@ -34,7 +34,7 @@ export const processImageUpload = async (
 
   // Validate file size
   if (maxSize && file.size > maxSize) {
-    throw new Error(`File size must be less than ${Math.round(maxSize / (1024 * 1024))}MB`);
+    throw new Error(`File size must be less than ${Math.round(maxSize / 1024)}KB`);
   }
 
   // Create preview URL

--- a/packages/apps/app-dashboard/src/utils/developer-dashboard/imageUtils.ts
+++ b/packages/apps/app-dashboard/src/utils/developer-dashboard/imageUtils.ts
@@ -10,9 +10,9 @@ export interface ImageUploadResult {
 }
 
 export const DEFAULT_IMAGE_OPTIONS: ImageValidationOptions = {
-  allowedTypes: ['image/jpeg', 'image/jpg', 'image/gif'],
+  allowedTypes: ['image/svg+xml'],
   maxSize: 512 * 1024, // 512KB
-  requireSquare: true,
+  requireSquare: false, // SVGs don't have inherent dimensions like raster images
 };
 
 /**

--- a/packages/apps/app-dashboard/src/utils/developer-dashboard/imageUtils.ts
+++ b/packages/apps/app-dashboard/src/utils/developer-dashboard/imageUtils.ts
@@ -11,7 +11,7 @@ export interface ImageUploadResult {
 
 export const DEFAULT_IMAGE_OPTIONS: ImageValidationOptions = {
   allowedTypes: ['image/svg+xml'],
-  maxSize: 512 * 1024, // 512KB
+  maxSize: 128 * 1024, // 128KB
   requireSquare: false, // SVGs don't have inherent dimensions like raster images
 };
 

--- a/packages/apps/registry-backend/src/lib/express/index.ts
+++ b/packages/apps/registry-backend/src/lib/express/index.ts
@@ -6,7 +6,7 @@ import cors from 'cors';
 import { json } from 'express';
 import * as OpenApiValidator from 'express-openapi-validator';
 
-// eslint-disable-next-line @nx/enforce-module-boundaries
+ 
 import { openApiJson } from '@lit-protocol/vincent-registry-sdk';
 
 import { html } from '../../assets/apiHtml.json';
@@ -24,7 +24,7 @@ const corsConfig = {
 
 export function registerRoutes(app: Express) {
   app.use(cors(corsConfig));
-  app.use(json({ limit: '512kb' }));
+  app.use(json({ limit: '768kb' }));
 
   app.get('/openApiJson', (req, res) => {
     res.json(openApiJson);

--- a/packages/apps/registry-backend/src/lib/express/index.ts
+++ b/packages/apps/registry-backend/src/lib/express/index.ts
@@ -6,7 +6,7 @@ import cors from 'cors';
 import { json } from 'express';
 import * as OpenApiValidator from 'express-openapi-validator';
 
- 
+// eslint-disable-next-line @nx/enforce-module-boundaries
 import { openApiJson } from '@lit-protocol/vincent-registry-sdk';
 
 import { html } from '../../assets/apiHtml.json';

--- a/packages/apps/registry-backend/src/lib/express/index.ts
+++ b/packages/apps/registry-backend/src/lib/express/index.ts
@@ -24,7 +24,7 @@ const corsConfig = {
 
 export function registerRoutes(app: Express) {
   app.use(cors(corsConfig));
-  app.use(json());
+  app.use(json({ limit: '512kb' }));
 
   app.get('/openApiJson', (req, res) => {
     res.json(openApiJson);

--- a/packages/apps/registry-backend/src/lib/express/index.ts
+++ b/packages/apps/registry-backend/src/lib/express/index.ts
@@ -6,7 +6,7 @@ import cors from 'cors';
 import { json } from 'express';
 import * as OpenApiValidator from 'express-openapi-validator';
 
-// eslint-disable-next-line @nx/enforce-module-boundaries
+ 
 import { openApiJson } from '@lit-protocol/vincent-registry-sdk';
 
 import { html } from '../../assets/apiHtml.json';
@@ -24,7 +24,7 @@ const corsConfig = {
 
 export function registerRoutes(app: Express) {
   app.use(cors(corsConfig));
-  app.use(json({ limit: '768kb' }));
+  app.use(json({ limit: '256kb' }));
 
   app.get('/openApiJson', (req, res) => {
     res.json(openApiJson);


### PR DESCRIPTION
# Description

A simple change to the registry. This will allow developers to put larger jpg/jpegs/gifs as their app/ability/policy logos, and ensure that the base metadata size never hits the previous 100KB default limit.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Locally on a dev server. I uploaded a 300KB+ GIF as the app logo, which didn't work previously. Now it does.

# Checklist:

- [ ] I created a [release plan](https://nx.dev/recipes/nx-release/file-based-versioning-version-plans) (`nx release plan`) describing my changes and the version bump
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
