### PR TITLE
fix(dashboard): atomic saving of authentication info

### DIFF
--- a/packages/apps/app-dashboard/src/components/user-dashboard/auth/ConnectMethods.tsx
+++ b/packages/apps/app-dashboard/src/components/user-dashboard/auth/ConnectMethods.tsx
@@ -8,7 +8,12 @@ import EthWalletAuth from './EthWalletAuth';
 
 interface ConnectProps {
   authWithWebAuthn: (credentialId: string, userId: string) => Promise<void>;
-  authWithStytch: (sessionJwt: string, userId: string, method: 'email' | 'phone') => Promise<void>;
+  authWithStytch: (
+    sessionJwt: string,
+    userId: string,
+    method: 'email' | 'phone',
+    userValue: string,
+  ) => Promise<void>;
   authWithEthWallet: (
     address: string,
     signMessage: (message: string) => Promise<string>,

--- a/packages/apps/app-dashboard/src/components/user-dashboard/auth/EthWalletAuth.tsx
+++ b/packages/apps/app-dashboard/src/components/user-dashboard/auth/EthWalletAuth.tsx
@@ -3,7 +3,6 @@ import { createAppKit } from '@reown/appkit/react';
 import { WagmiAdapter } from '@reown/appkit-adapter-wagmi';
 import { mainnet, polygon, arbitrum, optimism, base, AppKitNetwork } from '@reown/appkit/networks';
 import { useAccount, useSignMessage, useDisconnect } from 'wagmi';
-import { useSetAuthInfo } from '../../../hooks/user-dashboard/useAuthInfo';
 import { Button } from '@/components/shared/ui/button';
 import { ThemeType } from '../connect/ui/theme';
 import StatusMessage from '../connect/StatusMessage';
@@ -25,7 +24,6 @@ export default function EthWalletAuth({ authWithEthWallet, setView, theme }: Wal
   const { address, isConnected } = useAccount();
   const { signMessageAsync } = useSignMessage();
   const { disconnect } = useDisconnect();
-  const { setAuthInfo } = useSetAuthInfo();
   const appKitRef = useRef<any>(null);
 
   const { VITE_WALLETCONNECT_PROJECT_ID, VITE_DASHBOARD_URL } = env;
@@ -88,16 +86,6 @@ export default function EthWalletAuth({ authWithEthWallet, setView, theme }: Wal
       };
 
       await authWithEthWallet(address, signMessage);
-
-      try {
-        setAuthInfo({
-          type: 'wallet',
-          value: address,
-          authenticatedAt: new Date().toISOString(),
-        });
-      } catch (storageError) {
-        console.error('Error storing wallet auth info in localStorage:', storageError);
-      }
     } catch (err: any) {
       console.error('Error authenticating with wallet:', err);
       let errorMessage = 'Failed to authenticate with wallet. Please try again.';

--- a/packages/apps/app-dashboard/src/components/user-dashboard/auth/StytchOTP.tsx
+++ b/packages/apps/app-dashboard/src/components/user-dashboard/auth/StytchOTP.tsx
@@ -1,6 +1,5 @@
 import { useState } from 'react';
 import { useStytch } from '@stytch/react';
-import { useSetAuthInfo } from '../../../hooks/user-dashboard/useAuthInfo';
 import { z } from 'zod';
 import { Button } from '@/components/shared/ui/button';
 import { ThemeType } from '../connect/ui/theme';
@@ -38,7 +37,6 @@ const StytchOTP = ({ method, authWithStytch, setView, theme }: StytchOTPProps) =
   const [countryName, setCountryName] = useState<string>('United States');
   const [phoneNumber, setPhoneNumber] = useState<string>('');
   const stytchClient = useStytch();
-  const { setAuthInfo } = useSetAuthInfo();
 
   // Handle phone number changes and combine with country code
   const handlePhoneChange = (value: string) => {
@@ -167,18 +165,7 @@ const StytchOTP = ({ method, authWithStytch, setView, theme }: StytchOTPProps) =
         session_duration_minutes: 60,
       });
 
-      try {
-        setAuthInfo({
-          type: method,
-          value: userId,
-          userId: response.user_id,
-          authenticatedAt: new Date().toISOString(),
-        });
-      } catch (storageError) {
-        console.error('Error storing auth info in localStorage:', storageError);
-      }
-
-      await authWithStytch(response.session_jwt, response.user_id, method);
+      await authWithStytch(response.session_jwt, response.user_id, method, userId);
     } catch (err: any) {
       console.error(`Error authenticating with ${method} OTP:`, err);
       let errorMessage = 'Failed to verify code. Please try again.';

--- a/packages/apps/app-dashboard/src/components/user-dashboard/auth/WebAuthn.tsx
+++ b/packages/apps/app-dashboard/src/components/user-dashboard/auth/WebAuthn.tsx
@@ -1,5 +1,4 @@
 import { useState } from 'react';
-import { useSetAuthInfo } from '../../../hooks/user-dashboard/useAuthInfo';
 import { Button } from '@/components/shared/ui/button';
 import { ThemeType } from '../connect/ui/theme';
 import StatusMessage from '../connect/StatusMessage';
@@ -24,7 +23,6 @@ export default function WebAuthn({
   const [authLoading, setAuthLoading] = useState<boolean>(false);
   const [error, setError] = useState<string>('');
   const [passkeyName, setPasskeyName] = useState<string>('Vincent Passkey');
-  const { setAuthInfo } = useSetAuthInfo();
 
   const handleBackClick = () => {
     // Clear the error from the parent component when going back
@@ -81,17 +79,6 @@ export default function WebAuthn({
     setError('');
     try {
       await authWithWebAuthn();
-
-      // Store WebAuthn information in localStorage with a basic entry
-      // since the response is undefined
-      try {
-        setAuthInfo({
-          type: 'webauthn',
-          authenticatedAt: new Date().toISOString(),
-        });
-      } catch (storageError) {
-        console.error('Error storing WebAuthn info in localStorage:', storageError);
-      }
     } catch (err) {
       console.error(err);
       let errorMessage = '';

--- a/packages/apps/app-dashboard/src/hooks/user-dashboard/useAuthInfo.ts
+++ b/packages/apps/app-dashboard/src/hooks/user-dashboard/useAuthInfo.ts
@@ -46,9 +46,15 @@ export const useReadAuthInfo = (): ReadAuthInfo => {
           const parsedAuthInfo = JSON.parse(storedAuthInfo) as AuthInfo;
           setAuthInfo(parsedAuthInfo);
 
-          const sigs = await getValidSessionSigs();
-          if (sigs) {
-            setSessionSigs(sigs);
+          // Only try to get session sigs if we have a userPKP
+          if (parsedAuthInfo.userPKP) {
+            const sigs = await getValidSessionSigs();
+            if (sigs) {
+              setSessionSigs(sigs);
+            } else {
+              // If we have a userPKP but no valid session sigs, clear everything
+              await clearInfo();
+            }
           } else {
             setSessionSigs(null);
           }


### PR DESCRIPTION
# Description

Users ran into an issue when #315 was merged, where their authentication state was broken since we would have part of the authentication information in localstorage (`lit-auth-info`, but not `userPKP`). This would create a race condition with `getValidSessionSigs()`, where we would have authentication information, but we wouldn't be able to generate valid session signatures. This caused the page to then continue, look for session signatures (they don't exist), and then put the users back on the authentication page.

This PR has two fixes:
- Added a conditional to `getValidSessionSigs()` where we only check when we have a `userPKP`. If we don't, it means our stored authentication information is corrupted, and we clear it. This is run immediately after attempting to get valid session signatures, so this serves to ensure that we're not storing stale authentication information if the session signature generation fails.
- It's also made the storing of authentication information atomic. I didn't like how we were partially storing and updating the authentication info, since there was no need and we have to manage partial updates and worry about inconsistent states and future user issues. Now for any AuthMethod, we'll store the information ONLY when we have the UserPKP and the authentication information together. Goodbye race conditions, weird auth states, and partial updates!

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Tested locally using all AuthMethods. 

# Checklist:

- [ ] I created a [release plan](https://nx.dev/recipes/nx-release/file-based-versioning-version-plans) (`nx release plan`) describing my changes and the version bump
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
