### PR TITLE
Add new `isDelegateePermitted` function to `VincentUserViewFacet`

### DIFF
--- a/.nx/version-plans/version-plan-1758245236765.md
+++ b/.nx/version-plans/version-plan-1758245236765.md
@@ -1,0 +1,5 @@
+---
+contracts-sdk: minor
+---
+
+Add new isDelegateePermitted function that returns a boolean representing whether a given Delegatee is permitted to execute a Vincent Ability using a given Agent Wallet PKP

--- a/packages/libs/contracts-sdk/abis/VincentUserViewFacet.abi.json
+++ b/packages/libs/contracts-sdk/abis/VincentUserViewFacet.abi.json
@@ -269,6 +269,35 @@
   },
   {
     "type": "function",
+    "name": "isDelegateePermitted",
+    "inputs": [
+      {
+        "name": "delegatee",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "pkpTokenId",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "abilityIpfsCid",
+        "type": "string",
+        "internalType": "string"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "isPermitted",
+        "type": "bool",
+        "internalType": "bool"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
     "name": "validateAbilityExecutionAndGetPolicies",
     "inputs": [
       {

--- a/packages/libs/contracts-sdk/contracts/VincentDiamond.sol
+++ b/packages/libs/contracts-sdk/contracts/VincentDiamond.sol
@@ -215,7 +215,7 @@ contract VincentDiamond {
     }
 
     function getVincentUserViewFacetSelectors() internal pure returns (bytes4[] memory) {
-        bytes4[] memory selectors = new bytes4[](9);
+        bytes4[] memory selectors = new bytes4[](10);
         selectors[0] = VincentUserViewFacet.getAllRegisteredAgentPkps.selector;
         selectors[1] = VincentUserViewFacet.getPermittedAppVersionForPkp.selector;
         selectors[2] = VincentUserViewFacet.getAllPermittedAppIdsForPkp.selector;
@@ -225,6 +225,7 @@ contract VincentDiamond {
         selectors[6] = VincentUserViewFacet.getLastPermittedAppVersionForPkp.selector;
         selectors[7] = VincentUserViewFacet.getUnpermittedAppsForPkps.selector;
         selectors[8] = bytes4(keccak256("AGENT_PAGE_SIZE()"));
+        selectors[9] = VincentUserViewFacet.isDelegateePermitted.selector;
         return selectors;
     }
 

--- a/packages/libs/contracts-sdk/script/UpdateFacet.sol
+++ b/packages/libs/contracts-sdk/script/UpdateFacet.sol
@@ -310,7 +310,7 @@ contract SmartUpdateFacet is Script {
     }
 
     function getVincentUserViewFacetSelectors() internal pure returns (bytes4[] memory) {
-        bytes4[] memory selectors = new bytes4[](9);
+        bytes4[] memory selectors = new bytes4[](10);
         selectors[0] = VincentUserViewFacet.getAllRegisteredAgentPkps.selector;
         selectors[1] = VincentUserViewFacet.getPermittedAppVersionForPkp.selector;
         selectors[2] = VincentUserViewFacet.getAllPermittedAppIdsForPkp.selector;
@@ -320,6 +320,7 @@ contract SmartUpdateFacet is Script {
         selectors[6] = VincentUserViewFacet.getLastPermittedAppVersionForPkp.selector;
         selectors[7] = VincentUserViewFacet.getUnpermittedAppsForPkps.selector;
         selectors[8] = bytes4(keccak256("AGENT_PAGE_SIZE()"));
+        selectors[9] = VincentUserViewFacet.isDelegateePermitted.selector;
         return selectors;
     }
 

--- a/packages/libs/contracts-sdk/src/contractClient.ts
+++ b/packages/libs/contracts-sdk/src/contractClient.ts
@@ -39,6 +39,7 @@ import {
   getPermittedAppsForPkps as _getPermittedAppsForPkps,
   getLastPermittedAppVersionForPkp as _getLastPermittedAppVersionForPkp,
   getUnpermittedAppsForPkps as _getUnpermittedAppsForPkps,
+  isDelegateePermitted as _isDelegateePermitted,
 } from './internal/user/UserView';
 import { createContract } from './utils';
 
@@ -91,6 +92,7 @@ export function clientFromContract({ contract }: { contract: Contract }): Contra
       _getAllAbilitiesAndPoliciesForApp({ contract, args: params }),
     validateAbilityExecutionAndGetPolicies: (params) =>
       _validateAbilityExecutionAndGetPolicies({ contract, args: params }),
+    isDelegateePermitted: (params) => _isDelegateePermitted({ contract, args: params }),
     getLastPermittedAppVersionForPkp: (params) =>
       _getLastPermittedAppVersionForPkp({ contract, args: params }),
     getUnpermittedAppsForPkps: (params) => _getUnpermittedAppsForPkps({ contract, args: params }),

--- a/packages/libs/contracts-sdk/src/index.ts
+++ b/packages/libs/contracts-sdk/src/index.ts
@@ -12,6 +12,7 @@ export type {
   RegisterNextVersionParams,
   RegisterAppParams,
   ValidateAbilityExecutionAndGetPoliciesParams,
+  IsDelegateePermittedParams,
   GetDelegatedPkpEthAddressesParams,
   GetAllAbilitiesAndPoliciesForAppParams,
   GetAllPermittedAppIdsForPkpParams,

--- a/packages/libs/contracts-sdk/src/internal/user/UserView.ts
+++ b/packages/libs/contracts-sdk/src/internal/user/UserView.ts
@@ -14,6 +14,7 @@ import type {
   GetAllAbilitiesAndPoliciesForAppOptions,
   GetPermittedAppsForPkpsOptions,
   ValidateAbilityExecutionAndGetPoliciesOptions,
+  IsDelegateePermittedOptions,
   GetLastPermittedAppVersionOptions,
   GetUnpermittedAppsForPkpsOptions,
   ContractPkpPermittedApps,
@@ -251,5 +252,27 @@ export async function getUnpermittedAppsForPkps(
   } catch (error: unknown) {
     const decodedError = decodeContractError(error, contract);
     throw new Error(`Failed to Get Unpermitted Apps For PKPs: ${decodedError}`);
+  }
+}
+
+export async function isDelegateePermitted(params: IsDelegateePermittedOptions): Promise<boolean> {
+  const {
+    contract,
+    args: { delegateeAddress, pkpEthAddress, abilityIpfsCid },
+  } = params;
+
+  try {
+    const pkpTokenId = await getPkpTokenId({ pkpEthAddress, signer: contract.signer });
+
+    const isPermitted: boolean = await contract.isDelegateePermitted(
+      delegateeAddress,
+      pkpTokenId,
+      abilityIpfsCid,
+    );
+
+    return isPermitted;
+  } catch (error: unknown) {
+    const decodedError = decodeContractError(error, contract);
+    throw new Error(`Failed to Check If Delegatee Is Permitted: ${decodedError}`);
   }
 }

--- a/packages/libs/contracts-sdk/src/internal/user/types.ts
+++ b/packages/libs/contracts-sdk/src/internal/user/types.ts
@@ -13,6 +13,7 @@ import type {
   SetAbilityPolicyParametersParams,
   UnPermitAppParams,
   ValidateAbilityExecutionAndGetPoliciesParams,
+  IsDelegateePermittedParams,
 } from '../../types';
 import type { BaseOptions, BaseWritableOptions } from '../types/options';
 
@@ -108,6 +109,15 @@ export interface GetPermittedAppsForPkpsOptions extends BaseOptions {
  * */
 export interface ValidateAbilityExecutionAndGetPoliciesOptions extends BaseOptions {
   args: ValidateAbilityExecutionAndGetPoliciesParams;
+}
+
+/**
+ * @category Interfaces
+ * @inline
+ * @expand
+ * */
+export interface IsDelegateePermittedOptions extends BaseOptions {
+  args: IsDelegateePermittedParams;
 }
 
 /**

--- a/packages/libs/contracts-sdk/src/types.ts
+++ b/packages/libs/contracts-sdk/src/types.ts
@@ -33,6 +33,7 @@ import type {
   getPermittedAppsForPkps as _getPermittedAppsForPkps,
   getUnpermittedAppsForPkps as _getUnpermittedAppsForPkps,
   validateAbilityExecutionAndGetPolicies as _validateAbilityExecutionAndGetPolicies,
+  isDelegateePermitted as _isDelegateePermitted,
 } from './internal/user/UserView';
 
 /**
@@ -337,6 +338,15 @@ export interface ValidateAbilityExecutionAndGetPoliciesParams {
 /**
  * @category Interfaces
  * */
+export interface IsDelegateePermittedParams {
+  delegateeAddress: string;
+  pkpEthAddress: string;
+  abilityIpfsCid: string;
+}
+
+/**
+ * @category Interfaces
+ * */
 export interface GetLastPermittedAppVersionParams {
   pkpEthAddress: string;
   appId: number;
@@ -542,6 +552,14 @@ export interface ContractClient {
   validateAbilityExecutionAndGetPolicies(
     params: ValidateAbilityExecutionAndGetPoliciesParams,
   ): ReturnType<typeof _validateAbilityExecutionAndGetPolicies>;
+
+  /** Check if a delegatee is permitted to execute an ability with a PKP
+   *
+   * @returns Boolean indicating whether the delegatee has permission
+   */
+  isDelegateePermitted(
+    params: IsDelegateePermittedParams,
+  ): ReturnType<typeof _isDelegateePermitted>;
 
   /** Re-permits an app using the last permitted version for a PKP
    *

--- a/packages/libs/contracts-sdk/test/facets/VincentUserFacet.t.sol
+++ b/packages/libs/contracts-sdk/test/facets/VincentUserFacet.t.sol
@@ -293,6 +293,13 @@ contract VincentUserFacetTest is Test {
         assertEq(abilityExecutionValidation.policies[0].policyIpfsCid, POLICY_IPFS_CID_1);
         assertEq(abilityExecutionValidation.policies[0].policyParameterValues, POLICY_PARAMETER_VALUES_1);
 
+        bool isPermitted = vincentUserViewFacet.isDelegateePermitted(
+            APP_DELEGATEE_CHARLIE,
+            PKP_TOKEN_ID_1,
+            ABILITY_IPFS_CID_1
+        );
+        assertTrue(isPermitted);
+
         abilityExecutionValidation = vincentUserViewFacet.validateAbilityExecutionAndGetPolicies(
             APP_DELEGATEE_CHARLIE,
             PKP_TOKEN_ID_1,
@@ -302,6 +309,13 @@ contract VincentUserFacetTest is Test {
         assertEq(abilityExecutionValidation.appId, newAppId_1);
         assertEq(abilityExecutionValidation.appVersion, newAppVersion_1);
         assertEq(abilityExecutionValidation.policies.length, 0);
+
+        isPermitted = vincentUserViewFacet.isDelegateePermitted(
+            APP_DELEGATEE_CHARLIE,
+            PKP_TOKEN_ID_1,
+            ABILITY_IPFS_CID_2
+        );
+        assertTrue(isPermitted);
 
         abilityExecutionValidation = vincentUserViewFacet.validateAbilityExecutionAndGetPolicies(
             APP_DELEGATEE_DAVID,
@@ -315,6 +329,13 @@ contract VincentUserFacetTest is Test {
         assertEq(abilityExecutionValidation.policies[0].policyIpfsCid, POLICY_IPFS_CID_1);
         assertEq(abilityExecutionValidation.policies[0].policyParameterValues, POLICY_PARAMETER_VALUES_1);
 
+        isPermitted = vincentUserViewFacet.isDelegateePermitted(
+            APP_DELEGATEE_DAVID,
+            PKP_TOKEN_ID_1,
+            ABILITY_IPFS_CID_1
+        );
+        assertTrue(isPermitted);
+
         abilityExecutionValidation = vincentUserViewFacet.validateAbilityExecutionAndGetPolicies(
             APP_DELEGATEE_EVE,
             PKP_TOKEN_ID_2,
@@ -326,6 +347,13 @@ contract VincentUserFacetTest is Test {
         assertEq(abilityExecutionValidation.policies.length, 1);
         assertEq(abilityExecutionValidation.policies[0].policyIpfsCid, POLICY_IPFS_CID_1);
         assertEq(abilityExecutionValidation.policies[0].policyParameterValues, POLICY_PARAMETER_VALUES_1);
+
+        isPermitted = vincentUserViewFacet.isDelegateePermitted(
+            APP_DELEGATEE_EVE,
+            PKP_TOKEN_ID_2,
+            ABILITY_IPFS_CID_1
+        );
+        assertTrue(isPermitted);
     }
 
     function testUnPermitAppVersion() public {
@@ -424,6 +452,20 @@ contract VincentUserFacetTest is Test {
         );
         assertFalse(abilityExecutionValidation.isPermitted);
 
+        bool isPermitted = vincentUserViewFacet.isDelegateePermitted(
+            APP_DELEGATEE_CHARLIE,
+            PKP_TOKEN_ID_1,
+            ABILITY_IPFS_CID_1
+        );
+        assertFalse(isPermitted);
+
+        isPermitted = vincentUserViewFacet.isDelegateePermitted(
+            APP_DELEGATEE_CHARLIE,
+            PKP_TOKEN_ID_1,
+            ABILITY_IPFS_CID_2
+        );
+        assertFalse(isPermitted);
+
         // Verify ability execution validation for App 2 is still permitted  
         abilityExecutionValidation = vincentUserViewFacet.validateAbilityExecutionAndGetPolicies(
             APP_DELEGATEE_DAVID,
@@ -433,6 +475,13 @@ contract VincentUserFacetTest is Test {
         assertTrue(abilityExecutionValidation.isPermitted);
         assertEq(abilityExecutionValidation.appId, newAppId_2);
         assertEq(abilityExecutionValidation.appVersion, newAppVersion_2);
+
+        isPermitted = vincentUserViewFacet.isDelegateePermitted(
+            APP_DELEGATEE_DAVID,
+            PKP_TOKEN_ID_1,
+            ABILITY_IPFS_CID_1
+        );
+        assertTrue(isPermitted);
 
         // Test getUnpermittedAppsForPkps should show only App 1 as unpermitted
         uint256[] memory pkpTokenIds = new uint256[](1);
@@ -670,6 +719,13 @@ contract VincentUserFacetTest is Test {
         assertTrue(abilityExecutionValidation.isPermitted);
         assertEq(abilityExecutionValidation.policies.length, 1);
         assertEq(abilityExecutionValidation.policies[0].policyParameterValues, bytes("")); // Empty bytes after removal
+
+        bool isPermitted = vincentUserViewFacet.isDelegateePermitted(
+            APP_DELEGATEE_CHARLIE,
+            PKP_TOKEN_ID_1,
+            ABILITY_IPFS_CID_1
+        );
+        assertTrue(isPermitted);
     }
 
     /**

--- a/packages/libs/contracts-sdk/test/sdk.spec.ts
+++ b/packages/libs/contracts-sdk/test/sdk.spec.ts
@@ -407,6 +407,53 @@ describe('Vincent Contracts SDK E2E', () => {
       });
       expect(permittedVersion).toBe(TEST_CONFIG.appVersion);
     });
+
+    it('should validate delegatee permission using validateAbilityExecutionAndGetPolicies', async () => {
+      const validationResult = await USER_CLIENT.validateAbilityExecutionAndGetPolicies({
+        delegateeAddress: DELEGATEE_ADDRESS,
+        pkpEthAddress: TEST_CONFIG.userPkp!.ethAddress!,
+        abilityIpfsCid: ABILITY_IPFS_CIDS[0],
+      });
+
+      expect(validationResult).toBeDefined();
+      expect(validationResult.isPermitted).toBe(true);
+      expect(validationResult.appId).toBe(TEST_CONFIG.appId!);
+      expect(validationResult.appVersion).toBe(TEST_CONFIG.appVersion!);
+      expect(validationResult.decodedPolicies).toBeDefined();
+    });
+
+    it('should validate delegatee permission using isDelegateePermitted', async () => {
+      const isPermitted = await USER_CLIENT.isDelegateePermitted({
+        delegateeAddress: DELEGATEE_ADDRESS,
+        pkpEthAddress: TEST_CONFIG.userPkp!.ethAddress!,
+        abilityIpfsCid: ABILITY_IPFS_CIDS[0],
+      });
+
+      expect(isPermitted).toBe(true);
+    });
+
+    it('should return false for non-registered delegatee using isDelegateePermitted', async () => {
+      const nonRegisteredDelegatee = ethers.Wallet.createRandom().address;
+
+      await expect(
+        USER_CLIENT.isDelegateePermitted({
+          delegateeAddress: nonRegisteredDelegatee,
+          pkpEthAddress: TEST_CONFIG.userPkp!.ethAddress!,
+          abilityIpfsCid: ABILITY_IPFS_CIDS[0],
+        }),
+      ).rejects.toThrow('DelegateeNotAssociatedWithApp');
+    });
+
+    it('should return false for invalid ability IPFS CID using isDelegateePermitted', async () => {
+      const nonExistentAbility = 'QmInvalidAbilityCid123456789';
+      const isPermitted = await USER_CLIENT.isDelegateePermitted({
+        delegateeAddress: DELEGATEE_ADDRESS,
+        pkpEthAddress: TEST_CONFIG.userPkp!.ethAddress!,
+        abilityIpfsCid: nonExistentAbility,
+      });
+
+      expect(isPermitted).toBe(false);
+    });
   });
 
   describe('App Lifecycle', () => {


### PR DESCRIPTION
# Description

Addresses [this issue](https://linear.app/litprotocol/issue/DREL-1092/error-processing-delegated-wks-accs) and implements the proposed solution.

`isDelegateePermitted` takes a Delegatee ETH address, Agent Wallet PKP token ID, and an Ability IPFS CID and returns `bool` for whether or not that Delegatee is permitted to execute the Ability using the PKP

## Type of change
- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- New assertions calling `isDelegateePermitted` in existing facet Solidity tests
- New test cases added to contract SDK E2E tests

# Checklist:

- [x] I created a [release plan](https://nx.dev/recipes/nx-release/file-based-versioning-version-plans) (`nx release plan`) describing my changes and the version bump
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
