### PR TITLE
feat(dashboard): unpermitted PKP detection + reuse

### DIFF
--- a/packages/apps/app-dashboard/src/components/user-dashboard/connect/AppUnavailableConnect.tsx
+++ b/packages/apps/app-dashboard/src/components/user-dashboard/connect/AppUnavailableConnect.tsx
@@ -1,0 +1,119 @@
+import { useCallback } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { ArrowRight } from 'lucide-react';
+import { ReadAuthInfo } from '@/hooks/user-dashboard/useAuthInfo';
+import { ConnectPageHeader } from './ui/ConnectPageHeader';
+import { ConnectAppHeader } from './ui/ConnectAppHeader';
+import { ActionCard } from './ui/ActionCard';
+import { ConnectFooter } from '../ui/Footer';
+import { theme } from './ui/theme';
+import { InfoBanner } from './ui/InfoBanner';
+import { App } from '@/types/developer-dashboard/appTypes';
+
+interface AppUnavailableConnectProps {
+  appData: App;
+  readAuthInfo: ReadAuthInfo;
+  activeVersion?: number;
+}
+
+export function AppUnavailableConnect({ 
+  appData, 
+  readAuthInfo,
+  activeVersion
+}: AppUnavailableConnectProps) {
+  const navigate = useNavigate();
+
+  const handleGoBack = useCallback(() => {
+    navigate(-1);
+  }, [navigate]);
+
+  const handleUnpermit = useCallback(() => {
+    navigate(`/user/appId/${appData.appId}`);
+  }, [navigate, appData.appId]);
+
+  return (
+    <div
+      className={`max-w-md mx-auto ${theme.mainCard} border ${theme.mainCardBorder} rounded-2xl shadow-2xl overflow-hidden relative z-10 origin-center`}
+    >
+      {/* Header */}
+      <ConnectPageHeader authInfo={readAuthInfo.authInfo!} />
+
+      <div className="px-3 sm:px-4 py-6 sm:py-8 space-y-6">
+        {/* App Header */}
+        <ConnectAppHeader app={appData} />
+
+        {/* Dividing line */}
+        <div className={`border-b ${theme.cardBorder}`}></div>
+
+        {/* App Unavailable Information */}
+        <div className="space-y-4">
+          <InfoBanner
+            type="red"
+            title="App Unavailable"
+            message={`Both your previously permitted version and the app's active version${activeVersion ? ` (${activeVersion})` : ''} have been disabled by the app developer.${appData.contactEmail ? ` Contact them at ${appData.contactEmail}` : ''}`}
+          />
+        </div>
+
+        {/* Options */}
+        <div className="space-y-3">
+          <div className="space-y-2">
+            {appData.appUserUrl && (
+              <ActionCard
+                icon={
+                  <svg
+                    className="w-4 h-4 text-green-500"
+                    fill="none"
+                    stroke="currentColor"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      strokeWidth={2}
+                      d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14"
+                    />
+                  </svg>
+                }
+                iconBg="bg-green-500/20"
+                title="Visit App Website"
+                description=""
+                onClick={() => window.open(appData.appUserUrl, '_blank')}
+              />
+            )}
+            <ActionCard
+              icon={
+                <svg
+                  className="w-4 h-4 text-orange-500"
+                  fill="none"
+                  stroke="currentColor"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    strokeWidth={2}
+                    d="M6 18L18 6M6 6l12 12"
+                  />
+                </svg>
+              }
+              iconBg="bg-orange-500/20"
+              title="Unpermit App"
+              description=""
+              onClick={handleUnpermit}
+            />
+            <ActionCard
+              icon={<ArrowRight className="w-4 h-4 text-gray-500 rotate-180" />}
+              iconBg="bg-gray-500/20"
+              title="Go Back"
+              description=""
+              onClick={handleGoBack}
+            />
+          </div>
+        </div>
+      </div>
+
+      {/* Footer */}
+      <ConnectFooter />
+    </div>
+  );
+}

--- a/packages/apps/app-dashboard/src/components/user-dashboard/connect/AppUnavailableConnect.tsx
+++ b/packages/apps/app-dashboard/src/components/user-dashboard/connect/AppUnavailableConnect.tsx
@@ -1,10 +1,9 @@
 import { useCallback } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { ArrowRight } from 'lucide-react';
 import { ReadAuthInfo } from '@/hooks/user-dashboard/useAuthInfo';
 import { ConnectPageHeader } from './ui/ConnectPageHeader';
 import { ConnectAppHeader } from './ui/ConnectAppHeader';
-import { ActionCard } from './ui/ActionCard';
+import { ActionButtons } from './ui/ActionButtons';
 import { ConnectFooter } from '../ui/Footer';
 import { theme } from './ui/theme';
 import { InfoBanner } from './ui/InfoBanner';
@@ -23,11 +22,13 @@ export function AppUnavailableConnect({
 }: AppUnavailableConnectProps) {
   const navigate = useNavigate();
 
-  const handleGoBack = useCallback(() => {
-    navigate(-1);
-  }, [navigate]);
+  const handleVisitApp = useCallback(() => {
+    if (appData.appUserUrl) {
+      window.open(appData.appUserUrl, '_blank');
+    }
+  }, [appData.appUserUrl]);
 
-  const handleUnpermit = useCallback(() => {
+  const handleManagePermissions = useCallback(() => {
     navigate(`/user/appId/${appData.appId}`);
   }, [navigate, appData.appId]);
 
@@ -54,62 +55,16 @@ export function AppUnavailableConnect({
           />
         </div>
 
-        {/* Options */}
-        <div className="space-y-3">
-          <div className="space-y-2">
-            {appData.appUserUrl && (
-              <ActionCard
-                icon={
-                  <svg
-                    className="w-4 h-4 text-green-500"
-                    fill="none"
-                    stroke="currentColor"
-                    viewBox="0 0 24 24"
-                  >
-                    <path
-                      strokeLinecap="round"
-                      strokeLinejoin="round"
-                      strokeWidth={2}
-                      d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14"
-                    />
-                  </svg>
-                }
-                iconBg="bg-green-500/20"
-                title="Visit App Website"
-                description=""
-                onClick={() => window.open(appData.appUserUrl, '_blank')}
-              />
-            )}
-            <ActionCard
-              icon={
-                <svg
-                  className="w-4 h-4 text-orange-500"
-                  fill="none"
-                  stroke="currentColor"
-                  viewBox="0 0 24 24"
-                >
-                  <path
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    strokeWidth={2}
-                    d="M6 18L18 6M6 6l12 12"
-                  />
-                </svg>
-              }
-              iconBg="bg-orange-500/20"
-              title="Unpermit App"
-              description=""
-              onClick={handleUnpermit}
-            />
-            <ActionCard
-              icon={<ArrowRight className="w-4 h-4 text-gray-500 rotate-180" />}
-              iconBg="bg-gray-500/20"
-              title="Go Back"
-              description=""
-              onClick={handleGoBack}
-            />
-          </div>
-        </div>
+        {/* Action Buttons */}
+        <ActionButtons
+          onDecline={handleVisitApp}
+          onSubmit={handleManagePermissions}
+          isLoading={false}
+          error={null}
+          appName={appData.name}
+          submitText="Manage Permissions"
+          declineText="Visit App"
+        />
       </div>
 
       {/* Footer */}

--- a/packages/apps/app-dashboard/src/components/user-dashboard/connect/ConnectPageWraper.tsx
+++ b/packages/apps/app-dashboard/src/components/user-dashboard/connect/ConnectPageWraper.tsx
@@ -13,6 +13,7 @@ import { ReturningUserConnect } from './ReturningUserConnect';
 import { AppVersionNotInRegistryConnect } from './AppVersionNotInRegistry';
 import { useUriPrecheck } from '@/hooks/user-dashboard/connect/useUriPrecheck';
 import { RepermitConnect } from './RepermitConnect';
+import { DisabledVersionConnect } from './DisabledVersionConnect';
 
 export function ConnectPageWrapper() {
   const { appId } = useParams();
@@ -21,9 +22,11 @@ export function ConnectPageWrapper() {
   const {
     agentPKP,
     permittedVersion,
+    versionEnabled,
     loading: agentPKPLoading,
     error: agentPKPError,
   } = useAgentPkpForApp(authInfo?.userPKP?.ethAddress, appId ? Number(appId) : undefined);
+
   const { isLoading, isError, errors, data } = useConnectInfo(appId || '');
   const {
     appExists,
@@ -142,7 +145,17 @@ export function ConnectPageWrapper() {
         />
       );
     }
-    // Check for previously permitted PKP (unpermitted but has PKP)
+    // Check for previously permitted PKP with disabled version
+    else if (agentPKP && !isPermitted && versionEnabled === false) {
+      content = (
+        <DisabledVersionConnect
+          appData={data.app}
+          readAuthInfo={{ authInfo, sessionSigs, isProcessing, error }}
+          connectInfoMap={data}
+        />
+      );
+    }
+    // Check for previously permitted PKP (unpermitted but has PKP - either enabled version or current active version)
     else if (agentPKP && !isPermitted) {
       content = (
         <RepermitConnect

--- a/packages/apps/app-dashboard/src/components/user-dashboard/connect/ConnectPageWraper.tsx
+++ b/packages/apps/app-dashboard/src/components/user-dashboard/connect/ConnectPageWraper.tsx
@@ -14,6 +14,7 @@ import { AppVersionNotInRegistryConnect } from './AppVersionNotInRegistry';
 import { useUriPrecheck } from '@/hooks/user-dashboard/connect/useUriPrecheck';
 import { RepermitConnect } from './RepermitConnect';
 import { DisabledVersionConnect } from './DisabledVersionConnect';
+import { AppUnavailableConnect } from './AppUnavailableConnect';
 
 export function ConnectPageWrapper() {
   const { appId } = useParams();
@@ -145,7 +146,17 @@ export function ConnectPageWrapper() {
         />
       );
     }
-    // Check for previously permitted PKP with disabled version
+    // Check if both user's version and active version are disabled - app is unavailable
+    else if (agentPKP && !isPermitted && versionEnabled === false && activeVersionData && !activeVersionData.enabled) {
+      content = (
+        <AppUnavailableConnect
+          appData={data.app}
+          readAuthInfo={{ authInfo, sessionSigs, isProcessing, error }}
+          activeVersion={data.app?.activeVersion}
+        />
+      );
+    }
+    // Check for previously permitted PKP with disabled version (but active version is available)
     else if (agentPKP && !isPermitted && versionEnabled === false) {
       content = (
         <DisabledVersionConnect

--- a/packages/apps/app-dashboard/src/components/user-dashboard/connect/ConnectPageWraper.tsx
+++ b/packages/apps/app-dashboard/src/components/user-dashboard/connect/ConnectPageWraper.tsx
@@ -12,6 +12,7 @@ import { reactClient as vincentApiClient } from '@lit-protocol/vincent-registry-
 import { ReturningUserConnect } from './ReturningUserConnect';
 import { AppVersionNotInRegistryConnect } from './AppVersionNotInRegistry';
 import { useUriPrecheck } from '@/hooks/user-dashboard/connect/useUriPrecheck';
+import { RepermitConnect } from './RepermitConnect';
 
 export function ConnectPageWrapper() {
   const { appId } = useParams();
@@ -138,6 +139,17 @@ export function ConnectPageWrapper() {
           redirectUri={redirectUri || undefined}
           readAuthInfo={{ authInfo, sessionSigs, isProcessing, error }}
           agentPKP={agentPKP!}
+        />
+      );
+    }
+    // Check for previously permitted PKP (unpermitted but has PKP)
+    else if (agentPKP && !isPermitted) {
+      content = (
+        <RepermitConnect
+          appData={data.app}
+          previouslyPermittedPKP={agentPKP}
+          readAuthInfo={{ authInfo, sessionSigs, isProcessing, error }}
+          redirectUri={redirectUri || undefined}
         />
       );
     }

--- a/packages/apps/app-dashboard/src/components/user-dashboard/connect/DisabledVersionConnect.tsx
+++ b/packages/apps/app-dashboard/src/components/user-dashboard/connect/DisabledVersionConnect.tsx
@@ -9,11 +9,12 @@ import { theme } from './ui/theme';
 import { InfoBanner } from './ui/InfoBanner';
 import { App } from '@/types/developer-dashboard/appTypes';
 import { ConnectPage } from './ConnectPage';
+import { ConnectInfoMap } from '@/hooks/user-dashboard/connect/useConnectInfo';
 
 interface DisabledVersionConnectProps {
   appData: App;
   readAuthInfo: ReadAuthInfo;
-  connectInfoMap: any; // Same type as ConnectPage expects
+  connectInfoMap: ConnectInfoMap;
 }
 
 export function DisabledVersionConnect({ 

--- a/packages/apps/app-dashboard/src/components/user-dashboard/connect/DisabledVersionConnect.tsx
+++ b/packages/apps/app-dashboard/src/components/user-dashboard/connect/DisabledVersionConnect.tsx
@@ -1,0 +1,84 @@
+import { useState, useCallback } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { ReadAuthInfo } from '@/hooks/user-dashboard/useAuthInfo';
+import { ConnectPageHeader } from './ui/ConnectPageHeader';
+import { ConnectAppHeader } from './ui/ConnectAppHeader';
+import { ActionButtons } from './ui/ActionButtons';
+import { ConnectFooter } from '../ui/Footer';
+import { theme } from './ui/theme';
+import { InfoBanner } from './ui/InfoBanner';
+import { App } from '@/types/developer-dashboard/appTypes';
+import { ConnectPage } from './ConnectPage';
+
+interface DisabledVersionConnectProps {
+  appData: App;
+  readAuthInfo: ReadAuthInfo;
+  connectInfoMap: any; // Same type as ConnectPage expects
+}
+
+export function DisabledVersionConnect({ 
+  appData, 
+  readAuthInfo,
+  connectInfoMap
+}: DisabledVersionConnectProps) {
+  const navigate = useNavigate();
+  const [showConnectPage, setShowConnectPage] = useState(false);
+
+  const handleUpdateToLatest = useCallback(() => {
+    setShowConnectPage(true);
+  }, []);
+
+  const handleDecline = useCallback(() => {
+    navigate(-1);
+  }, [navigate]);
+
+  // If user has clicked to update, show the ConnectPage
+  if (showConnectPage) {
+    return (
+      <ConnectPage
+        connectInfoMap={connectInfoMap}
+        readAuthInfo={readAuthInfo}
+      />
+    );
+  }
+
+  // Show the disabled version message
+  return (
+    <div
+      className={`max-w-md mx-auto ${theme.mainCard} border ${theme.mainCardBorder} rounded-2xl shadow-2xl overflow-hidden relative z-10 origin-center`}
+    >
+      {/* Header */}
+      <ConnectPageHeader authInfo={readAuthInfo.authInfo!} />
+
+      <div className="px-3 sm:px-4 py-6 sm:py-8 space-y-6">
+        {/* App Header */}
+        <ConnectAppHeader app={appData} />
+
+        {/* Dividing line */}
+        <div className={`border-b ${theme.cardBorder}`}></div>
+
+        {/* Version Update Information */}
+        <div className="space-y-4">
+          <InfoBanner
+            type="orange"
+            title="Version Update Required"
+            message="Your previously permitted version has been disabled. Please update to the latest version to continue using this app."
+          />
+        </div>
+
+        {/* Action Buttons */}
+        <ActionButtons
+          onDecline={handleDecline}
+          onSubmit={handleUpdateToLatest}
+          isLoading={false}
+          error={null}
+          appName={appData.name}
+          submitText="Update to Latest Version"
+        />
+      </div>
+
+      {/* Footer */}
+      <ConnectFooter />
+    </div>
+  );
+}

--- a/packages/apps/app-dashboard/src/components/user-dashboard/connect/RepermitConnect.tsx
+++ b/packages/apps/app-dashboard/src/components/user-dashboard/connect/RepermitConnect.tsx
@@ -5,7 +5,6 @@ import { IRelayPKP } from '@lit-protocol/types';
 import { PKPEthersWallet } from '@lit-protocol/pkp-ethers';
 import { litNodeClient } from '@/utils/user-dashboard/lit';
 import { ReadAuthInfo } from '@/hooks/user-dashboard/useAuthInfo';
-import { useJwtRedirect } from '@/hooks/user-dashboard/connect/useJwtRedirect';
 import { ConnectPageHeader } from './ui/ConnectPageHeader';
 import { ConnectAppHeader } from './ui/ConnectAppHeader';
 import { StatusCard } from './ui/StatusCard';
@@ -28,36 +27,19 @@ export function RepermitConnect({ appData, previouslyPermittedPKP, readAuthInfo 
   const [localSuccess, setLocalSuccess] = useState<string | null>(null);
   const [isConnectProcessing, setIsConnectProcessing] = useState(false);
 
-  const {
-    generateJWT,
-    executeRedirect,
-    isLoading: isJwtLoading,
-    loadingStatus: jwtLoadingStatus,
-    error: jwtError,
-    redirectUrl,
-  } = useJwtRedirect({ readAuthInfo, agentPKP: previouslyPermittedPKP });
-
-  // Handle redirect when JWT is ready
-  useEffect(() => {
-    if (redirectUrl && !localSuccess) {
-      setLocalSuccess('Success! Redirecting to app...');
-      setTimeout(() => {
-        executeRedirect();
-      }, 2000);
-    }
-  }, [redirectUrl, localSuccess, executeRedirect]);
-
-  // Generate JWT when repermitting is successful
+  // Handle page refresh when repermitting is successful
   useEffect(() => {
     if (localSuccess === 'App re-permitted successfully!') {
-      const timer = setTimeout(async () => {
-        setLocalSuccess(null);
-        await generateJWT(appData, appData.activeVersion!);
-      }, 3000);
+      const timer = setTimeout(() => {
+        setLocalSuccess('Success! Refreshing...');
+        setTimeout(() => {
+          window.location.reload();
+        }, 1000);
+      }, 2000);
       return () => clearTimeout(timer);
     }
     return undefined;
-  }, [localSuccess, generateJWT, appData]);
+  }, [localSuccess]);
 
   const handleSubmit = useCallback(async () => {
     setLocalError(null);
@@ -96,9 +78,9 @@ export function RepermitConnect({ appData, previouslyPermittedPKP, readAuthInfo 
     navigate(-1);
   }, [navigate]);
 
-  const isLoading = isJwtLoading || isConnectProcessing || !!localSuccess;
-  const loadingStatus = jwtLoadingStatus || (isConnectProcessing ? 'Re-permitting app...' : null);
-  const error = jwtError || localError;
+  const isLoading = isConnectProcessing || !!localSuccess;
+  const loadingStatus = isConnectProcessing ? 'Re-permitting app...' : localSuccess || null;
+  const error = localError;
 
   return (
     <div

--- a/packages/apps/app-dashboard/src/components/user-dashboard/connect/RepermitConnect.tsx
+++ b/packages/apps/app-dashboard/src/components/user-dashboard/connect/RepermitConnect.tsx
@@ -101,7 +101,7 @@ export function RepermitConnect({ appData, previouslyPermittedPKP, readAuthInfo 
           <InfoBanner
             type="blue"
             title="Previously Connected"
-            message="You've previously connected to this app. Re-permitting will restore your previous permissions and app version."
+            message="You've previously connected to this app. Re-permitting will restore your previous permissions."
           />
         </div>
 

--- a/packages/apps/app-dashboard/src/components/user-dashboard/connect/RepermitConnect.tsx
+++ b/packages/apps/app-dashboard/src/components/user-dashboard/connect/RepermitConnect.tsx
@@ -1,0 +1,148 @@
+import { useState, useCallback, useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { getClient } from '@lit-protocol/vincent-contracts-sdk';
+import { IRelayPKP } from '@lit-protocol/types';
+import { PKPEthersWallet } from '@lit-protocol/pkp-ethers';
+import { litNodeClient } from '@/utils/user-dashboard/lit';
+import { ReadAuthInfo } from '@/hooks/user-dashboard/useAuthInfo';
+import { useJwtRedirect } from '@/hooks/user-dashboard/connect/useJwtRedirect';
+import { ConnectPageHeader } from './ui/ConnectPageHeader';
+import { ConnectAppHeader } from './ui/ConnectAppHeader';
+import { StatusCard } from './ui/StatusCard';
+import { ActionButtons } from './ui/ActionButtons';
+import { ConnectFooter } from '../ui/Footer';
+import { theme } from './ui/theme';
+import { InfoBanner } from './ui/InfoBanner';
+import { App } from '@/types/developer-dashboard/appTypes';
+
+interface RepermitConnectProps {
+  appData: App;
+  previouslyPermittedPKP: IRelayPKP;
+  readAuthInfo: ReadAuthInfo;
+  redirectUri?: string;
+}
+
+export function RepermitConnect({ appData, previouslyPermittedPKP, readAuthInfo }: RepermitConnectProps) {
+  const navigate = useNavigate();
+  const [localError, setLocalError] = useState<string | null>(null);
+  const [localSuccess, setLocalSuccess] = useState<string | null>(null);
+  const [isConnectProcessing, setIsConnectProcessing] = useState(false);
+
+  const {
+    generateJWT,
+    executeRedirect,
+    isLoading: isJwtLoading,
+    loadingStatus: jwtLoadingStatus,
+    error: jwtError,
+    redirectUrl,
+  } = useJwtRedirect({ readAuthInfo, agentPKP: previouslyPermittedPKP });
+
+  // Handle redirect when JWT is ready
+  useEffect(() => {
+    if (redirectUrl && !localSuccess) {
+      setLocalSuccess('Success! Redirecting to app...');
+      setTimeout(() => {
+        executeRedirect();
+      }, 2000);
+    }
+  }, [redirectUrl, localSuccess, executeRedirect]);
+
+  // Generate JWT when repermitting is successful
+  useEffect(() => {
+    if (localSuccess === 'App re-permitted successfully!') {
+      const timer = setTimeout(async () => {
+        setLocalSuccess(null);
+        await generateJWT(appData, appData.activeVersion!);
+      }, 3000);
+      return () => clearTimeout(timer);
+    }
+    return undefined;
+  }, [localSuccess, generateJWT, appData]);
+
+  const handleSubmit = useCallback(async () => {
+    setLocalError(null);
+    setLocalSuccess(null);
+    setIsConnectProcessing(true);
+
+    if (!readAuthInfo.authInfo?.userPKP || !readAuthInfo.sessionSigs) {
+      setLocalError('Missing authentication information. Please try refreshing the page.');
+      setIsConnectProcessing(false);
+      return;
+    }
+
+    try {
+      const userPkpWallet = new PKPEthersWallet({
+        controllerSessionSigs: readAuthInfo.sessionSigs,
+        pkpPubKey: readAuthInfo.authInfo.userPKP.publicKey,
+        litNodeClient: litNodeClient,
+      });
+      await userPkpWallet.init();
+
+      const client = getClient({ signer: userPkpWallet });
+      await client.rePermitApp({
+        pkpEthAddress: previouslyPermittedPKP.ethAddress,
+        appId: Number(appData.appId),
+      });
+
+      setIsConnectProcessing(false);
+      setLocalSuccess('App re-permitted successfully!');
+    } catch (error) {
+      setLocalError(error instanceof Error ? error.message : 'Failed to re-permit app');
+      setIsConnectProcessing(false);
+    }
+  }, [readAuthInfo, previouslyPermittedPKP, appData]);
+
+  const handleDecline = useCallback(() => {
+    navigate(-1);
+  }, [navigate]);
+
+  const isLoading = isJwtLoading || isConnectProcessing || !!localSuccess;
+  const loadingStatus = jwtLoadingStatus || (isConnectProcessing ? 'Re-permitting app...' : null);
+  const error = jwtError || localError;
+
+  return (
+    <div
+      className={`max-w-md mx-auto ${theme.mainCard} border ${theme.mainCardBorder} rounded-2xl shadow-2xl overflow-hidden relative z-10 origin-center`}
+    >
+      {/* Header */}
+      <ConnectPageHeader authInfo={readAuthInfo.authInfo!} />
+
+      <div className="px-3 sm:px-4 py-6 sm:py-8 space-y-6">
+        {/* App Header */}
+        <ConnectAppHeader app={appData} />
+
+        {/* Dividing line */}
+        <div className={`border-b ${theme.cardBorder}`}></div>
+
+        {/* Re-permit Information */}
+        <div className="space-y-4">
+          <InfoBanner
+            type="blue"
+            title="Previously Connected"
+            message="You've previously connected to this app. Re-permitting will restore your previous permissions and app version."
+          />
+        </div>
+
+        {/* Status Card */}
+        <StatusCard
+          isLoading={isLoading}
+          loadingStatus={loadingStatus}
+          error={error}
+          success={localSuccess}
+        />
+
+        {/* Action Buttons */}
+        <ActionButtons
+          onDecline={handleDecline}
+          onSubmit={handleSubmit}
+          isLoading={isLoading}
+          error={error}
+          appName={appData.name}
+        />
+      </div>
+
+      {/* Footer */}
+      <ConnectFooter />
+    </div>
+  );
+}

--- a/packages/apps/app-dashboard/src/components/user-dashboard/connect/ui/ActionButtons.tsx
+++ b/packages/apps/app-dashboard/src/components/user-dashboard/connect/ui/ActionButtons.tsx
@@ -9,6 +9,7 @@ interface ActionButtonsProps {
   onSubmit: () => void;
   isLoading?: boolean;
   error?: string | null;
+  submitText?: string;
 }
 
 export function ActionButtons({
@@ -17,6 +18,7 @@ export function ActionButtons({
   onSubmit,
   isLoading = false,
   error,
+  submitText = 'Grant Permissions',
 }: ActionButtonsProps) {
   return (
     <div className="space-y-4">
@@ -57,7 +59,7 @@ export function ActionButtons({
           >
             {isLoading && <Loader2 className="w-4 h-4 animate-spin" />}
             {error && <AlertCircle className="w-4 h-4" />}
-            {error ? 'Retry' : isLoading ? 'Processing...' : 'Grant Permissions'}
+            {error ? 'Retry' : isLoading ? 'Processing...' : submitText}
           </Button>
         </motion.div>
       </div>

--- a/packages/apps/app-dashboard/src/components/user-dashboard/connect/ui/ActionButtons.tsx
+++ b/packages/apps/app-dashboard/src/components/user-dashboard/connect/ui/ActionButtons.tsx
@@ -10,6 +10,7 @@ interface ActionButtonsProps {
   isLoading?: boolean;
   error?: string | null;
   submitText?: string;
+  declineText?: string;
 }
 
 export function ActionButtons({
@@ -19,6 +20,7 @@ export function ActionButtons({
   isLoading = false,
   error,
   submitText = 'Grant Permissions',
+  declineText = 'Decline',
 }: ActionButtonsProps) {
   return (
     <div className="space-y-4">
@@ -44,7 +46,7 @@ export function ActionButtons({
             className={`w-full sm:w-auto px-6 py-2 border ${theme.cardBorder} ${theme.text} hover:bg-red-500/10 hover:text-red-400 hover:border-red-400/30`}
             disabled={isLoading}
           >
-            Decline
+            {declineText}
           </Button>
         </motion.div>
         <motion.div

--- a/packages/apps/app-dashboard/src/components/user-dashboard/connect/ui/InfoBanner.tsx
+++ b/packages/apps/app-dashboard/src/components/user-dashboard/connect/ui/InfoBanner.tsx
@@ -1,8 +1,8 @@
-import { AlertTriangle, CheckCircle } from 'lucide-react';
+import { AlertTriangle, CheckCircle, Info } from 'lucide-react';
 import { theme } from './theme';
 
 interface InfoBannerProps {
-  type?: 'warning' | 'success' | 'orange';
+  type?: 'warning' | 'success' | 'orange' | 'blue';
   title?: string;
   message?: string;
 }
@@ -14,10 +14,14 @@ export function InfoBanner({
 }: InfoBannerProps) {
   const isSuccess = type === 'success';
   const isOrange = type === 'orange';
-  const Icon = isSuccess || isOrange ? CheckCircle : AlertTriangle;
+  const isBlue = type === 'blue';
+  const Icon = isSuccess || isOrange ? CheckCircle : isBlue ? Info : AlertTriangle;
 
   let bgClass, iconClass;
-  if (isOrange) {
+  if (isBlue) {
+    bgClass = 'bg-blue-50 border-blue-300 dark:bg-blue-500/10 dark:border-blue-500/30';
+    iconClass = 'text-blue-700 dark:text-blue-400';
+  } else if (isOrange) {
     bgClass = 'bg-orange-50 border-orange-300 dark:bg-orange-500/10 dark:border-orange-500/30';
     iconClass = 'text-orange-700 dark:text-orange-400';
   } else if (isSuccess) {

--- a/packages/apps/app-dashboard/src/components/user-dashboard/connect/ui/InfoBanner.tsx
+++ b/packages/apps/app-dashboard/src/components/user-dashboard/connect/ui/InfoBanner.tsx
@@ -1,8 +1,8 @@
-import { AlertTriangle, CheckCircle, Info } from 'lucide-react';
+import { AlertTriangle, CheckCircle, Info, XCircle } from 'lucide-react';
 import { theme } from './theme';
 
 interface InfoBannerProps {
-  type?: 'warning' | 'success' | 'orange' | 'blue';
+  type?: 'warning' | 'success' | 'orange' | 'blue' | 'red';
   title?: string;
   message?: string;
 }
@@ -15,10 +15,14 @@ export function InfoBanner({
   const isSuccess = type === 'success';
   const isOrange = type === 'orange';
   const isBlue = type === 'blue';
-  const Icon = isSuccess || isOrange ? CheckCircle : isBlue ? Info : AlertTriangle;
+  const isRed = type === 'red';
+  const Icon = isRed ? XCircle : isSuccess || isOrange ? CheckCircle : isBlue ? Info : AlertTriangle;
 
   let bgClass, iconClass;
-  if (isBlue) {
+  if (isRed) {
+    bgClass = 'bg-red-50 border-red-300 dark:bg-red-500/10 dark:border-red-500/30';
+    iconClass = 'text-red-700 dark:text-red-400';
+  } else if (isBlue) {
     bgClass = 'bg-blue-50 border-blue-300 dark:bg-blue-500/10 dark:border-blue-500/30';
     iconClass = 'text-blue-700 dark:text-blue-400';
   } else if (isOrange) {

--- a/packages/apps/app-dashboard/src/hooks/user-dashboard/useAgentPkpForApp.ts
+++ b/packages/apps/app-dashboard/src/hooks/user-dashboard/useAgentPkpForApp.ts
@@ -6,6 +6,7 @@ import { env } from '@/config/env';
 export function useAgentPkpForApp(userAddress: string | undefined, appId: number | undefined) {
   const [agentPKP, setAgentPKP] = useState<IRelayPKP | null>(null);
   const [permittedVersion, setPermittedVersion] = useState<number | null>(null);
+  const [versionEnabled, setVersionEnabled] = useState<boolean | null>(null);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<Error | null>(null);
 
@@ -13,6 +14,7 @@ export function useAgentPkpForApp(userAddress: string | undefined, appId: number
     if (!userAddress || appId === undefined) {
       setAgentPKP(null);
       setPermittedVersion(null);
+      setVersionEnabled(null);
       setError(null);
       return;
     }
@@ -31,6 +33,7 @@ export function useAgentPkpForApp(userAddress: string | undefined, appId: number
           if (hadUnpermittedFallback) {
             setAgentPKP(permitted[0].pkp);
             setPermittedVersion(null);
+            setVersionEnabled(null);
             setLoading(false);
             return;
           }
@@ -42,6 +45,7 @@ export function useAgentPkpForApp(userAddress: string | undefined, appId: number
         if (appPermission) {
           setAgentPKP(appPermission.pkp);
           setPermittedVersion(appPermission.permittedVersion);
+          setVersionEnabled(null); // For permitted apps, versionEnabled is not relevant
         } else {
           // Check if this app was previously permitted and return that PKP for reuse
           const previousPermission = unpermitted.find((p) => p.appId === appId);
@@ -49,15 +53,18 @@ export function useAgentPkpForApp(userAddress: string | undefined, appId: number
             // Return the PKP that was previously permitted so ConnectPage can reuse it
             setAgentPKP(previousPermission.pkp);
             setPermittedVersion(null);
+            setVersionEnabled(previousPermission.versionEnabled ?? null);
           } else {
             setAgentPKP(null);
             setPermittedVersion(null);
+            setVersionEnabled(null);
           }
         }
       } catch (err) {
         setError(err as Error);
         setAgentPKP(null);
         setPermittedVersion(null);
+        setVersionEnabled(null);
       } finally {
         setLoading(false);
       }
@@ -66,5 +73,5 @@ export function useAgentPkpForApp(userAddress: string | undefined, appId: number
     fetchAgentPKP();
   }, [userAddress, appId]);
 
-  return { agentPKP, permittedVersion, loading, error };
+  return { agentPKP, permittedVersion, versionEnabled, loading, error };
 }

--- a/packages/apps/app-dashboard/src/hooks/user-dashboard/useAllAgentApps.ts
+++ b/packages/apps/app-dashboard/src/hooks/user-dashboard/useAllAgentApps.ts
@@ -18,9 +18,9 @@ export function useAllAgentApps(userAddress: string | undefined) {
 
     const fetchAllPermissions = async () => {
       try {
-        const agentPKPs = await getAgentPkps(userAddress);
+        const { permitted } = await getAgentPkps(userAddress);
 
-        setPermittedPKPs(agentPKPs);
+        setPermittedPKPs(permitted);
       } catch (err) {
         setError(err as Error);
         setPermittedPKPs([]);

--- a/packages/apps/app-dashboard/src/utils/user-dashboard/getAgentPkps.ts
+++ b/packages/apps/app-dashboard/src/utils/user-dashboard/getAgentPkps.ts
@@ -9,6 +9,7 @@ export type AgentAppPermission = {
   appId: number;
   pkp: IRelayPKP;
   permittedVersion: number | null;
+  versionEnabled?: boolean;
 };
 
 export type AgentPkpsResult = {
@@ -96,7 +97,7 @@ export async function getAgentPkps(userAddress: string): Promise<AgentPkpsResult
     // Convert the unpermitted apps results to our format
     const pkpToUnpermittedAppsMap = new Map<
       string,
-      Array<{ appId: number; previousPermittedVersion: number | null }>
+      Array<{ appId: number; previousPermittedVersion: number | null; versionEnabled: boolean }>
     >();
     for (const pkpUnpermittedApps of unpermittedAppsArray) {
       // Find the PKP by matching tokenId
@@ -105,6 +106,7 @@ export async function getAgentPkps(userAddress: string): Promise<AgentPkpsResult
         const appsWithVersions = pkpUnpermittedApps.unpermittedApps.map((app) => ({
           appId: app.appId,
           previousPermittedVersion: app.previousPermittedVersion,
+          versionEnabled: app.versionEnabled,
         }));
         pkpToUnpermittedAppsMap.set(pkp.ethAddress, appsWithVersions);
       }
@@ -133,6 +135,7 @@ export async function getAgentPkps(userAddress: string): Promise<AgentPkpsResult
           appId: app.appId,
           pkp,
           permittedVersion: app.previousPermittedVersion,
+          versionEnabled: app.versionEnabled,
         });
       }
 

--- a/packages/apps/app-dashboard/src/utils/user-dashboard/getAgentPkps.ts
+++ b/packages/apps/app-dashboard/src/utils/user-dashboard/getAgentPkps.ts
@@ -11,23 +11,28 @@ export type AgentAppPermission = {
   permittedVersion: number | null;
 };
 
+export type AgentPkpsResult = {
+  permitted: AgentAppPermission[];
+  unpermitted: AgentAppPermission[];
+};
+
 /**
  * Get Agent PKPs for a user address
  *
  * Finds all Agent PKPs owned by the user that are different from their current PKP.
- * Returns permitted agent PKPs as a flat array of app-PKP pairs.
+ * Returns both currently permitted and previously permitted (unpermitted) agent PKPs.
  *
  * @param userAddress The ETH address of the user's current PKP
- * @returns Promise<AgentAppPermission[]> Array of permitted agent PKPs
+ * @returns Promise<AgentPkpsResult> Object containing permitted and unpermitted agent PKPs
  * @throws Error if there's an issue with the contract calls
  */
-export async function getAgentPkps(userAddress: string): Promise<AgentAppPermission[]> {
+export async function getAgentPkps(userAddress: string): Promise<AgentPkpsResult> {
   try {
     const pkpNftContract = getPkpNftContract(SELECTED_LIT_NETWORK);
 
     const balance = await pkpNftContract.balanceOf(userAddress);
     if (balance.toNumber() === 0) {
-      return [];
+      return { permitted: [], unpermitted: [] };
     }
 
     // Get all token IDs in parallel first
@@ -56,16 +61,22 @@ export async function getAgentPkps(userAddress: string): Promise<AgentAppPermiss
       (pkp) => pkp.ethAddress.toLowerCase() !== userAddress.toLowerCase(),
     );
 
-    // Fetch all permitted apps for all agent PKPs in a single call
+    // Fetch both permitted and unpermitted apps for all agent PKPs
     const client = getClient({ signer: readOnlySigner });
     const pkpEthAddresses = agentPKPs.map((pkp) => pkp.ethAddress);
 
-    const permittedAppsArray = await client.getPermittedAppsForPkps({
-      pkpEthAddresses,
-      offset: '0',
-    });
+    const [permittedAppsArray, unpermittedAppsArray] = await Promise.all([
+      client.getPermittedAppsForPkps({
+        pkpEthAddresses,
+        offset: '0',
+      }),
+      client.getUnpermittedAppsForPkps({
+        pkpEthAddresses,
+        offset: '0',
+      }),
+    ]);
 
-    // Convert the array results to our format
+    // Convert the permitted apps results to our format
     const pkpToPermittedAppsMap = new Map<
       string,
       Array<{ appId: number; version: number | null }>
@@ -82,31 +93,52 @@ export async function getAgentPkps(userAddress: string): Promise<AgentAppPermiss
       }
     }
 
-    const results = agentPKPs.map((pkp) => ({
-      pkp,
-      appsWithVersions: pkpToPermittedAppsMap.get(pkp.ethAddress) || [],
-    }));
+    // Convert the unpermitted apps results to our format
+    const pkpToUnpermittedAppsMap = new Map<
+      string,
+      Array<{ appId: number; previousPermittedVersion: number | null }>
+    >();
+    for (const pkpUnpermittedApps of unpermittedAppsArray) {
+      // Find the PKP by matching tokenId
+      const pkp = agentPKPs.find((p) => p.tokenId === pkpUnpermittedApps.pkpTokenId);
+      if (pkp) {
+        const appsWithVersions = pkpUnpermittedApps.unpermittedApps.map((app) => ({
+          appId: app.appId,
+          previousPermittedVersion: app.previousPermittedVersion,
+        }));
+        pkpToUnpermittedAppsMap.set(pkp.ethAddress, appsWithVersions);
+      }
+    }
 
     const permitted: AgentAppPermission[] = [];
+    const unpermitted: AgentAppPermission[] = [];
     let unpermittedAgentPKP: IRelayPKP | null = null;
 
-    for (const result of results) {
-      const { pkp, appsWithVersions } = result;
+    for (const pkp of agentPKPs) {
+      const permittedApps = pkpToPermittedAppsMap.get(pkp.ethAddress) || [];
+      const unpermittedApps = pkpToUnpermittedAppsMap.get(pkp.ethAddress) || [];
 
-      if (appsWithVersions.length > 0) {
-        // PKP has permitted apps - add each app-PKP pair with version
-        for (const app of appsWithVersions) {
-          permitted.push({
-            appId: app.appId,
-            pkp,
-            permittedVersion: app.version,
-          });
-        }
-      } else {
-        // Store the first unpermitted agent PKP we find
-        if (!unpermittedAgentPKP) {
-          unpermittedAgentPKP = pkp;
-        }
+      // Add permitted apps
+      for (const app of permittedApps) {
+        permitted.push({
+          appId: app.appId,
+          pkp,
+          permittedVersion: app.version,
+        });
+      }
+
+      // Add unpermitted apps (previously permitted)
+      for (const app of unpermittedApps) {
+        unpermitted.push({
+          appId: app.appId,
+          pkp,
+          permittedVersion: app.previousPermittedVersion,
+        });
+      }
+
+      // Track PKPs with no apps at all
+      if (permittedApps.length === 0 && unpermittedApps.length === 0 && !unpermittedAgentPKP) {
+        unpermittedAgentPKP = pkp;
       }
     }
 
@@ -121,10 +153,12 @@ export async function getAgentPkps(userAddress: string): Promise<AgentAppPermiss
 
     console.log('[getAgentPkps] Final result:', {
       permittedCount: permitted.length,
+      unpermittedCount: unpermitted.length,
       permitted: permitted,
+      unpermitted: unpermitted,
     });
 
-    return permitted;
+    return { permitted, unpermitted };
   } catch (error) {
     if (error instanceof Error) {
       throw error;
@@ -132,30 +166,4 @@ export async function getAgentPkps(userAddress: string): Promise<AgentAppPermiss
       throw new Error(`Failed to get Agent PKPs: ${error}`);
     }
   }
-}
-
-/**
- * Get the Agent PKP for a specific app ID
- *
- * @param agentPKPs Result from getAgentPkps
- * @param appId The app ID to get the PKP for
- * @returns The PKP for the app, or null if not found
- */
-export function getAgentPKPForApp(
-  agentPKPs: AgentAppPermission[],
-  appId: number,
-): IRelayPKP | null {
-  // Check if there are PKPs for this app
-  const pkpForApp = agentPKPs.find((p) => p.appId === appId);
-
-  if (pkpForApp) {
-    console.log(
-      `[getAgentPKPForApp] Found specific PKP for appId ${appId}:`,
-      pkpForApp.pkp.ethAddress,
-    );
-    return pkpForApp.pkp;
-  }
-
-  console.log(`[getAgentPKPForApp] No PKP found for appId ${appId}`);
-  return null;
 }


### PR DESCRIPTION
# Description

### Additional Frontend Detection
1. User unpermits an app
2. The appId is still tied to their PKP on-chain
3. The user wants to permit the app again
4. **NEW:** The `ConnectPage` screen will now inform them that they've permitted the app previously, and repermitting the app will grant the same permissions that they had previously.

### New Page Views

#### Repermitting an Unchanged App
<img width="503" height="711" alt="image" src="https://github.com/user-attachments/assets/2150d7a9-d40a-4a5e-8ef0-6fe8c0cdf922" />


#### Trying to Repermit a Disabled App
<img width="547" height="718" alt="image" src="https://github.com/user-attachments/assets/34275f35-407e-4db9-9e9b-a5e9bcdae8e5" />


#### Repermitting to an Updated App
<img width="500" height="702" alt="image" src="https://github.com/user-attachments/assets/20d2d5cf-e4a4-4414-8c57-eec2e9edfd6b" />


### Support for Existing Logic
The VY integration is safe, since VY will be added to the `permittedPkps` array, and the detection for `appId` -1 is still functional. 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Locally with manual testing.

# Checklist:

- [ ] I created a [release plan](https://nx.dev/recipes/nx-release/file-based-versioning-version-plans) (`nx release plan`) describing my changes and the version bump
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
