### PR TITLE
feat: Allow deletion of existing policy parameters during sparse updates

### DIFF
--- a/.nx/version-plans/version-plan-1755533774990.md
+++ b/.nx/version-plans/version-plan-1755533774990.md
@@ -1,0 +1,13 @@
+---
+contracts-sdk: minor
+---
+
+## Enable deletion of existing policy parameters during sparse updates
+
+Adds functionality to allow contract-sdk consumers to remove existing policy parameters during sparse updates, by providing an optional `deletePermissionData` argument to `setAbilityPolicyParameters()`
+
+- Added `deletePermissionData` to `setAbilityPolicyParameters()` parameters
+- `policyParams` is now optional in `setAbilityPolicyParameters()`, in case the only change being made is to remove existing policy parameters
+- Provide an object mapping of `abilityIpfsCids` with arryays of `policyIpfsCids` to remove existing policy parameters for those policies during sparse updates
+- Existing behaviour for updating using `policyParams` remains unchanged
+- You cannot provide the same `abilityIpfsCid` and `policyIpfsCid` in both the `policyParams` and `deletePermissionData` objects; deleting or updating are exclusive operations

--- a/packages/libs/contracts-sdk/jest.config.js
+++ b/packages/libs/contracts-sdk/jest.config.js
@@ -3,7 +3,7 @@ const path = require('path');
 module.exports = {
   preset: '../../../jest.preset.js',
   testEnvironment: 'node',
-  testMatch: ['**/VincentContracts.spec.ts'],
+  testMatch: ['**/*.spec.ts'],
   transformIgnorePatterns: [
     // PNPM style: scoped packages with `.` become `+`, and non-scoped stay the same
     '<rootDir>/node_modules/.pnpm/(?!(@noble\\+secp256k1|cbor2|@cto\\.af\\+wtf8)@)',

--- a/packages/libs/contracts-sdk/src/internal/user/User.ts
+++ b/packages/libs/contracts-sdk/src/internal/user/User.ts
@@ -90,14 +90,14 @@ export async function setAbilityPolicyParameters(
 ): Promise<{ txHash: string }> {
   const {
     contract,
-    args: { appId, appVersion, pkpEthAddress, policyParams },
+    args: { appId, appVersion, pkpEthAddress, policyParams, deletePermissionData },
     overrides,
   } = params;
 
   try {
     const pkpTokenId = await getPkpTokenId({ pkpEthAddress, signer: contract.signer });
 
-    const flattenedParams = encodePermissionDataForChain(policyParams);
+    const flattenedParams = encodePermissionDataForChain(policyParams, deletePermissionData);
 
     const adjustedOverrides = await gasAdjustedOverrides(
       contract,

--- a/packages/libs/contracts-sdk/src/types.ts
+++ b/packages/libs/contracts-sdk/src/types.ts
@@ -230,13 +230,29 @@ export interface UnPermitAppParams {
 }
 
 /**
+ * Represents a nested map of existing policy entries to delete, keyed by ability.
+ * Keys are ability IPFS CIDs, values are arrays of policy IPFS CIDs that should be removed for that ability.
+ *
+ * Used by setAbilityPolicyParameters to request deletions without providing new parameters.
+ *
+ * @example
+ * {
+ *   "abilityCidA": ["policyCid1", "policyCid2"],
+ *   "abilityCidB": ["policyCid3"]
+ * }
+ *
  * @category Interfaces
  * */
+export interface DeletePermissionData {
+  [abilityIpfsCid: string]: string[];
+}
+
 export interface SetAbilityPolicyParametersParams {
   pkpEthAddress: string;
   appId: number;
   appVersion: number;
-  policyParams: PermissionData;
+  policyParams?: PermissionData;
+  deletePermissionData?: DeletePermissionData;
 }
 
 /**
@@ -399,7 +415,9 @@ export interface ContractClient {
   unPermitApp(params: UnPermitAppParams, overrides?: Overrides): ReturnType<typeof _unPermitApp>;
 
   /** Sets ability policy parameters for a specific app version
+   * Note that omitting parameters from `policyParams` does not remove any existing values; this function allows atomic/sparse updates.
    *
+   * To remove existing policy parameters, provide their IPFS CIDs in the `deletePermissionData` param.
    * @returns { txHash } The transaction hash that set the policy parameters
    */
   setAbilityPolicyParameters(

--- a/packages/libs/contracts-sdk/test/policyParams.spec.ts
+++ b/packages/libs/contracts-sdk/test/policyParams.spec.ts
@@ -1,0 +1,116 @@
+import { encode as cborEncode } from 'cbor2';
+import { hexlify } from 'ethers/lib/utils';
+
+import type { PermissionData, DeletePermissionData } from '../src/types';
+
+import { encodePermissionDataForChain } from '../src/utils/policyParams';
+
+describe('encodePermissionDataForChain', () => {
+  it('throws when PermissionData and DeletePermissionData share the same ability key', () => {
+    const permissionData: PermissionData = {
+      abilityA: {
+        policy1: { a: 1 },
+      },
+    };
+
+    const deletePermissionData: DeletePermissionData = {
+      abilityA: ['policyX'],
+    };
+
+    expect(() => encodePermissionDataForChain(permissionData, deletePermissionData)).toThrow(
+      /deletePermissionData contains ability abilityA/,
+    );
+  });
+
+  it('sets deleted policy entries to 0x in the output (deletion-only)', () => {
+    const deletePermissionData: DeletePermissionData = {
+      abilityA: ['policy1', 'policy2'],
+      abilityB: ['policy3'],
+    };
+
+    const result = encodePermissionDataForChain(undefined, deletePermissionData);
+
+    // Order should follow: keys from permissionData (none) then keys from deletePermissionData
+    expect(result.abilityIpfsCids).toEqual(['abilityA', 'abilityB']);
+    expect(result.policyIpfsCids).toEqual([['policy1', 'policy2'], ['policy3']]);
+    expect(result.policyParameterValues).toEqual([['0x', '0x'], ['0x']]);
+  });
+
+  it('encodes updates to CBOR2 hex values', () => {
+    const permissionData: PermissionData = {
+      abilityA: {
+        policy1: { foo: 'bar' },
+        // explicit undefined should be allowed and encoded as CBOR undefined
+        policy2: undefined,
+      },
+      abilityB: {
+        policy3: { count: 123 },
+      },
+    };
+
+    const result = encodePermissionDataForChain(permissionData);
+
+    // Compute expected encodings using the same CBOR2 encoder for precise matching
+    const expectedPolicy1 = hexlify(cborEncode({ foo: 'bar' }));
+    const expectedPolicy2 = hexlify(cborEncode(undefined));
+    const expectedPolicy3 = hexlify(cborEncode({ count: 123 }));
+
+    expect(result.abilityIpfsCids).toEqual(['abilityA', 'abilityB']);
+    expect(result.policyIpfsCids).toEqual([['policy1', 'policy2'], ['policy3']]);
+    expect(result.policyParameterValues).toEqual([
+      [expectedPolicy1, expectedPolicy2],
+      [expectedPolicy3],
+    ]);
+  });
+
+  it('maintains correct positional ordering and alignment for mixed updates and deletions', () => {
+    // permissionData first keys followed by deletePermissionData-only ability keys
+    const permissionData: PermissionData = {
+      ability1: {
+        polA: { x: 1 },
+      },
+      ability2: {
+        polB: { y: 2 },
+      },
+    };
+
+    const deletePermissionData: DeletePermissionData = {
+      ability3: ['polC', 'polD'],
+    };
+
+    const result = encodePermissionDataForChain(permissionData, deletePermissionData);
+
+    // Combined key order: Object.keys(permissionData) then Object.keys(deletePermissionData)
+    expect(result.abilityIpfsCids).toEqual(['ability1', 'ability2', 'ability3']);
+
+    // Ensure inner arrays are aligned index-by-index
+    expect(result.policyIpfsCids.length).toBe(3);
+    expect(result.policyParameterValues.length).toBe(3);
+
+    // ability1 updates
+    expect(result.policyIpfsCids[0]).toEqual(['polA']);
+    const expectedPolA = hexlify(cborEncode({ x: 1 }));
+    expect(result.policyParameterValues[0]).toEqual([expectedPolA]);
+
+    // ability2 updates
+    expect(result.policyIpfsCids[1]).toEqual(['polB']);
+    const expectedPolB = hexlify(cborEncode({ y: 2 }));
+    expect(result.policyParameterValues[1]).toEqual([expectedPolB]);
+
+    // ability3 deletions
+    expect(result.policyIpfsCids[2]).toEqual(['polC', 'polD']);
+    expect(result.policyParameterValues[2]).toEqual(['0x', '0x']);
+  });
+
+  it('handles permissionData being optional when only deletions are provided', () => {
+    const deletePermissionData: DeletePermissionData = {
+      abilityX: ['policyZ'],
+    };
+
+    const result = encodePermissionDataForChain(undefined, deletePermissionData);
+
+    expect(result.abilityIpfsCids).toEqual(['abilityX']);
+    expect(result.policyIpfsCids).toEqual([['policyZ']]);
+    expect(result.policyParameterValues).toEqual([['0x']]);
+  });
+});


### PR DESCRIPTION
- added `deletePolicyIpfsCids` to `setAbilityPolicyParameters()` parameters

# Description
## Enable deletion of existing policy parameters during sparse updates

Adds functionality to allow contract-sdk consumers to remove existing policy parameters during sparse updates, by providing an optional `deletePolicyIpfsCids` argument to `setAbilityPolicyParameters()`

- Added `deletePolicyIpfsCids` to `setAbilityPolicyParameters()` parameters
- Provide an array of policy IPFS CIDs to remove existing policy parameters for those policies during sparse updates
- Behaviour of `policyParams` remains unchanged

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

# Checklist:

- [X] I created a [release plan](https://nx.dev/recipes/nx-release/file-based-versioning-version-plans) (`nx release plan`) describing my changes and the version bump
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
