### PR TITLE
DREL-947 & 935 UnPermittedApps

### DIFF
--- a/packages/libs/contracts-sdk/abis/VincentUserFacet.abi.json
+++ b/packages/libs/contracts-sdk/abis/VincentUserFacet.abi.json
@@ -39,6 +39,24 @@
   },
   {
     "type": "function",
+    "name": "rePermitApp",
+    "inputs": [
+      {
+        "name": "pkpTokenId",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "appId",
+        "type": "uint40",
+        "internalType": "uint40"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
     "name": "setAbilityPolicyParameters",
     "inputs": [
       {
@@ -144,6 +162,31 @@
   {
     "type": "event",
     "name": "AppVersionPermitted",
+    "inputs": [
+      {
+        "name": "pkpTokenId",
+        "type": "uint256",
+        "indexed": true,
+        "internalType": "uint256"
+      },
+      {
+        "name": "appId",
+        "type": "uint40",
+        "indexed": true,
+        "internalType": "uint40"
+      },
+      {
+        "name": "appVersion",
+        "type": "uint24",
+        "indexed": true,
+        "internalType": "uint24"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "AppVersionRePermitted",
     "inputs": [
       {
         "name": "pkpTokenId",
@@ -275,6 +318,27 @@
   },
   {
     "type": "error",
+    "name": "AppNeverPermitted",
+    "inputs": [
+      {
+        "name": "pkpTokenId",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "appId",
+        "type": "uint40",
+        "internalType": "uint40"
+      },
+      {
+        "name": "appVersion",
+        "type": "uint24",
+        "internalType": "uint24"
+      }
+    ]
+  },
+  {
+    "type": "error",
     "name": "AppNotRegistered",
     "inputs": [
       {
@@ -293,6 +357,22 @@
         "type": "uint256",
         "internalType": "uint256"
       },
+      {
+        "name": "appId",
+        "type": "uint40",
+        "internalType": "uint40"
+      },
+      {
+        "name": "appVersion",
+        "type": "uint24",
+        "internalType": "uint24"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "AppVersionNotEnabled",
+    "inputs": [
       {
         "name": "appId",
         "type": "uint40",

--- a/packages/libs/contracts-sdk/abis/VincentUserViewFacet.abi.json
+++ b/packages/libs/contracts-sdk/abis/VincentUserViewFacet.abi.json
@@ -110,7 +110,7 @@
   },
   {
     "type": "function",
-    "name": "getLastPermittedAppVersion",
+    "name": "getLastPermittedAppVersionForPkp",
     "inputs": [
       {
         "name": "pkpTokenId",

--- a/packages/libs/contracts-sdk/abis/VincentUserViewFacet.abi.json
+++ b/packages/libs/contracts-sdk/abis/VincentUserViewFacet.abi.json
@@ -110,6 +110,30 @@
   },
   {
     "type": "function",
+    "name": "getLastPermittedAppVersion",
+    "inputs": [
+      {
+        "name": "pkpTokenId",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "appId",
+        "type": "uint40",
+        "internalType": "uint40"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint24",
+        "internalType": "uint24"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
     "name": "getPermittedAppVersionForPkp",
     "inputs": [
       {
@@ -175,6 +199,59 @@
               },
               {
                 "name": "version",
+                "type": "uint24",
+                "internalType": "uint24"
+              },
+              {
+                "name": "versionEnabled",
+                "type": "bool",
+                "internalType": "bool"
+              }
+            ]
+          }
+        ]
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getUnpermittedAppsForPkps",
+    "inputs": [
+      {
+        "name": "pkpTokenIds",
+        "type": "uint256[]",
+        "internalType": "uint256[]"
+      },
+      {
+        "name": "offset",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "results",
+        "type": "tuple[]",
+        "internalType": "struct VincentUserViewFacet.PkpUnpermittedApps[]",
+        "components": [
+          {
+            "name": "pkpTokenId",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "unpermittedApps",
+            "type": "tuple[]",
+            "internalType": "struct VincentUserViewFacet.UnpermittedApp[]",
+            "components": [
+              {
+                "name": "appId",
+                "type": "uint40",
+                "internalType": "uint40"
+              },
+              {
+                "name": "previousPermittedVersion",
                 "type": "uint24",
                 "internalType": "uint24"
               },

--- a/packages/libs/contracts-sdk/contracts/LibVincentDiamondStorage.sol
+++ b/packages/libs/contracts-sdk/contracts/LibVincentDiamondStorage.sol
@@ -73,6 +73,10 @@ library VincentUserStorage {
         mapping(uint40 => uint24) permittedAppVersion;
         // App ID -> App version -> Ability IPFS CID hash -> Ability Policy storage -> Ability Policy IPFS CID hash -> User's CBOR2 encoded Policy parameter values
         mapping(uint40 => mapping(uint24 => mapping(bytes32 => mapping(bytes32 => bytes)))) abilityPolicyParameterValues;
+        // Set of all App IDs that have ever been permitted (complete historical record, contains unpermitted apps too)
+        EnumerableSet.UintSet allPermittedApps;
+        // App ID -> Last Permitted App Version (for re-permitting unpermitted apps)
+        mapping(uint40 => uint24) lastPermitted;
     }
 
     struct UserStorage {

--- a/packages/libs/contracts-sdk/contracts/LibVincentDiamondStorage.sol
+++ b/packages/libs/contracts-sdk/contracts/LibVincentDiamondStorage.sol
@@ -76,7 +76,7 @@ library VincentUserStorage {
         // Set of all App IDs that have ever been permitted (complete historical record, contains unpermitted apps too)
         EnumerableSet.UintSet allPermittedApps;
         // App ID -> Last Permitted App Version (for re-permitting unpermitted apps)
-        mapping(uint40 => uint24) lastPermitted;
+        mapping(uint40 => uint24) lastPermittedVersion;
     }
 
     struct UserStorage {

--- a/packages/libs/contracts-sdk/contracts/VincentDiamond.sol
+++ b/packages/libs/contracts-sdk/contracts/VincentDiamond.sol
@@ -222,7 +222,7 @@ contract VincentDiamond {
         selectors[3] = VincentUserViewFacet.validateAbilityExecutionAndGetPolicies.selector;
         selectors[4] = VincentUserViewFacet.getAllAbilitiesAndPoliciesForApp.selector;
         selectors[5] = VincentUserViewFacet.getPermittedAppsForPkps.selector;
-        selectors[6] = VincentUserViewFacet.getLastPermittedAppVersion.selector;
+        selectors[6] = VincentUserViewFacet.getLastPermittedAppVersionForPkp.selector;
         selectors[7] = VincentUserViewFacet.getUnpermittedAppsForPkps.selector;
         selectors[8] = bytes4(keccak256("AGENT_PAGE_SIZE()"));
         return selectors;

--- a/packages/libs/contracts-sdk/contracts/VincentDiamond.sol
+++ b/packages/libs/contracts-sdk/contracts/VincentDiamond.sol
@@ -206,22 +206,25 @@ contract VincentDiamond {
     }
 
     function getVincentUserFacetSelectors() internal pure returns (bytes4[] memory) {
-        bytes4[] memory selectors = new bytes4[](3);
+        bytes4[] memory selectors = new bytes4[](4);
         selectors[0] = VincentUserFacet.permitAppVersion.selector;
         selectors[1] = VincentUserFacet.unPermitAppVersion.selector;
         selectors[2] = VincentUserFacet.setAbilityPolicyParameters.selector;
+        selectors[3] = VincentUserFacet.rePermitApp.selector;
         return selectors;
     }
 
     function getVincentUserViewFacetSelectors() internal pure returns (bytes4[] memory) {
-        bytes4[] memory selectors = new bytes4[](7);
+        bytes4[] memory selectors = new bytes4[](9);
         selectors[0] = VincentUserViewFacet.getAllRegisteredAgentPkps.selector;
         selectors[1] = VincentUserViewFacet.getPermittedAppVersionForPkp.selector;
         selectors[2] = VincentUserViewFacet.getAllPermittedAppIdsForPkp.selector;
         selectors[3] = VincentUserViewFacet.validateAbilityExecutionAndGetPolicies.selector;
         selectors[4] = VincentUserViewFacet.getAllAbilitiesAndPoliciesForApp.selector;
         selectors[5] = VincentUserViewFacet.getPermittedAppsForPkps.selector;
-        selectors[6] = bytes4(keccak256("AGENT_PAGE_SIZE()"));
+        selectors[6] = VincentUserViewFacet.getLastPermittedAppVersion.selector;
+        selectors[7] = VincentUserViewFacet.getUnpermittedAppsForPkps.selector;
+        selectors[8] = bytes4(keccak256("AGENT_PAGE_SIZE()"));
         return selectors;
     }
 

--- a/packages/libs/contracts-sdk/contracts/facets/VincentUserFacet.sol
+++ b/packages/libs/contracts-sdk/contracts/facets/VincentUserFacet.sol
@@ -121,7 +121,7 @@ contract VincentUserFacet is VincentBase {
         agentStorage.permittedAppVersion[appId] = appVersion;
         
         // Store this version as the last permitted version for potential re-permitting
-        agentStorage.lastPermitted[appId] = appVersion;
+        agentStorage.lastPermittedVersion[appId] = appVersion;
 
         // Add pkpTokenId to the User's registered agent PKPs
         // .add will not add the PKP Token ID again if it is already registered
@@ -164,7 +164,7 @@ contract VincentUserFacet is VincentBase {
 
         // Store the version as last permitted before removing (for potential re-permitting)
         // Note: We already verified this version is currently permitted at line 155-157
-        us_.agentPkpTokenIdToAgentStorage[pkpTokenId].lastPermitted[appId] = appVersion;
+        us_.agentPkpTokenIdToAgentStorage[pkpTokenId].lastPermittedVersion[appId] = appVersion;
 
         // Remove the App Version from the User's Permitted App Versions
         us_.agentPkpTokenIdToAgentStorage[pkpTokenId].permittedAppVersion[appId] = 0;
@@ -209,8 +209,8 @@ contract VincentUserFacet is VincentBase {
         // Get the last permitted version
         // Note: lastPermittedVersion should never be 0 here because:
         // - If app is currently permitted, we already reverted above
-        // - If app was unpermitted, unPermitAppVersion sets lastPermitted
-        uint24 lastPermittedVersion = agentStorage.lastPermitted[appId];
+        // - If app was unpermitted, unPermitAppVersion sets lastPermittedVersion
+        uint24 lastPermittedVersion = agentStorage.lastPermittedVersion[appId];
         
         // Check if the last permitted version is still enabled
         VincentAppStorage.AppStorage storage as_ = VincentAppStorage.appStorage();

--- a/packages/libs/contracts-sdk/contracts/facets/VincentUserFacet.sol
+++ b/packages/libs/contracts-sdk/contracts/facets/VincentUserFacet.sol
@@ -163,7 +163,7 @@ contract VincentUserFacet is VincentBase {
             .remove(pkpTokenId);
 
         // Store the version as last permitted before removing (for potential re-permitting)
-        // Note: We already verified this version is currently permitted at line 155-157
+        // This handles existing permitted Apps before the lastPermittedVersion tracking was added
         us_.agentPkpTokenIdToAgentStorage[pkpTokenId].lastPermittedVersion[appId] = appVersion;
 
         // Remove the App Version from the User's Permitted App Versions

--- a/packages/libs/contracts-sdk/contracts/facets/VincentUserFacet.sol
+++ b/packages/libs/contracts-sdk/contracts/facets/VincentUserFacet.sol
@@ -113,8 +113,15 @@ contract VincentUserFacet is VincentBase {
         // .add will not add the app ID again if it is already registered
         agentStorage.permittedApps.add(appId);
 
+        // Add the app ID to the User's historical permitted apps set (never removed)
+        // .add will not add the app ID again if it is already registered
+        agentStorage.allPermittedApps.add(appId);
+
         // Set the new permitted app version
         agentStorage.permittedAppVersion[appId] = appVersion;
+        
+        // Store this version as the last permitted version for potential re-permitting
+        agentStorage.lastPermitted[appId] = appVersion;
 
         // Add pkpTokenId to the User's registered agent PKPs
         // .add will not add the PKP Token ID again if it is already registered
@@ -155,13 +162,71 @@ contract VincentUserFacet is VincentBase {
             .delegatedAgentPkps
             .remove(pkpTokenId);
 
+        // Store the version as last permitted before removing (for potential re-permitting)
+        // Note: We already verified this version is currently permitted at line 155-157
+        us_.agentPkpTokenIdToAgentStorage[pkpTokenId].lastPermitted[appId] = appVersion;
+
         // Remove the App Version from the User's Permitted App Versions
         us_.agentPkpTokenIdToAgentStorage[pkpTokenId].permittedAppVersion[appId] = 0;
 
         // Remove the app from the User's permitted apps set
         us_.agentPkpTokenIdToAgentStorage[pkpTokenId].permittedApps.remove(appId);
 
+        // Add the App ID to the User's historical permitted apps set
+        // This ensures apps permitted before the allPermittedApps tracking was added are captured
+        us_.agentPkpTokenIdToAgentStorage[pkpTokenId].allPermittedApps.add(appId);
+
         emit LibVincentUserFacet.AppVersionUnPermitted(pkpTokenId, appId, appVersion);
+    }
+
+    /**
+     * @notice Re-permits a previously unpermitted app with its last permitted version
+     * @dev This function allows a PKP owner to quickly re-authorize an app that was previously unpermitted,
+     *      using the last version that was permitted. The app must have been previously permitted
+     *      (exists in allPermittedApps) and the last permitted version must still be enabled.
+     *
+     * @param pkpTokenId The token ID of the PKP to re-permit the app for
+     * @param appId The ID of the app to re-permit
+     */
+    function rePermitApp(uint256 pkpTokenId, uint40 appId)
+        external
+        appNotDeleted(appId)
+        onlyPkpOwner(pkpTokenId)
+    {
+        VincentUserStorage.UserStorage storage us_ = VincentUserStorage.userStorage();
+        VincentUserStorage.AgentStorage storage agentStorage = us_.agentPkpTokenIdToAgentStorage[pkpTokenId];
+        
+        // Check if app is currently permitted
+        if (agentStorage.permittedApps.contains(appId)) {
+            revert LibVincentUserFacet.AppVersionAlreadyPermitted(pkpTokenId, appId, agentStorage.permittedAppVersion[appId]);
+        }
+        
+        // Check if app was ever permitted (exists in allPermittedApps)
+        if (!agentStorage.allPermittedApps.contains(appId)) {
+            revert LibVincentUserFacet.AppNeverPermitted(pkpTokenId, appId, 0);
+        }
+        
+        // Get the last permitted version
+        // Note: lastPermittedVersion should never be 0 here because:
+        // - If app is currently permitted, we already reverted above
+        // - If app was unpermitted, unPermitAppVersion sets lastPermitted
+        uint24 lastPermittedVersion = agentStorage.lastPermitted[appId];
+        
+        // Check if the last permitted version is still enabled
+        VincentAppStorage.AppStorage storage as_ = VincentAppStorage.appStorage();
+        VincentAppStorage.AppVersion storage appVersion =
+            as_.appIdToApp[appId].appVersions[getAppVersionIndex(lastPermittedVersion)];
+            
+        if (!appVersion.enabled) {
+            revert LibVincentUserFacet.AppVersionNotEnabled(appId, lastPermittedVersion);
+        }
+        
+        // Re-permit the app with the last permitted version
+        appVersion.delegatedAgentPkps.add(pkpTokenId);
+        agentStorage.permittedApps.add(appId);
+        agentStorage.permittedAppVersion[appId] = lastPermittedVersion;
+        
+        emit LibVincentUserFacet.AppVersionRePermitted(pkpTokenId, appId, lastPermittedVersion);
     }
 
     /**

--- a/packages/libs/contracts-sdk/contracts/facets/VincentUserViewFacet.sol
+++ b/packages/libs/contracts-sdk/contracts/facets/VincentUserViewFacet.sol
@@ -506,7 +506,7 @@ contract VincentUserViewFacet is VincentBase {
         }
 
         VincentUserStorage.UserStorage storage us_ = VincentUserStorage.userStorage();
-        return us_.agentPkpTokenIdToAgentStorage[pkpTokenId].lastPermitted[appId];
+        return us_.agentPkpTokenIdToAgentStorage[pkpTokenId].lastPermittedVersion[appId];
     }
 
     /**
@@ -589,7 +589,7 @@ contract VincentUserViewFacet is VincentBase {
             uint40 appId = uint40(agentStorage.allPermittedApps.at(j));
             if (!agentStorage.permittedApps.contains(appId) && !as_.appIdToApp[appId].isDeleted) {
                 if (currentIndex >= offset) {
-                    uint24 lastPermittedVersion = agentStorage.lastPermitted[appId];
+                    uint24 lastPermittedVersion = agentStorage.lastPermittedVersion[appId];
                     bool enabled = lastPermittedVersion > 0 ? 
                         as_.appIdToApp[appId].appVersions[getAppVersionIndex(lastPermittedVersion)].enabled : false;
                     

--- a/packages/libs/contracts-sdk/contracts/facets/VincentUserViewFacet.sol
+++ b/packages/libs/contracts-sdk/contracts/facets/VincentUserViewFacet.sol
@@ -202,6 +202,31 @@ contract VincentUserViewFacet is VincentBase {
     }
 
     /**
+     * @notice Gets the last permitted app version for a specific app and PKP token
+     * @dev Returns the last version that was permitted before unpermitting, or 0 if never permitted
+     * @param pkpTokenId The PKP token ID
+     * @param appId The app ID
+     * @return The last permitted app version
+     */
+    function getLastPermittedAppVersionForPkp(uint256 pkpTokenId, uint40 appId)
+        external
+        view
+        returns (uint24)
+    {
+        // Check for invalid PKP token ID and app ID
+        if (pkpTokenId == 0) {
+            revert InvalidPkpTokenId();
+        }
+
+        if (appId == 0) {
+            revert InvalidAppId();
+        }
+
+        VincentUserStorage.UserStorage storage us_ = VincentUserStorage.userStorage();
+        return us_.agentPkpTokenIdToAgentStorage[pkpTokenId].lastPermittedVersion[appId];
+    }
+
+    /**
      * @notice DEPRECATED: Use {getPermittedAppsForPkps} instead. This function will be removed in future releases.
      * @dev Gets all app IDs that have permissions for a specific PKP token, excluding deleted apps, with pagination support.
      * @dev Migration guidance: Replace calls to this function with {getPermittedAppsForPkps}, which returns both app IDs and their permitted versions for a PKP token. Update your code to handle the new return type and logic as needed.
@@ -482,31 +507,6 @@ contract VincentUserViewFacet is VincentBase {
         }
 
         return validation;
-    }
-
-    /**
-     * @notice Gets the last permitted app version for a specific app and PKP token
-     * @dev Returns the last version that was permitted before unpermitting, or 0 if never permitted
-     * @param pkpTokenId The PKP token ID
-     * @param appId The app ID
-     * @return The last permitted app version
-     */
-    function getLastPermittedAppVersion(uint256 pkpTokenId, uint40 appId)
-        external
-        view
-        returns (uint24)
-    {
-        // Check for invalid PKP token ID and app ID
-        if (pkpTokenId == 0) {
-            revert InvalidPkpTokenId();
-        }
-
-        if (appId == 0) {
-            revert InvalidAppId();
-        }
-
-        VincentUserStorage.UserStorage storage us_ = VincentUserStorage.userStorage();
-        return us_.agentPkpTokenIdToAgentStorage[pkpTokenId].lastPermittedVersion[appId];
     }
 
     /**

--- a/packages/libs/contracts-sdk/contracts/libs/LibVincentUserFacet.sol
+++ b/packages/libs/contracts-sdk/contracts/libs/LibVincentUserFacet.sol
@@ -30,6 +30,14 @@ library LibVincentUserFacet {
     event AppVersionUnPermitted(uint256 indexed pkpTokenId, uint40 indexed appId, uint24 indexed appVersion);
 
     /**
+     * @notice Emitted when an app version is re-permitted for a PKP
+     * @param pkpTokenId The token ID of the PKP
+     * @param appId The ID of the app being re-permitted
+     * @param appVersion The version number of the app being re-permitted
+     */
+    event AppVersionRePermitted(uint256 indexed pkpTokenId, uint40 indexed appId, uint24 indexed appVersion);
+
+    /**
      * @notice Emitted when an ability policy parameters are set
      * @param pkpTokenId The token ID of the PKP
      * @param appId The ID of the app
@@ -184,4 +192,19 @@ library LibVincentUserFacet {
      * @param appVersion The version of the app
      */
     error NotAllRegisteredAbilitiesProvided(uint40 appId, uint24 appVersion);
+
+    /**
+     * @notice Error thrown when an app version is not registered
+     * @param appId The ID of the app
+     * @param appVersion The version of the app
+     */
+    error AppVersionNotRegistered(uint40 appId, uint24 appVersion);
+
+    /**
+     * @notice Error thrown when an app has never been permitted for a PKP
+     * @param pkpTokenId The token ID of the PKP
+     * @param appId The ID of the app
+     * @param appVersion The version of the app
+     */
+    error AppNeverPermitted(uint256 pkpTokenId, uint40 appId, uint24 appVersion);
 }

--- a/packages/libs/contracts-sdk/contracts/libs/LibVincentUserFacet.sol
+++ b/packages/libs/contracts-sdk/contracts/libs/LibVincentUserFacet.sol
@@ -194,14 +194,7 @@ library LibVincentUserFacet {
     error NotAllRegisteredAbilitiesProvided(uint40 appId, uint24 appVersion);
 
     /**
-     * @notice Error thrown when an app version is not registered
-     * @param appId The ID of the app
-     * @param appVersion The version of the app
-     */
-    error AppVersionNotRegistered(uint40 appId, uint24 appVersion);
-
-    /**
-     * @notice Error thrown when an app has never been permitted for a PKP
+     * @notice Error thrown when an app has never been permitted for a PKP, but the user is trying to re-permit it
      * @param pkpTokenId The token ID of the PKP
      * @param appId The ID of the app
      * @param appVersion The version of the app

--- a/packages/libs/contracts-sdk/src/contractClient.ts
+++ b/packages/libs/contracts-sdk/src/contractClient.ts
@@ -37,7 +37,7 @@ import {
   getAllAbilitiesAndPoliciesForApp as _getAllAbilitiesAndPoliciesForApp,
   validateAbilityExecutionAndGetPolicies as _validateAbilityExecutionAndGetPolicies,
   getPermittedAppsForPkps as _getPermittedAppsForPkps,
-  getLastPermittedAppVersion as _getLastPermittedAppVersion,
+  getLastPermittedAppVersionForPkp as _getLastPermittedAppVersionForPkp,
   getUnpermittedAppsForPkps as _getUnpermittedAppsForPkps,
 } from './internal/user/UserView';
 import { createContract } from './utils';
@@ -91,7 +91,8 @@ export function clientFromContract({ contract }: { contract: Contract }): Contra
       _getAllAbilitiesAndPoliciesForApp({ contract, args: params }),
     validateAbilityExecutionAndGetPolicies: (params) =>
       _validateAbilityExecutionAndGetPolicies({ contract, args: params }),
-    getLastPermittedAppVersion: (params) => _getLastPermittedAppVersion({ contract, args: params }),
+    getLastPermittedAppVersionForPkp: (params) =>
+      _getLastPermittedAppVersionForPkp({ contract, args: params }),
     getUnpermittedAppsForPkps: (params) => _getUnpermittedAppsForPkps({ contract, args: params }),
   };
 }

--- a/packages/libs/contracts-sdk/src/contractClient.ts
+++ b/packages/libs/contracts-sdk/src/contractClient.ts
@@ -27,6 +27,7 @@ import {
 import {
   permitApp as _permitApp,
   unPermitApp as _unPermitApp,
+  rePermitApp as _rePermitApp,
   setAbilityPolicyParameters as _setAbilityPolicyParameters,
 } from './internal/user/User';
 import {
@@ -36,6 +37,8 @@ import {
   getAllAbilitiesAndPoliciesForApp as _getAllAbilitiesAndPoliciesForApp,
   validateAbilityExecutionAndGetPolicies as _validateAbilityExecutionAndGetPolicies,
   getPermittedAppsForPkps as _getPermittedAppsForPkps,
+  getLastPermittedAppVersion as _getLastPermittedAppVersion,
+  getUnpermittedAppsForPkps as _getUnpermittedAppsForPkps,
 } from './internal/user/UserView';
 import { createContract } from './utils';
 
@@ -72,6 +75,7 @@ export function clientFromContract({ contract }: { contract: Contract }): Contra
     // User write methods
     permitApp: (params, overrides) => _permitApp({ contract, args: params, overrides }),
     unPermitApp: (params, overrides) => _unPermitApp({ contract, args: params, overrides }),
+    rePermitApp: (params, overrides) => _rePermitApp({ contract, args: params, overrides }),
     setAbilityPolicyParameters: (params, overrides) =>
       _setAbilityPolicyParameters({ contract, args: params, overrides }),
 
@@ -87,6 +91,8 @@ export function clientFromContract({ contract }: { contract: Contract }): Contra
       _getAllAbilitiesAndPoliciesForApp({ contract, args: params }),
     validateAbilityExecutionAndGetPolicies: (params) =>
       _validateAbilityExecutionAndGetPolicies({ contract, args: params }),
+    getLastPermittedAppVersion: (params) => _getLastPermittedAppVersion({ contract, args: params }),
+    getUnpermittedAppsForPkps: (params) => _getUnpermittedAppsForPkps({ contract, args: params }),
   };
 }
 

--- a/packages/libs/contracts-sdk/src/index.ts
+++ b/packages/libs/contracts-sdk/src/index.ts
@@ -15,11 +15,15 @@ export type {
   GetDelegatedPkpEthAddressesParams,
   GetAllAbilitiesAndPoliciesForAppParams,
   GetAllPermittedAppIdsForPkpParams,
+  GetLastPermittedAppVersionParams,
   GetPermittedAppVersionForPkpParams,
+  GetPermittedAppsForPkpsParams,
+  GetUnpermittedAppsForPkpsParams,
   GetAllRegisteredAgentPkpsParams,
   SetAbilityPolicyParametersParams,
   UnPermitAppParams,
   PermitAppParams,
+  RePermitAppParams,
   AbilityPolicyParameterData,
   Ability,
   App,
@@ -28,6 +32,10 @@ export type {
   ValidateAbilityExecutionAndGetPoliciesResult,
   PermissionData,
   AppVersion,
+  PermittedApp,
+  PkpPermittedApps,
+  UnpermittedApp,
+  PkpUnpermittedApps,
 } from './types';
 
 export { getTestClient, clientFromContract, getClient } from './contractClient';

--- a/packages/libs/contracts-sdk/src/internal/user/User.ts
+++ b/packages/libs/contracts-sdk/src/internal/user/User.ts
@@ -1,6 +1,7 @@
 import type {
   PermitAppOptions,
   UnPermitAppOptions,
+  RePermitAppOptions,
   SetAbilityPolicyParametersOptions,
 } from './types';
 
@@ -82,6 +83,37 @@ export async function unPermitApp({
   } catch (error: unknown) {
     const decodedError = decodeContractError(error, contract);
     throw new Error(`Failed to UnPermit App: ${decodedError}`);
+  }
+}
+
+export async function rePermitApp(params: RePermitAppOptions): Promise<{ txHash: string }> {
+  const {
+    contract,
+    args: { pkpEthAddress, appId },
+    overrides,
+  } = params;
+
+  try {
+    const pkpTokenId = await getPkpTokenId({ pkpEthAddress, signer: contract.signer });
+
+    const adjustedOverrides = await gasAdjustedOverrides(
+      contract,
+      'rePermitApp',
+      [pkpTokenId, appId],
+      overrides,
+    );
+
+    const tx = await contract.rePermitApp(pkpTokenId, appId, {
+      ...adjustedOverrides,
+    });
+    await tx.wait();
+
+    return {
+      txHash: tx.hash,
+    };
+  } catch (error: unknown) {
+    const decodedError = decodeContractError(error, contract);
+    throw new Error(`Failed to Re-Permit App: ${decodedError}`);
   }
 }
 

--- a/packages/libs/contracts-sdk/src/internal/user/UserView.ts
+++ b/packages/libs/contracts-sdk/src/internal/user/UserView.ts
@@ -194,7 +194,7 @@ export async function validateAbilityExecutionAndGetPolicies(
   }
 }
 
-export async function getLastPermittedAppVersion(
+export async function getLastPermittedAppVersionForPkp(
   params: GetLastPermittedAppVersionOptions,
 ): Promise<number | null> {
   const {
@@ -205,7 +205,7 @@ export async function getLastPermittedAppVersion(
   try {
     const pkpTokenId = await getPkpTokenId({ pkpEthAddress, signer: contract.signer });
 
-    const lastPermittedVersion: number = await contract.getLastPermittedAppVersion(
+    const lastPermittedVersion: number = await contract.getLastPermittedAppVersionForPkp(
       pkpTokenId,
       appId,
     );

--- a/packages/libs/contracts-sdk/src/internal/user/types.ts
+++ b/packages/libs/contracts-sdk/src/internal/user/types.ts
@@ -4,9 +4,12 @@ import type {
   GetAllPermittedAppIdsForPkpParams,
   GetAllRegisteredAgentPkpsParams,
   GetAllAbilitiesAndPoliciesForAppParams,
+  GetLastPermittedAppVersionParams,
   GetPermittedAppVersionForPkpParams,
   GetPermittedAppsForPkpsParams,
+  GetUnpermittedAppsForPkpsParams,
   PermitAppParams,
+  RePermitAppParams,
   SetAbilityPolicyParametersParams,
   UnPermitAppParams,
   ValidateAbilityExecutionAndGetPoliciesParams,
@@ -29,6 +32,15 @@ export interface PermitAppOptions extends BaseWritableOptions {
  * */
 export interface UnPermitAppOptions extends BaseWritableOptions {
   args: UnPermitAppParams;
+}
+
+/**
+ * @category Interfaces
+ * @inline
+ * @expand
+ * */
+export interface RePermitAppOptions extends BaseWritableOptions {
+  args: RePermitAppParams;
 }
 
 /**
@@ -103,11 +115,43 @@ export interface ValidateAbilityExecutionAndGetPoliciesOptions extends BaseOptio
  * @inline
  * @expand
  * */
+export interface GetLastPermittedAppVersionOptions extends BaseOptions {
+  args: GetLastPermittedAppVersionParams;
+}
+
+/**
+ * @category Interfaces
+ * @inline
+ * @expand
+ * */
+export interface GetUnpermittedAppsForPkpsOptions extends BaseOptions {
+  args: GetUnpermittedAppsForPkpsParams;
+}
+
+/**
+ * @category Interfaces
+ * @inline
+ * @expand
+ * */
 export interface ContractPkpPermittedApps {
   pkpTokenId: BigNumber;
   permittedApps: {
     appId: number;
     version: number;
+    versionEnabled: boolean;
+  }[];
+}
+
+/**
+ * @category Interfaces
+ * @inline
+ * @expand
+ * */
+export interface ContractPkpUnpermittedApps {
+  pkpTokenId: BigNumber;
+  unpermittedApps: {
+    appId: number;
+    previousPermittedVersion: number;
     versionEnabled: boolean;
   }[];
 }

--- a/packages/libs/contracts-sdk/src/types.ts
+++ b/packages/libs/contracts-sdk/src/types.ts
@@ -28,7 +28,7 @@ import type {
   getAllPermittedAppIdsForPkp as _getAllPermittedAppIdsForPkp,
   getAllRegisteredAgentPkpEthAddresses as _getAllRegisteredAgentPkpEthAddresses,
   getAllAbilitiesAndPoliciesForApp as _getAllAbilitiesAndPoliciesForApp,
-  getLastPermittedAppVersion as _getLastPermittedAppVersion,
+  getLastPermittedAppVersionForPkp as _getLastPermittedAppVersionForPkp,
   getPermittedAppVersionForPkp as _getPermittedAppVersionForPkp,
   getPermittedAppsForPkps as _getPermittedAppsForPkps,
   getUnpermittedAppsForPkps as _getUnpermittedAppsForPkps,
@@ -535,9 +535,9 @@ export interface ContractClient {
    *
    * @returns The last permitted app version, or null if never permitted
    */
-  getLastPermittedAppVersion(
+  getLastPermittedAppVersionForPkp(
     params: GetLastPermittedAppVersionParams,
-  ): ReturnType<typeof _getLastPermittedAppVersion>;
+  ): ReturnType<typeof _getLastPermittedAppVersionForPkp>;
 
   /** Get unpermitted apps for multiple PKPs with their last permitted versions
    *

--- a/packages/libs/contracts-sdk/src/types.ts
+++ b/packages/libs/contracts-sdk/src/types.ts
@@ -20,6 +20,7 @@ import type {
 } from './internal/app/AppView';
 import type {
   permitApp as _permitApp,
+  rePermitApp as _rePermitApp,
   setAbilityPolicyParameters as _setAbilityPolicyParameters,
   unPermitApp as _unPermitApp,
 } from './internal/user/User';
@@ -27,8 +28,10 @@ import type {
   getAllPermittedAppIdsForPkp as _getAllPermittedAppIdsForPkp,
   getAllRegisteredAgentPkpEthAddresses as _getAllRegisteredAgentPkpEthAddresses,
   getAllAbilitiesAndPoliciesForApp as _getAllAbilitiesAndPoliciesForApp,
+  getLastPermittedAppVersion as _getLastPermittedAppVersion,
   getPermittedAppVersionForPkp as _getPermittedAppVersionForPkp,
   getPermittedAppsForPkps as _getPermittedAppsForPkps,
+  getUnpermittedAppsForPkps as _getUnpermittedAppsForPkps,
   validateAbilityExecutionAndGetPolicies as _validateAbilityExecutionAndGetPolicies,
 } from './internal/user/UserView';
 
@@ -233,6 +236,14 @@ export interface UnPermitAppParams {
 /**
  * @category Interfaces
  * */
+export interface RePermitAppParams {
+  pkpEthAddress: string;
+  appId: number;
+}
+
+/**
+ * @category Interfaces
+ * */
 export interface SetAbilityPolicyParametersParams {
   pkpEthAddress: string;
   appId: number;
@@ -305,6 +316,39 @@ export interface ValidateAbilityExecutionAndGetPoliciesParams {
   delegateeAddress: string;
   pkpEthAddress: string;
   abilityIpfsCid: string;
+}
+
+/**
+ * @category Interfaces
+ * */
+export interface GetLastPermittedAppVersionParams {
+  pkpEthAddress: string;
+  appId: number;
+}
+
+/**
+ * @category Interfaces
+ * */
+export interface UnpermittedApp {
+  appId: number;
+  previousPermittedVersion: number;
+  versionEnabled: boolean;
+}
+
+/**
+ * @category Interfaces
+ * */
+export interface PkpUnpermittedApps {
+  pkpTokenId: string;
+  unpermittedApps: UnpermittedApp[];
+}
+
+/**
+ * @category Interfaces
+ * */
+export interface GetUnpermittedAppsForPkpsParams {
+  pkpEthAddresses: string[];
+  offset: string;
 }
 /** @category API */
 export interface ContractClient {
@@ -480,4 +524,24 @@ export interface ContractClient {
   validateAbilityExecutionAndGetPolicies(
     params: ValidateAbilityExecutionAndGetPoliciesParams,
   ): ReturnType<typeof _validateAbilityExecutionAndGetPolicies>;
+
+  /** Re-permits an app using the last permitted version for a PKP
+   *
+   * @returns { txHash } The transaction hash that re-permitted the app
+   */
+  rePermitApp(params: RePermitAppParams, overrides?: Overrides): ReturnType<typeof _rePermitApp>;
+
+  /** Get the last permitted version for a specific app and PKP
+   *
+   * @returns The last permitted app version, or null if never permitted
+   */
+  getLastPermittedAppVersion(
+    params: GetLastPermittedAppVersionParams,
+  ): ReturnType<typeof _getLastPermittedAppVersion>;
+
+  /** Get unpermitted apps for multiple PKPs with their last permitted versions
+   *
+   * @returns Array of PkpUnpermittedApps containing unpermitted app details for each PKP
+   */
+  getUnpermittedAppsForPkps(params: GetUnpermittedAppsForPkpsParams): Promise<PkpUnpermittedApps[]>;
 }

--- a/packages/libs/contracts-sdk/test/facets/VincentUserFacet.t.sol
+++ b/packages/libs/contracts-sdk/test/facets/VincentUserFacet.t.sol
@@ -508,6 +508,16 @@ contract VincentUserFacetTest is Test {
         permittedAppVersion = vincentUserViewFacet.getPermittedAppVersionForPkp(PKP_TOKEN_ID_1, newAppId_1);
         assertEq(permittedAppVersion, newAppVersion_1, "App should be re-permitted with last version");
 
+        // Verify initial policy parameters
+        VincentUserViewFacet.AbilityWithPolicies[] memory abilitiesWithPolicies = vincentUserViewFacet.getAllAbilitiesAndPoliciesForApp(
+            PKP_TOKEN_ID_1,
+            newAppId_1
+        );
+        assertEq(abilitiesWithPolicies.length, 2);
+        assertEq(abilitiesWithPolicies[0].policies.length, 1);
+        assertEq(abilitiesWithPolicies[0].policies[0].policyParameterValues, POLICY_PARAMETER_VALUES_1);
+        assertEq(abilitiesWithPolicies[1].policies.length, 0);
+
         // Verify only App 1 is permitted again (App 2 remains unpermitted)
         permittedAppsResults = vincentUserViewFacet.getPermittedAppsForPkps(pkpTokenIds, 0, 10);
         assertEq(permittedAppsResults[0].permittedApps.length, 1, "Only App 1 should be permitted again");

--- a/packages/libs/contracts-sdk/test/facets/VincentUserFacet.t.sol
+++ b/packages/libs/contracts-sdk/test/facets/VincentUserFacet.t.sol
@@ -452,7 +452,7 @@ contract VincentUserFacetTest is Test {
         assertEq(permittedAppVersion, newAppVersion_1, "App should be re-permitted with last version");
 
         // Verify both apps are now permitted
-        permittedAppsResults = vincentUserViewFacet.getPermittedAppsForPkps(pkpTokenIds, 0);
+        permittedAppsResults = vincentUserViewFacet.getPermittedAppsForPkps(pkpTokenIds, 0, 10);
         assertEq(permittedAppsResults[0].permittedApps.length, 2, "Both apps should be permitted again");
 
         // Verify no apps are unpermitted now

--- a/packages/libs/contracts-sdk/test/facets/VincentUserFacet.t.sol
+++ b/packages/libs/contracts-sdk/test/facets/VincentUserFacet.t.sol
@@ -427,8 +427,8 @@ contract VincentUserFacetTest is Test {
         assertEq(permittedAppsResults[0].permittedApps[0].version, newAppVersion_2);
         assertTrue(permittedAppsResults[0].permittedApps[0].versionEnabled);
 
-        // Test getLastPermittedAppVersion for unpermitted app
-        uint24 lastPermittedVersion = vincentUserViewFacet.getLastPermittedAppVersion(PKP_TOKEN_ID_1, newAppId_1);
+        // Test getLastPermittedAppVersionForPkp for unpermitted app
+        uint24 lastPermittedVersion = vincentUserViewFacet.getLastPermittedAppVersionForPkp(PKP_TOKEN_ID_1, newAppId_1);
         assertEq(lastPermittedVersion, newAppVersion_1, "Last permitted version should be stored");
 
         // Test getUnpermittedAppsForPkps should show the unpermitted app

--- a/packages/libs/contracts-sdk/test/sdk.spec.ts
+++ b/packages/libs/contracts-sdk/test/sdk.spec.ts
@@ -283,6 +283,47 @@ describe('Vincent Contracts SDK E2E', () => {
       const testApp = result[0].permittedApps.find((app) => app.appId === TEST_CONFIG.appId);
       expect(testApp).toBeUndefined();
     });
+
+    it('should get unpermitted apps for PKPs', async () => {
+      const result = await USER_CLIENT.getUnpermittedAppsForPkps({
+        pkpEthAddresses: [TEST_CONFIG.userPkp!.ethAddress!],
+        offset: '0',
+      });
+      expect(result).toHaveLength(1);
+      expect(result[0].pkpTokenId).toBe(TEST_CONFIG.userPkp!.tokenId);
+      expect(result[0]).toHaveProperty('unpermittedApps');
+      expect(result[0].unpermittedApps.length).toBeGreaterThan(0);
+
+      // Find our test app in the unpermitted apps
+      const testApp = result[0].unpermittedApps.find((app) => app.appId === TEST_CONFIG.appId);
+      expect(testApp).toBeDefined();
+      expect(testApp!.previousPermittedVersion).toBe(TEST_CONFIG.appVersion);
+      expect(testApp!.versionEnabled).toBe(true);
+    });
+
+    it('should get last permitted app version', async () => {
+      const lastPermittedVersion = await USER_CLIENT.getLastPermittedAppVersion({
+        pkpEthAddress: TEST_CONFIG.userPkp!.ethAddress!,
+        appId: TEST_CONFIG.appId!,
+      });
+      expect(lastPermittedVersion).toBe(TEST_CONFIG.appVersion);
+    });
+
+    it('should re-permit app using last permitted version', async () => {
+      // Re-permit using the new function
+      const rePermitResult = await USER_CLIENT.rePermitApp({
+        pkpEthAddress: TEST_CONFIG.userPkp!.ethAddress!,
+        appId: TEST_CONFIG.appId!,
+      });
+      expect(rePermitResult).toHaveProperty('txHash');
+
+      // Verify app is permitted again
+      const permittedVersion = await USER_CLIENT.getPermittedAppVersionForPkp({
+        pkpEthAddress: TEST_CONFIG.userPkp!.ethAddress!,
+        appId: TEST_CONFIG.appId!,
+      });
+      expect(permittedVersion).toBe(TEST_CONFIG.appVersion);
+    });
   });
 
   describe('App Lifecycle', () => {

--- a/packages/libs/contracts-sdk/test/sdk.spec.ts
+++ b/packages/libs/contracts-sdk/test/sdk.spec.ts
@@ -201,10 +201,13 @@ describe('Vincent Contracts SDK E2E', () => {
       expect(result[0].pkpTokenId).toBe(TEST_CONFIG.userPkp!.tokenId);
 
       expect(result[0]).toHaveProperty('permittedApps');
-      expect(result[0].permittedApps).toHaveLength(1);
-      expect(result[0].permittedApps[0].appId).toBe(TEST_CONFIG.appId);
-      expect(result[0].permittedApps[0].version).toBe(TEST_CONFIG.appVersion);
-      expect(result[0].permittedApps[0].versionEnabled).toBe(true);
+      expect(result[0].permittedApps.length).toBeGreaterThan(0);
+
+      // Find our test app in the permitted apps
+      const testApp = result[0].permittedApps.find((app) => app.appId === TEST_CONFIG.appId);
+      expect(testApp).toBeDefined();
+      expect(testApp!.version).toBe(TEST_CONFIG.appVersion);
+      expect(testApp!.versionEnabled).toBe(true);
     });
 
     it('should get all registered agent PKPs', async () => {
@@ -302,7 +305,7 @@ describe('Vincent Contracts SDK E2E', () => {
     });
 
     it('should get last permitted app version', async () => {
-      const lastPermittedVersion = await USER_CLIENT.getLastPermittedAppVersion({
+      const lastPermittedVersion = await USER_CLIENT.getLastPermittedAppVersionForPkp({
         pkpEthAddress: TEST_CONFIG.userPkp!.ethAddress!,
         appId: TEST_CONFIG.appId!,
       });


### PR DESCRIPTION
# Description

**DEPENDS ON #298 SO IT MUST BE MERGED FIRST**

- Adds to `VincentUserStorage.AgentStorage`:

```solidity
// Set of all App IDs that have ever been permitted (complete historical record, contains unpermitted apps too)
EnumerableSet.UintSet allPermittedApps;

// App ID -> Last Permitted App Version (for re-permitting unpermitted apps)
mapping(uint40 => uint24) lastPermitted;
```

- Updates `permitAppVersion` to:
    - Add the App ID to `agentStorage.allPermittedApps`, so that every permitted App after the contract upgrade is tracked in `agentStorage.allPermittedApps`
    - Set `agentStorage.lastPermittedVersion[appId]` to the App version being permitted, keeping `lastPermittedVersion` up to date 
- Updates `unPermitAppVersion` to:
    - Set `us_.agentPkpTokenIdToAgentStorage[pkpTokenId].lastPermittedVersion[appId]` to the version being unpermitted, this tracks the version for any App that was permitted before the contract upgrade (**however **`lastPermittedVersion` will be `0` for all Apps permitted before the contract upgrade that stay permitted)
    - Adds `us_.agentPkpTokenIdToAgentStorage[pkpTokenId].allPermittedApps.add(appId);` to account for Apps permitted before the contract upgrade (post upgrade, `allPermittedApps` will contain all App IDs since we add to this during `permitAppVersion`, however Apps permitted before the upgrade will only have the App IDs in `VincentUserStorage.AgentStorage.permittedApps`)
- Adds `rePermitApp(uint256 pkpTokenId, uint40 appId)` which will only permit the `lastPermittedVersion` if it's still enabled, and another App version is currently permitted
- Adds `getLastPermittedAppVersionForPkp`
- Adds `getUnpermittedAppsForPkps` which gets paginated unpermitted Apps for an array of PKP token IDs
- Updates the contracts-sdk to have the above new methods
- Updates both the forge contract tests, and the new contracts-sdk E2E test introduce in #299 

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- Assertions added to existing forge tests for contract updates
- New test cases added to contracts-sdk E2E test

# Checklist:

- [ ] I created a [release plan](https://nx.dev/recipes/nx-release/file-based-versioning-version-plans) (`nx release plan`) describing my changes and the version bump
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
