### PR TITLE
Refactor `getAllPermittedAppIdsForPkp` to optimize frontend user dashboard

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "packages/libs/contracts-sdk/lib/forge-std"]
+	path = packages/libs/contracts-sdk/lib/forge-std
+	url = https://github.com/foundry-rs/forge-std.git

--- a/packages/libs/contracts-sdk/contracts/VincentDiamond.sol
+++ b/packages/libs/contracts-sdk/contracts/VincentDiamond.sol
@@ -214,13 +214,14 @@ contract VincentDiamond {
     }
 
     function getVincentUserViewFacetSelectors() internal pure returns (bytes4[] memory) {
-        bytes4[] memory selectors = new bytes4[](6);
+        bytes4[] memory selectors = new bytes4[](7);
         selectors[0] = VincentUserViewFacet.getAllRegisteredAgentPkps.selector;
         selectors[1] = VincentUserViewFacet.getPermittedAppVersionForPkp.selector;
         selectors[2] = VincentUserViewFacet.getAllPermittedAppIdsForPkp.selector;
         selectors[3] = VincentUserViewFacet.validateAbilityExecutionAndGetPolicies.selector;
         selectors[4] = VincentUserViewFacet.getAllAbilitiesAndPoliciesForApp.selector;
-        selectors[5] = bytes4(keccak256("AGENT_PAGE_SIZE()"));
+        selectors[5] = VincentUserViewFacet.getPermittedAppsForPkps.selector;
+        selectors[6] = bytes4(keccak256("AGENT_PAGE_SIZE()"));
         return selectors;
     }
 

--- a/packages/libs/contracts-sdk/contracts/VincentDiamond.sol
+++ b/packages/libs/contracts-sdk/contracts/VincentDiamond.sol
@@ -214,14 +214,13 @@ contract VincentDiamond {
     }
 
     function getVincentUserViewFacetSelectors() internal pure returns (bytes4[] memory) {
-        bytes4[] memory selectors = new bytes4[](7);
+        bytes4[] memory selectors = new bytes4[](6);
         selectors[0] = VincentUserViewFacet.getAllRegisteredAgentPkps.selector;
         selectors[1] = VincentUserViewFacet.getPermittedAppVersionForPkp.selector;
-        selectors[2] = VincentUserViewFacet.getAllPermittedAppIdsForPkp.selector;
-        selectors[3] = VincentUserViewFacet.validateAbilityExecutionAndGetPolicies.selector;
-        selectors[4] = VincentUserViewFacet.getAllAbilitiesAndPoliciesForApp.selector;
-        selectors[5] = VincentUserViewFacet.getPermittedAppsForPkps.selector;
-        selectors[6] = bytes4(keccak256("AGENT_PAGE_SIZE()"));
+        selectors[2] = VincentUserViewFacet.validateAbilityExecutionAndGetPolicies.selector;
+        selectors[3] = VincentUserViewFacet.getAllAbilitiesAndPoliciesForApp.selector;
+        selectors[4] = VincentUserViewFacet.getPermittedAppsForPkps.selector;
+        selectors[5] = bytes4(keccak256("AGENT_PAGE_SIZE()"));
         return selectors;
     }
 

--- a/packages/libs/contracts-sdk/script/UpdateFacet.sol
+++ b/packages/libs/contracts-sdk/script/UpdateFacet.sol
@@ -312,9 +312,9 @@ contract SmartUpdateFacet is Script {
         bytes4[] memory selectors = new bytes4[](6);
         selectors[0] = VincentUserViewFacet.getAllRegisteredAgentPkps.selector;
         selectors[1] = VincentUserViewFacet.getPermittedAppVersionForPkp.selector;
-        selectors[2] = VincentUserViewFacet.getAllPermittedAppIdsForPkp.selector;
-        selectors[3] = VincentUserViewFacet.validateAbilityExecutionAndGetPolicies.selector;
-        selectors[4] = VincentUserViewFacet.getAllAbilitiesAndPoliciesForApp.selector;
+        selectors[2] = VincentUserViewFacet.validateAbilityExecutionAndGetPolicies.selector;
+        selectors[3] = VincentUserViewFacet.getAllAbilitiesAndPoliciesForApp.selector;
+        selectors[4] = VincentUserViewFacet.getPermittedAppsForPkps.selector;
         selectors[5] = bytes4(keccak256("AGENT_PAGE_SIZE()"));
         return selectors;
     }

--- a/packages/libs/contracts-sdk/test/facets/VincentAppFacet.t.sol
+++ b/packages/libs/contracts-sdk/test/facets/VincentAppFacet.t.sol
@@ -658,7 +658,7 @@ contract VincentAppFacetTest is Test {
         pkpTokenIds[0] = PKP_TOKEN_ID_1; // This PKP has permitted apps
         pkpTokenIds[1] = PKP_TOKEN_ID_2; // This PKP has no permitted apps
         
-        VincentUserViewFacet.PkpPermittedApps[] memory permittedAppsResults = vincentUserViewFacet.getPermittedAppsForPkps(pkpTokenIds);
+        VincentUserViewFacet.PkpPermittedApps[] memory permittedAppsResults = vincentUserViewFacet.getPermittedAppsForPkps(pkpTokenIds, 0);
         assertEq(permittedAppsResults.length, 2);
         
         // PKP_TOKEN_ID_1 should have 1 permitted app
@@ -666,6 +666,7 @@ contract VincentAppFacetTest is Test {
         assertEq(permittedAppsResults[0].permittedApps.length, 1);
         assertEq(permittedAppsResults[0].permittedApps[0].appId, newAppId);
         assertEq(permittedAppsResults[0].permittedApps[0].version, newAppVersion);
+        assertEq(permittedAppsResults[0].permittedApps[0].versionEnabled, true);
         
         // PKP_TOKEN_ID_2 should have no permitted apps
         assertEq(permittedAppsResults[1].pkpTokenId, PKP_TOKEN_ID_2);
@@ -720,12 +721,13 @@ contract VincentAppFacetTest is Test {
         uint256[] memory pkpTokenIds = new uint256[](1);
         pkpTokenIds[0] = PKP_TOKEN_ID_1;
         
-        VincentUserViewFacet.PkpPermittedApps[] memory permittedAppsResults = vincentUserViewFacet.getPermittedAppsForPkps(pkpTokenIds);
+        VincentUserViewFacet.PkpPermittedApps[] memory permittedAppsResults = vincentUserViewFacet.getPermittedAppsForPkps(pkpTokenIds, 0);
         assertEq(permittedAppsResults.length, 1);
         assertEq(permittedAppsResults[0].pkpTokenId, PKP_TOKEN_ID_1);
         assertEq(permittedAppsResults[0].permittedApps.length, 1);
         assertEq(permittedAppsResults[0].permittedApps[0].appId, newAppId);
         assertEq(permittedAppsResults[0].permittedApps[0].version, newAppVersion);
+        assertEq(permittedAppsResults[0].permittedApps[0].versionEnabled, true); // App version should be enabled
     }
 
     function _registerApp(

--- a/packages/libs/contracts-sdk/test/facets/VincentAppFacet.t.sol
+++ b/packages/libs/contracts-sdk/test/facets/VincentAppFacet.t.sol
@@ -653,6 +653,24 @@ contract VincentAppFacetTest is Test {
         );
         vm.stopPrank();
 
+        // Test getPermittedAppsForPkps before deleting the app
+        uint256[] memory pkpTokenIds = new uint256[](2);
+        pkpTokenIds[0] = PKP_TOKEN_ID_1; // This PKP has permitted apps
+        pkpTokenIds[1] = PKP_TOKEN_ID_2; // This PKP has no permitted apps
+        
+        VincentUserViewFacet.PkpPermittedApps[] memory permittedAppsResults = vincentUserViewFacet.getPermittedAppsForPkps(pkpTokenIds);
+        assertEq(permittedAppsResults.length, 2);
+        
+        // PKP_TOKEN_ID_1 should have 1 permitted app
+        assertEq(permittedAppsResults[0].pkpTokenId, PKP_TOKEN_ID_1);
+        assertEq(permittedAppsResults[0].permittedApps.length, 1);
+        assertEq(permittedAppsResults[0].permittedApps[0].appId, newAppId);
+        assertEq(permittedAppsResults[0].permittedApps[0].version, newAppVersion);
+        
+        // PKP_TOKEN_ID_2 should have no permitted apps
+        assertEq(permittedAppsResults[1].pkpTokenId, PKP_TOKEN_ID_2);
+        assertEq(permittedAppsResults[1].permittedApps.length, 0);
+
         vm.startPrank(APP_MANAGER_ALICE);
         vm.expectEmit(true, true, true, true);
         emit LibVincentAppFacet.AppDeleted(newAppId);
@@ -697,6 +715,17 @@ contract VincentAppFacetTest is Test {
 
         vm.expectRevert(abi.encodeWithSelector(VincentBase.InvalidOffset.selector, 1, 1));
         vincentAppViewFacet.getDelegatedAgentPkpTokenIds(newAppId, newAppVersion, 1);
+
+        // Test the new getPermittedAppsForPkps function
+        uint256[] memory pkpTokenIds = new uint256[](1);
+        pkpTokenIds[0] = PKP_TOKEN_ID_1;
+        
+        VincentUserViewFacet.PkpPermittedApps[] memory permittedAppsResults = vincentUserViewFacet.getPermittedAppsForPkps(pkpTokenIds);
+        assertEq(permittedAppsResults.length, 1);
+        assertEq(permittedAppsResults[0].pkpTokenId, PKP_TOKEN_ID_1);
+        assertEq(permittedAppsResults[0].permittedApps.length, 1);
+        assertEq(permittedAppsResults[0].permittedApps[0].appId, newAppId);
+        assertEq(permittedAppsResults[0].permittedApps[0].version, newAppVersion);
     }
 
     function _registerApp(

--- a/packages/libs/contracts-sdk/test/facets/VincentUserFacet.t.sol
+++ b/packages/libs/contracts-sdk/test/facets/VincentUserFacet.t.sol
@@ -201,16 +201,21 @@ contract VincentUserFacetTest is Test {
         permittedAppVersion = vincentUserViewFacet.getPermittedAppVersionForPkp(PKP_TOKEN_ID_2, newAppId_3);
         assertEq(permittedAppVersion, newAppVersion_3);
 
-        // Check that Frank has permitted App IDs
-        uint40[] memory permittedAppIds = vincentUserViewFacet.getAllPermittedAppIdsForPkp(PKP_TOKEN_ID_1, 0);
-        assertEq(permittedAppIds.length, 2);
-        assertEq(permittedAppIds[0], newAppId_1);
-        assertEq(permittedAppIds[1], newAppId_2);
+        // Check that Frank has permitted App IDs using the new function
+        uint256[] memory pkpTokenIds = new uint256[](1);
+        pkpTokenIds[0] = PKP_TOKEN_ID_1;
+        VincentUserViewFacet.PkpPermittedApps[] memory permittedAppsResults = vincentUserViewFacet.getPermittedAppsForPkps(pkpTokenIds, 0);
+        assertEq(permittedAppsResults.length, 1);
+        assertEq(permittedAppsResults[0].pkpTokenId, PKP_TOKEN_ID_1);
+        assertEq(permittedAppsResults[0].permittedApps.length, 2);
+        assertEq(permittedAppsResults[0].permittedApps[0].appId, newAppId_1);
+        assertEq(permittedAppsResults[0].permittedApps[1].appId, newAppId_2);
 
         // Check that George has permitted App IDs
-        permittedAppIds = vincentUserViewFacet.getAllPermittedAppIdsForPkp(PKP_TOKEN_ID_2, 0);
-        assertEq(permittedAppIds.length, 1);
-        assertEq(permittedAppIds[0], newAppId_3);
+        pkpTokenIds[0] = PKP_TOKEN_ID_2;
+        permittedAppsResults = vincentUserViewFacet.getPermittedAppsForPkps(pkpTokenIds, 0);
+        assertEq(permittedAppsResults[0].permittedApps.length, 1);
+        assertEq(permittedAppsResults[0].permittedApps[0].appId, newAppId_3);
 
         // Check the Ability and Policies for App 1 Version 1 for PKP 1 (Frank)
         VincentUserViewFacet.AbilityWithPolicies[] memory abilitiesWithPolicies = vincentUserViewFacet.getAllAbilitiesAndPoliciesForApp(PKP_TOKEN_ID_1, newAppId_1);
@@ -347,10 +352,12 @@ contract VincentUserFacetTest is Test {
         vm.stopPrank();
 
         // Verify initial state
-        uint40[] memory permittedAppIds = vincentUserViewFacet.getAllPermittedAppIdsForPkp(PKP_TOKEN_ID_1, 0);
-        assertEq(permittedAppIds.length, 2);
-        assertEq(permittedAppIds[0], newAppId_1);
-        assertEq(permittedAppIds[1], newAppId_2);
+        uint256[] memory pkpTokenIds = new uint256[](1);
+        pkpTokenIds[0] = PKP_TOKEN_ID_1;
+        VincentUserViewFacet.PkpPermittedApps[] memory permittedAppsResults = vincentUserViewFacet.getPermittedAppsForPkps(pkpTokenIds, 0);
+        assertEq(permittedAppsResults[0].permittedApps.length, 2);
+        assertEq(permittedAppsResults[0].permittedApps[0].appId, newAppId_1);
+        assertEq(permittedAppsResults[0].permittedApps[1].appId, newAppId_2);
 
         // Expect event for unpermit
         vm.startPrank(APP_USER_FRANK);
@@ -370,9 +377,9 @@ contract VincentUserFacetTest is Test {
         assertEq(permittedAppVersion, newAppVersion_2);
 
         // Verify permitted apps list is updated
-        permittedAppIds = vincentUserViewFacet.getAllPermittedAppIdsForPkp(PKP_TOKEN_ID_1, 0);
-        assertEq(permittedAppIds.length, 1);
-        assertEq(permittedAppIds[0], newAppId_2);
+        permittedAppsResults = vincentUserViewFacet.getPermittedAppsForPkps(pkpTokenIds, 0);
+        assertEq(permittedAppsResults[0].permittedApps.length, 1);
+        assertEq(permittedAppsResults[0].permittedApps[0].appId, newAppId_2);
 
         // Verify ability execution validation for App 1 is no longer permitted
         VincentUserViewFacet.AbilityExecutionValidation memory abilityExecutionValidation = vincentUserViewFacet.validateAbilityExecutionAndGetPolicies(


### PR DESCRIPTION
# Description

**This is a breaking change to the contract API. The `getAllPermittedAppIdsForPkp` has been renamed to `getPermittedAppsForPkps`, it's input parameters and return value has changed.**

My understanding of the problem is: a User PKP can have multiple Agent PKPs, and each Agent PKP can have multiple permitted Apps (the contract support it even if we intended there to be 1 Agent PKP per App). When the User loads the App Dashboard, the frontend would ideally make a single RPC request with a list of Agent PKP identifiers (pkp token IDs), and get back the permitted Apps with versions for each Agent PKP, ideally with a flag that signals the frontend on whether or not the permitted App version has been disabled so it can flag that to the User.

To address this, this PR:

- Refactors the existing `getAllPermittedAppIdsForPkp` functions which just returned an array of App IDs permitted by an Agent PKP
    - Function renamed to `getPermittedAppsForPkps`
    - Now accepts an array of PKP token IDs
    - Now returns an array of structs with nested structs instead of an array of App versions.

The new return value is:

```
[
    {
        pkpTokenId: uint256,
        permittedApps: [
            {
                appId: uint40,
                version: uint24,
                versionEnabled: bool
            }
        ]
    }
]
```

One missing property that _may_ save the frontend from making extra RPC calls is the latest version of each permitted App, but I omitted this as I'm not sure we need it.

The rationale behind this refactor:

- We _could_ add new view methods and keep the existing `getAllPermittedAppIdsForPkp` to only accept a single PKP token ID and return an array of just App IDs, but it seems more appropriate to refactor the method to support our needs rather than having two methods that doing basically the same thing, one with just significantly less data.
- We can still fetch a single PKP token ID's permitted Apps by just passing the single token ID if gas cost is a concern (so basically the new function provides the same functionality as before)
- I've opted to not support querying via a PKP ETH address as that would mean we'd need to query the PKP contract to get the token ID since everything is tracked via token ID in the contracts
    - Although, querying the PKP token ID using it's ETH address would be better than the frontend having to do it via separate RPC calls as the Lit nodes would be reading from their local node DB within the single RPC call to `getAllPermittedAppIdsForPkp`
    - However, I'm not sure what info the frontend has available to it, and it seems like our off-chain DB should have the PKP ETH address and token ID stored, so maybe it doesn't have to query the PKP token ID if all it has is the ETH address?

## Type of change

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- Updated existing assertions in existing test cases

# Checklist:

- [ ] I created a [release plan](https://nx.dev/recipes/nx-release/file-based-versioning-version-plans) (`nx release plan`) describing my changes and the version bump
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
