### PR TITLE
fix(dashboard): check for policy deletions and updates when permissioning

### DIFF
--- a/packages/apps/app-dashboard/src/components/user-dashboard/dashboard/UserPermissionPage.tsx
+++ b/packages/apps/app-dashboard/src/components/user-dashboard/dashboard/UserPermissionPage.tsx
@@ -77,7 +77,7 @@ export function AppPermissionPage({
     console.log('[UserPermissionPage] Starting submission', {
       formData,
       selectedPolicies,
-      existingData
+      existingData,
     });
 
     // Clear any previous local errors and success
@@ -147,6 +147,23 @@ export function AppPermissionPage({
           }
         }
       });
+
+      // Check if there are any meaningful changes to make
+      const hasPolicyUpdates = Object.keys(policyParams).some(
+        (abilityId) => Object.keys(policyParams[abilityId]).length > 0,
+      );
+      const hasDeletions = Object.keys(deletePermissionData).some(
+        (abilityId) => deletePermissionData[abilityId].length > 0,
+      );
+
+      if (!hasPolicyUpdates && !hasDeletions) {
+        setLocalStatus(null);
+        setLocalSuccess('Permissions are up to date.');
+        setTimeout(() => {
+          setLocalSuccess(null);
+        }, 3000);
+        return;
+      }
 
       // We should do this in case there was ever an error doing this previously
       setLocalStatus('Adding permitted actions...');

--- a/packages/apps/app-dashboard/src/components/user-dashboard/dashboard/UserPermissionPage.tsx
+++ b/packages/apps/app-dashboard/src/components/user-dashboard/dashboard/UserPermissionPage.tsx
@@ -148,15 +148,23 @@ export function AppPermissionPage({
         }
       });
 
-      // Check if there are any meaningful changes to make
-      const hasPolicyUpdates = Object.keys(policyParams).some(
-        (abilityId) => Object.keys(policyParams[abilityId]).length > 0,
-      );
-      const hasDeletions = Object.keys(deletePermissionData).some(
-        (abilityId) => deletePermissionData[abilityId].length > 0,
-      );
+      const currentStateJson = JSON.stringify({ formData, selectedPolicies });
+      const initialStateJson = JSON.stringify({
+        formData: existingData || {},
+        selectedPolicies: Object.fromEntries(
+          Object.keys(selectedPolicies).map((policyId) => [
+            policyId,
+            // A policy was initially selected if it exists in existingData
+            Object.keys(existingData || {}).some(
+              (abilityId) => existingData?.[abilityId]?.[policyId] !== undefined,
+            ),
+          ]),
+        ),
+      });
 
-      if (!hasPolicyUpdates && !hasDeletions) {
+      const hasAnyChanges = currentStateJson !== initialStateJson;
+
+      if (!hasAnyChanges) {
         setLocalStatus(null);
         setLocalSuccess('Permissions are up to date.');
         setTimeout(() => {


### PR DESCRIPTION
# Description

Bug fix. We would submit an empty object when no changes to the exiting policy permissions had been made. The `contracts-sdk` didn't like this, since it doesn't know what to do with an empty object (nothing). 

Added a check on submission, where if nothing in the policies has changed, then nothing happens:
<img width="528" height="605" alt="image" src="https://github.com/user-attachments/assets/109060af-70f7-4138-aae7-0f6fe133cd8a" />

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Locally

# Checklist:

- [ ] I created a [release plan](https://nx.dev/recipes/nx-release/file-based-versioning-version-plans) (`nx release plan`) describing my changes and the version bump
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
