### PR TITLE
DREL-947 Add `allPermittedApps` storage and view method

### DIFF
--- a/packages/libs/contracts-sdk/contracts/LibVincentDiamondStorage.sol
+++ b/packages/libs/contracts-sdk/contracts/LibVincentDiamondStorage.sol
@@ -73,6 +73,8 @@ library VincentUserStorage {
         mapping(uint40 => uint24) permittedAppVersion;
         // App ID -> App version -> Ability IPFS CID hash -> Ability Policy storage -> Ability Policy IPFS CID hash -> User's CBOR2 encoded Policy parameter values
         mapping(uint40 => mapping(uint24 => mapping(bytes32 => mapping(bytes32 => bytes)))) abilityPolicyParameterValues;
+        // Set of all App IDs that have ever been permitted (complete historical record, contains unpermitted apps too)
+        EnumerableSet.UintSet allPermittedApps;
     }
 
     struct UserStorage {

--- a/packages/libs/contracts-sdk/contracts/VincentDiamond.sol
+++ b/packages/libs/contracts-sdk/contracts/VincentDiamond.sol
@@ -214,13 +214,14 @@ contract VincentDiamond {
     }
 
     function getVincentUserViewFacetSelectors() internal pure returns (bytes4[] memory) {
-        bytes4[] memory selectors = new bytes4[](6);
+        bytes4[] memory selectors = new bytes4[](7);
         selectors[0] = VincentUserViewFacet.getAllRegisteredAgentPkps.selector;
         selectors[1] = VincentUserViewFacet.getPermittedAppVersionForPkp.selector;
         selectors[2] = VincentUserViewFacet.validateAbilityExecutionAndGetPolicies.selector;
         selectors[3] = VincentUserViewFacet.getAllAbilitiesAndPoliciesForApp.selector;
         selectors[4] = VincentUserViewFacet.getPermittedAppsForPkps.selector;
-        selectors[5] = bytes4(keccak256("AGENT_PAGE_SIZE()"));
+        selectors[5] = VincentUserViewFacet.getAllAppsForPkps.selector;
+        selectors[6] = bytes4(keccak256("AGENT_PAGE_SIZE()"));
         return selectors;
     }
 

--- a/packages/libs/contracts-sdk/contracts/facets/VincentUserFacet.sol
+++ b/packages/libs/contracts-sdk/contracts/facets/VincentUserFacet.sol
@@ -113,6 +113,10 @@ contract VincentUserFacet is VincentBase {
         // .add will not add the app ID again if it is already registered
         agentStorage.permittedApps.add(appId);
 
+        // Add the app ID to the User's historical permitted apps set (never removed)
+        // .add will not add the app ID again if it is already registered
+        agentStorage.allPermittedApps.add(appId);
+
         // Set the new permitted app version
         agentStorage.permittedAppVersion[appId] = appVersion;
 
@@ -157,6 +161,10 @@ contract VincentUserFacet is VincentBase {
 
         // Remove the App Version from the User's Permitted App Versions
         us_.agentPkpTokenIdToAgentStorage[pkpTokenId].permittedAppVersion[appId] = 0;
+
+        // Add the App ID to the User's historical permitted apps set
+        // This ensures apps permitted before the allPermittedApps tracking was added are captured
+        us_.agentPkpTokenIdToAgentStorage[pkpTokenId].allPermittedApps.add(appId);
 
         // Remove the app from the User's permitted apps set
         us_.agentPkpTokenIdToAgentStorage[pkpTokenId].permittedApps.remove(appId);

--- a/packages/libs/contracts-sdk/contracts/facets/VincentUserViewFacet.sol
+++ b/packages/libs/contracts-sdk/contracts/facets/VincentUserViewFacet.sol
@@ -324,41 +324,40 @@ contract VincentUserViewFacet is VincentBase {
                 }
             }
             
-            // Apply pagination to combined total
-            uint256 totalCount = permittedCount + historicalCount;
-            uint256 start = offset;
-            uint256 end = offset + AGENT_PAGE_SIZE;
+            // Apply pagination separately to permitted and historical apps
             
-            if (start >= totalCount) {
-                // Offset beyond available items
-                results[i].pkpTokenId = pkpTokenId;
+            // Paginate permitted apps
+            uint256 permittedStart = offset;
+            uint256 permittedEnd = offset + AGENT_PAGE_SIZE;
+            if (permittedStart >= permittedCount) {
+                // Offset beyond available permitted apps
                 results[i].permittedApps = new PermittedApp[](0);
+            } else {
+                if (permittedEnd > permittedCount) {
+                    permittedEnd = permittedCount;
+                }
+                uint256 permittedResultCount = permittedEnd - permittedStart;
+                results[i].permittedApps = new PermittedApp[](permittedResultCount);
+                for (uint256 k = 0; k < permittedResultCount; k++) {
+                    results[i].permittedApps[k] = tempPermittedApps[permittedStart + k];
+                }
+            }
+            
+            // Paginate historical apps
+            uint256 historicalStart = offset;
+            uint256 historicalEnd = offset + AGENT_PAGE_SIZE;
+            if (historicalStart >= historicalCount) {
+                // Offset beyond available historical apps
                 results[i].historicalAppIds = new uint40[](0);
-                continue;
-            }
-            
-            if (end > totalCount) {
-                end = totalCount;
-            }
-            
-            // Determine how to split the paginated results
-            uint256 permittedStart = start < permittedCount ? start : permittedCount;
-            uint256 permittedEnd = end < permittedCount ? end : permittedCount;
-            uint256 historicalStart = start > permittedCount ? start - permittedCount : 0;
-            uint256 historicalEnd = end > permittedCount ? end - permittedCount : 0;
-            
-            // Copy permitted apps within pagination range
-            uint256 permittedResultCount = permittedEnd - permittedStart;
-            results[i].permittedApps = new PermittedApp[](permittedResultCount);
-            for (uint256 k = 0; k < permittedResultCount; k++) {
-                results[i].permittedApps[k] = tempPermittedApps[permittedStart + k];
-            }
-            
-            // Copy historical app IDs within pagination range
-            uint256 historicalResultCount = historicalEnd - historicalStart;
-            results[i].historicalAppIds = new uint40[](historicalResultCount);
-            for (uint256 k = 0; k < historicalResultCount; k++) {
-                results[i].historicalAppIds[k] = tempHistoricalAppIds[historicalStart + k];
+            } else {
+                if (historicalEnd > historicalCount) {
+                    historicalEnd = historicalCount;
+                }
+                uint256 historicalResultCount = historicalEnd - historicalStart;
+                results[i].historicalAppIds = new uint40[](historicalResultCount);
+                for (uint256 k = 0; k < historicalResultCount; k++) {
+                    results[i].historicalAppIds[k] = tempHistoricalAppIds[historicalStart + k];
+                }
             }
             
             results[i].pkpTokenId = pkpTokenId;

--- a/packages/libs/contracts-sdk/script/UpdateFacet.sol
+++ b/packages/libs/contracts-sdk/script/UpdateFacet.sol
@@ -309,13 +309,14 @@ contract SmartUpdateFacet is Script {
     }
 
     function getVincentUserViewFacetSelectors() internal pure returns (bytes4[] memory) {
-        bytes4[] memory selectors = new bytes4[](6);
+        bytes4[] memory selectors = new bytes4[](7);
         selectors[0] = VincentUserViewFacet.getAllRegisteredAgentPkps.selector;
         selectors[1] = VincentUserViewFacet.getPermittedAppVersionForPkp.selector;
         selectors[2] = VincentUserViewFacet.validateAbilityExecutionAndGetPolicies.selector;
         selectors[3] = VincentUserViewFacet.getAllAbilitiesAndPoliciesForApp.selector;
         selectors[4] = VincentUserViewFacet.getPermittedAppsForPkps.selector;
-        selectors[5] = bytes4(keccak256("AGENT_PAGE_SIZE()"));
+        selectors[5] = VincentUserViewFacet.getAllAppsForPkps.selector;
+        selectors[6] = bytes4(keccak256("AGENT_PAGE_SIZE()"));
         return selectors;
     }
 

--- a/packages/libs/contracts-sdk/test/facets/VincentUserFacet.t.sol
+++ b/packages/libs/contracts-sdk/test/facets/VincentUserFacet.t.sol
@@ -217,6 +217,27 @@ contract VincentUserFacetTest is Test {
         assertEq(permittedAppsResults[0].permittedApps.length, 1);
         assertEq(permittedAppsResults[0].permittedApps[0].appId, newAppId_3);
 
+        // Test getAllAppsForPkps function - Frank should have 2 permitted apps, no historical apps yet
+        pkpTokenIds[0] = PKP_TOKEN_ID_1;
+        VincentUserViewFacet.PkpAllApps[] memory allAppsResults = vincentUserViewFacet.getAllAppsForPkps(pkpTokenIds, 0);
+        assertEq(allAppsResults.length, 1);
+        assertEq(allAppsResults[0].pkpTokenId, PKP_TOKEN_ID_1);
+        assertEq(allAppsResults[0].permittedApps.length, 2);
+        assertEq(allAppsResults[0].permittedApps[0].appId, newAppId_1);
+        assertEq(allAppsResults[0].permittedApps[0].version, newAppVersion_1);
+        assertTrue(allAppsResults[0].permittedApps[0].versionEnabled);
+        assertEq(allAppsResults[0].permittedApps[1].appId, newAppId_2);
+        assertEq(allAppsResults[0].permittedApps[1].version, newAppVersion_2);
+        assertTrue(allAppsResults[0].permittedApps[1].versionEnabled);
+        assertEq(allAppsResults[0].historicalAppIds.length, 0); // No historical apps yet
+
+        // Test George's apps
+        pkpTokenIds[0] = PKP_TOKEN_ID_2;
+        allAppsResults = vincentUserViewFacet.getAllAppsForPkps(pkpTokenIds, 0);
+        assertEq(allAppsResults[0].permittedApps.length, 1);
+        assertEq(allAppsResults[0].permittedApps[0].appId, newAppId_3);
+        assertEq(allAppsResults[0].historicalAppIds.length, 0); // No historical apps yet
+
         // Check the Ability and Policies for App 1 Version 1 for PKP 1 (Frank)
         VincentUserViewFacet.AbilityWithPolicies[] memory abilitiesWithPolicies = vincentUserViewFacet.getAllAbilitiesAndPoliciesForApp(PKP_TOKEN_ID_1, newAppId_1);
         assertEq(abilitiesWithPolicies.length, 2);
@@ -380,6 +401,20 @@ contract VincentUserFacetTest is Test {
         permittedAppsResults = vincentUserViewFacet.getPermittedAppsForPkps(pkpTokenIds, 0);
         assertEq(permittedAppsResults[0].permittedApps.length, 1);
         assertEq(permittedAppsResults[0].permittedApps[0].appId, newAppId_2);
+
+        // Test getAllAppsForPkps function after unpermitting - should show App 2 as permitted and App 1 as historical
+        VincentUserViewFacet.PkpAllApps[] memory allAppsResults = vincentUserViewFacet.getAllAppsForPkps(pkpTokenIds, 0);
+        assertEq(allAppsResults[0].pkpTokenId, PKP_TOKEN_ID_1);
+        
+        // Should have 1 permitted app (App 2)
+        assertEq(allAppsResults[0].permittedApps.length, 1);
+        assertEq(allAppsResults[0].permittedApps[0].appId, newAppId_2);
+        assertEq(allAppsResults[0].permittedApps[0].version, newAppVersion_2);
+        assertTrue(allAppsResults[0].permittedApps[0].versionEnabled);
+        
+        // Should have 1 historical app (App 1 that was unpermitted)
+        assertEq(allAppsResults[0].historicalAppIds.length, 1);
+        assertEq(allAppsResults[0].historicalAppIds[0], newAppId_1);
 
         // Verify ability execution validation for App 1 is no longer permitted
         VincentUserViewFacet.AbilityExecutionValidation memory abilityExecutionValidation = vincentUserViewFacet.validateAbilityExecutionAndGetPolicies(


### PR DESCRIPTION
# Description

**Branches off #295, so `295` must be merged first**

**As I called out in Slack, the method added in this PR: `getAllAppsForPkps` returns the same data as the function added in #295, just with the addition of an array of unpermitted App IDs - wondering if we should just combine the methods?**

- Adds to `VincentUserStorage.AgentStorage`:

```solidity
// Set of all App IDs that have ever been permitted (complete historical record, contains unpermitted apps too)
EnumerableSet.UintSet allPermittedApps;
```

- Adds `getAllAppsForPkps` to `VincentUserViewFacet` which returns:
    - Pagination is tracked separately for `permittedApps` and `historicalAppIds`, so and offset of `0` will return up to `50` (that's our hardcoded page size) permitted Apps and historical App IDs

```
[
    {
        pkpTokenId: uint256,
        permittedApps: [
            {
                appId: uint40,
                version: uint24,
                versionEnabled: bool
            }
        ],
        historicalAppIds: uint40[]
    }
]
```

Rationale behind this return value: Instead of the frontend having to do:

> To find all the unpermitted apps: We will need to iterate through all the [AgentPKP](https://github.com/LIT-Protocol/Vincent/blob/1a88677a1d1ac0a4829e4a62da7363b053dbd8c7/packages/libs/contracts-sdk/contracts/LibVincentDiamondStorage.sol#L83C42-L83C71) for a UserPKP (log in method) and comparing the allApps mapping against the [permittedApps](https://github.com/LIT-Protocol/Vincent/blob/1a88677a1d1ac0a4829e4a62da7363b053dbd8c7/packages/libs/contracts-sdk/contracts/LibVincentDiamondStorage.sol#L71) to find all the unpermitted apps

a single RPC call to this method will return the Agent PKP's permitted Apps, and the unpermitted Apps separately

- Adds App ID to `VincentUserStorage.AgentStorage.allPermittedApps` when permitting App version
- When unpermitting an App version, the App ID is added to `VincentUserStorage.AgentStorage.allPermittedApps` to account for all existing Apps that have been permitted before these contract changes

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- Add assertions for `getAllAppsForPkps` to existing test cases

# Checklist:

- [ ] I created a [release plan](https://nx.dev/recipes/nx-release/file-based-versioning-version-plans) (`nx release plan`) describing my changes and the version bump
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
