### PR TITLE
docs: replace link to dca example with vincent yield

### DIFF
--- a/docs/src/Developers/Abilities/EvmTransactionSigner.md
+++ b/docs/src/Developers/Abilities/EvmTransactionSigner.md
@@ -40,7 +40,7 @@ Depending on your role in the Vincent Ecosystem, you'll be interacting with this
 
 When defining your Vincent App, you select which Abilities you want to be able to execute on behalf of your users. If you want to enable your App Delegatees to be able to sign transactions on behalf of your Vincent App Users, allowing them to interact with contracts that don't have an explicit Vincent Ability made for interacting with them, you can add this Ability to your App.
 
-Adding Abilities to your Vincent App is done using the Vincent App management interface, or while creating the App. Visit the [Create Vincent App](../App-Developers/Create-App.md) guide to learn more about how to add Abilities to your App during creation, or check out the [Upgrading Your App](../App-Developers/Update-App.md) guide to learn how to add Abilities to an existing App.
+Adding Abilities to your Vincent App is done using the Vincent App management interface, or while creating the App. Visit the [Creating Vincent Apps](../App-Agent-Developers/Creating-Apps.md) guide to learn more about how to add Abilities to your App during creation, or check out the [Upgrading Vincent Apps](../App-Agent-Developers/Upgrading-Apps.md) guide to learn how to add Abilities to an existing App.
 
 ## Executing the Ability as a Vincent App Delegatee
 

--- a/docs/src/Developers/App-Agent-Developers/Auth-Users.md
+++ b/docs/src/Developers/App-Agent-Developers/Auth-Users.md
@@ -141,7 +141,7 @@ if (vincentAppClient.uriContainsVincentJWT()) {
 
 > **Note:** The `redirectUri` given to `redirectToConnectPage` is where the user will be sent with the signed Vincent JWT after completing the Vincent Connect flow.
 >
-> This **must** be one of the [Authorized Redirect URIs](Creating-Apps.md#authorized-redirect-uris) you've configured for your App.
+> This **must** be one of the [Authorized Redirect URIs](Creating-Apps.md#redirect-uris) you've configured for your App.
 
 ## Verifying the Vincent JWT on your backend
 

--- a/docs/src/Developers/App-Agent-Developers/Executing-Abilities.md
+++ b/docs/src/Developers/App-Agent-Developers/Executing-Abilities.md
@@ -54,7 +54,7 @@ The two required parameters for the `getVincentAbilityClient` function are:
    - This ability definition is exported by the author of the Vincent Ability package and defines properties like the expected input parameters of the Ability, the Vincent Policies supported by the Ability, and the Ability's expected return values
    - The Ability Client handles wrapping this ability definition, providing you with a simple interface for executing the Ability, abstracting away the complexity of the Ability's implementation
 2. `ethersSigner`: An Ethers.js signer that will be used to sign the request to execute the Ability using the Lit Protocol network
-   - **Note:** The corresponding Ethereum address of the signer **must** be added as a delegatee for the Vincent App you are executing the Ability for. You can see how to add a delegatee to your Vincent App [here](./Creating-Apps.md#adding-delegatees-to-your-app)
+   - **Note:** The corresponding Ethereum address of the signer **must** be added as a delegatee for the Vincent App you are executing the Ability for. You can see how to add a delegatee to your Vincent App [here](./Creating-Apps.md#delegatee-addresses)
 
 # Executing the Ability Client's `precheck` function
 

--- a/docs/src/Developers/App-Agent-Developers/Getting-Started.md
+++ b/docs/src/Developers/App-Agent-Developers/Getting-Started.md
@@ -38,5 +38,5 @@ Vincent Apps enable secure, policy governed automation on behalf of Vincent User
 - Check out the [Creating a Vincent App](./Creating-Apps.md) guide to get started
 - Learn how to [Authenticate Vincent Users](./Auth-Users.md) in your frontend app
 - See how to [execute Vincent Abilities](./Executing-Abilities.md) on behalf of your App Users
-- Checkout the official [Automated Dollar-cost-averaging](https://demo.heyvincent.ai/) Vincent demo and explore it's [source code](https://github.com/LIT-Protocol/vincent-dca)
+- Checkout the official [Vincent Yield Maximizer](https://yield.heyvincent.ai/) Vincent App
 - Join the [Vincent community](https://t.me/c/2038294753/3289) for support and collaboration

--- a/docs/src/Developers/App-Agent-Developers/Upgrading-Apps.md
+++ b/docs/src/Developers/App-Agent-Developers/Upgrading-Apps.md
@@ -134,7 +134,7 @@ As the App Manager, versioning gives you control over your App’s configuration
 
 ## Next Steps
 
-- Checkout how to [Authenticate your Users with Vincent](../App-Agent-Developers/Authenticating-Users.md) to get Users to started delegating to your Vincent App.
+- Checkout how to [Authenticate your Users with Vincent](./Auth-Users.md) to get Users to started delegating to your Vincent App.
 - Dive into how to [Execute Vincent Abilities](../App-Agent-Developers/Executing-Abilities.md) and start executing Vincent Abilities on behalf of your Users.
 - Learn how to [Create a Vincent Ability](../Ability-Developers/Getting-Started.md) to add new functionality to your App.
 - Learn how to [Create a Vincent Policy](../Policy-Developers/Getting-Started.md) to add new governance rules to your App's Abilities.

--- a/docs/src/Why-Vincent.md
+++ b/docs/src/Why-Vincent.md
@@ -4,10 +4,19 @@ title: Why Vincent?
 
 # Start Here
 
-Vincent is an open-source framework powered by [Lit Protocol](https://litprotocol.com/) that empowers developers to create automated, user-controlled AI agents. With Vincent, you can build agents that automate the execution of operations across crypto networks, traditional finance (TradFi), and e-commerce platforms—all while ensuring users retain full control over their assets and data. Powered by Lit’s decentralized [key management network](https://developer.litprotocol.com/resources/how-it-works) and smart contracts, Vincent is your gateway to the future of the automated, User-Owned Web.
+Vincent is an open-source framework powered by [Lit Protocol](https://litprotocol.com/) that empowers developers to create automated, user-controlled AI agents. With Vincent, you can build agents that automate the execution of operations across crypto networks, traditional finance (TradFi), and e-commerce platforms—all while ensuring users retain full control over their assets and data. Powered by Lit’s decentralized [key management network](https://developer.litprotocol.com/resources/how-it-works) and smart contracts, Vincent is your gateway to the future of the automated, User-Owned Web.˛
 
-[Demo](https://demo.heyvincent.ai/) |
-[Source Code](https://github.com/LIT-Protocol/vincent-dca/tree/main)
+<div class="box info-box">
+  <p class="box-title info-box-title">
+    <span class="box-icon info-icon">Info</span> Checkout the Vincent Yield Maximizer
+  </p>
+  <p>This Vincent App helps you earn more yield on your USDC by automatically moving your funds into the highest-yielding Morpho vault.</p>
+  <p>
+    <a href="https://yield.heyvincent.ai/" class="button">
+      Try the Vincent Yield Maximizer
+    </a>
+  </p>
+</div>
 
 ## Why Vincent?
 

--- a/typedoc.config.base.js
+++ b/typedoc.config.base.js
@@ -14,6 +14,7 @@ module.exports = {
     'typedoc-plugin-zod',
     './typedoc-remove-type-params-plugin.mjs',
   ],
+  highlightLanguages: ['ts', 'tsx', 'js', 'json', 'bash', 'yaml', 'dockerfile'],
   externalSymbolLinkMappings: {
     '@lit-protocol/types': {
       '*': 'https://v7-api-doc-lit-js-sdk.vercel.app/modules/types_src.html',


### PR DESCRIPTION
# Description

- Replaces link to old DCA example with Vincent Yield Maximizer
- Fixes some warnings when building docs

## Type of change

- [x] Docs update

# Checklist:

- [ ] I created a [release plan](https://nx.dev/recipes/nx-release/file-based-versioning-version-plans) (`nx release plan`) describing my changes and the version bump
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
