### PR TITLE
Fix Uniswap ability gas estimation

### DIFF
--- a/.nx/version-plans/version-plan-1758674330790.md
+++ b/.nx/version-plans/version-plan-1758674330790.md
@@ -1,0 +1,5 @@
+---
+ability-uniswap-swap: minor
+---
+
+Fix the logic used to estimate gas for Uniswap Swaps in Vincent Ability

--- a/packages/apps/ability-uniswap-swap/package.json
+++ b/packages/apps/ability-uniswap-swap/package.json
@@ -11,6 +11,7 @@
     "@uniswap/sdk-core": "^7.7.2",
     "@uniswap/smart-order-router": "^4.22.9",
     "ethers": "^5.8.0",
+    "ethers-v6": "npm:ethers@^6",
     "json-stable-stringify": "^1.3.0",
     "tslib": "2.8.1",
     "zod": "^3.25.64"

--- a/packages/apps/ability-uniswap-swap/src/generated/vincent-ability-metadata.json
+++ b/packages/apps/ability-uniswap-swap/src/generated/vincent-ability-metadata.json
@@ -1,3 +1,3 @@
 {
-  "ipfsCid": "QmTMKwJU61HgE7qqZtuAwproKYJekU1vRGuyPKRQTtpB7a"
+  "ipfsCid": "QmU9pDNzhktpvc2uNpAENY9UryXevtnd8eaLMNfdpqRqgw"
 }

--- a/packages/apps/ability-uniswap-swap/src/generated/vincent-ability-metadata.json
+++ b/packages/apps/ability-uniswap-swap/src/generated/vincent-ability-metadata.json
@@ -1,3 +1,3 @@
 {
-  "ipfsCid": "QmdcQbrTwXkF5VCGXsHegZrWFPrHeaUNGnPsf45iWuCv2a"
+  "ipfsCid": "QmTMKwJU61HgE7qqZtuAwproKYJekU1vRGuyPKRQTtpB7a"
 }

--- a/packages/apps/ability-uniswap-swap/src/lib/ability-helpers/get-gas-params.ts
+++ b/packages/apps/ability-uniswap-swap/src/lib/ability-helpers/get-gas-params.ts
@@ -14,18 +14,18 @@ interface Eip1559GasParams {
 }
 
 const DEFAULT_GAS_LIMIT_BUFFER = 50; // adding 50% buffer to the estimated gas
-const DEFAULT_HEADROOM_MULTIPLIER = 2; // maxFee = base * 2 + tip
+const DEFAULT_BASE_FEE_PER_GAS_MULTIPLIER = 2; // maxFee = base * 2 + tip
 
 export const getGasParams = async ({
   rpcUrl,
   estimatedGas,
   gasLimitBuffer = DEFAULT_GAS_LIMIT_BUFFER,
-  headroomMultiplier = DEFAULT_HEADROOM_MULTIPLIER,
+  baseFeePerGasMultiplier = DEFAULT_BASE_FEE_PER_GAS_MULTIPLIER,
 }: {
   rpcUrl: string;
   estimatedGas: string;
   gasLimitBuffer?: number;
-  headroomMultiplier?: number;
+  baseFeePerGasMultiplier?: number;
 }): Promise<GasParams> => {
   const provider = new JsonRpcProvider(rpcUrl);
 
@@ -41,10 +41,10 @@ export const getGasParams = async ({
      *
      * For example:
      *  gasLimitBuffer = 50 → 5000 (meaning 50.00%)
-     *  headroomMultiplier = 1.5 → 150 (meaning 1.50×)
+     *  baseFeePerGasMultiplier = 1.5 → 150 (meaning 1.50×)
      */
     const gasLimitBufferScaled = BigInt(Math.round(gasLimitBuffer * 100)); // e.g. 50 -> 5000
-    const headroomMultiplierScaled = BigInt(Math.round(headroomMultiplier * 100)); // e.g. 1.5 -> 150
+    const baseFeePerGasMultiplierScaled = BigInt(Math.round(baseFeePerGasMultiplier * 100)); // e.g. 1.5 -> 150
     const SCALE = 100n;
 
     /**
@@ -79,10 +79,10 @@ export const getGasParams = async ({
     const isEip1559Network = baseFee != null || maxFee != null || priority != null;
 
     if (isEip1559Network) {
-      // Prefer maxFee provided by the provider, otherwise compute with headroomMultiplier: base * headroomMultiplier + tip
+      // Prefer maxFee provided by the provider, otherwise compute with baseFeePerGasMultiplier: base * baseFeePerGasMultiplier + tip
       let computedMaxFee = maxFee;
       if (!computedMaxFee && baseFee != null && priority != null) {
-        computedMaxFee = (baseFee * headroomMultiplierScaled) / SCALE + priority;
+        computedMaxFee = (baseFee * baseFeePerGasMultiplierScaled) / SCALE + priority;
       }
 
       if (priority == null || computedMaxFee == null) {

--- a/packages/apps/ability-uniswap-swap/src/lib/ability-helpers/get-gas-params.ts
+++ b/packages/apps/ability-uniswap-swap/src/lib/ability-helpers/get-gas-params.ts
@@ -1,43 +1,112 @@
-import { ethers } from 'ethers';
+import { formatUnits, JsonRpcProvider } from 'ethers-v6';
 
-export interface GasParams {
-  estimatedGas: ethers.BigNumber;
-  maxFeePerGas: ethers.BigNumber;
-  maxPriorityFeePerGas: ethers.BigNumber;
+export type GasParams = LegacyGasParams | Eip1559GasParams;
+
+interface LegacyGasParams {
+  gasPrice: string; // in wei
+  estimatedGas: string;
 }
 
-export const getGasParams = async (
-  provider: ethers.providers.Provider,
-  estimatedGas: ethers.BigNumber,
-): Promise<GasParams> => {
-  // Fetch block and fee data
-  const [block, feeData] = await Promise.all([provider.getBlock('latest'), provider.getFeeData()]);
-  // Determine baseFeePerGas, with multiple fallbacks
-  let baseFeePerGas = block.baseFeePerGas;
-  if (baseFeePerGas == null) {
-    // Fallback to feeData.gasPrice if available
-    baseFeePerGas = feeData && feeData.gasPrice ? feeData.gasPrice : await provider.getGasPrice();
+interface Eip1559GasParams {
+  maxFeePerGas: string; // in wei
+  maxPriorityFeePerGas: string; // in wei
+  estimatedGas: string;
+}
+
+const DEFAULT_GAS_LIMIT_BUFFER = 50; // adding 50% buffer to the estimated gas
+const DEFAULT_HEADROOM_MULTIPLIER = 2; // maxFee = base * 2 + tip
+
+export const getGasParams = async ({
+  rpcUrl,
+  estimatedGas,
+  gasLimitBuffer = DEFAULT_GAS_LIMIT_BUFFER,
+  headroomMultiplier = DEFAULT_HEADROOM_MULTIPLIER,
+}: {
+  rpcUrl: string;
+  estimatedGas: string;
+  gasLimitBuffer?: number;
+  headroomMultiplier?: number;
+}): Promise<GasParams> => {
+  const provider = new JsonRpcProvider(rpcUrl);
+
+  try {
+    const [feeData, block] = await Promise.all([
+      provider.getFeeData(),
+      provider.getBlock('latest'),
+    ]);
+
+    /**
+     * BigInt doesn't support decimals, so we scale percentage/multiplier inputs by 100 and work entirely in integers.
+     * When applying, we divide by SCALE to get the correct decimal.
+     *
+     * For example:
+     *  gasLimitBuffer = 50 → 5000 (meaning 50.00%)
+     *  headroomMultiplier = 1.5 → 150 (meaning 1.50×)
+     */
+    const gasLimitBufferScaled = BigInt(Math.round(gasLimitBuffer * 100)); // e.g. 50 -> 5000
+    const headroomMultiplierScaled = BigInt(Math.round(headroomMultiplier * 100)); // e.g. 1.5 -> 150
+    const SCALE = 100n;
+
+    /**
+     * We scale everything by SCALE so floats like 37.5% become integers (e.g. 3750).
+     * (100n * SCALE + gasLimitBufferScaled) gives us (100% + buffer%).
+     *
+     * Multiplying estimatedGas by that factor and dividing by (100 * SCALE)
+     * applies the percentage increase while staying in integer math with BigInt.
+     *
+     * Example: estimatedGas=21000, buffer=50 → (21000 * 15000) / 10000 = 31500.
+     */
+    const estimatedGasWithBuffer =
+      (BigInt(estimatedGas) * (100n * SCALE + gasLimitBufferScaled)) / (100n * SCALE);
+
+    const gasPrice = feeData.gasPrice ?? null;
+    const maxFee = feeData.maxFeePerGas ?? null;
+    const priority = feeData.maxPriorityFeePerGas ?? null;
+    const baseFee = block?.baseFeePerGas ?? null;
+
+    console.log('[getGasParams] v6 feeData:', {
+      gasPrice: gasPrice ? `${formatUnits(gasPrice, 'gwei')} gwei` : null,
+      maxFeePerGas: maxFee ? `${formatUnits(maxFee, 'gwei')} gwei` : null,
+      maxPriorityFeePerGas: priority ? `${formatUnits(priority, 'gwei')} gwei` : null,
+    });
+    console.log(
+      '[getGasParams] v6 block baseFeePerGas:',
+      baseFee ? `${formatUnits(baseFee, 'gwei')} gwei` : null,
+    );
+    console.log('[getGasParams] estimatedGasWithBuffer:', estimatedGasWithBuffer.toString());
+
+    // Check if this is an EIP-1559 network (has baseFee or EIP-1559 fee data)
+    const isEip1559Network = baseFee != null || maxFee != null || priority != null;
+
+    if (isEip1559Network) {
+      // Prefer maxFee provided by the provider, otherwise compute with headroomMultiplier: base * headroomMultiplier + tip
+      let computedMaxFee = maxFee;
+      if (!computedMaxFee && baseFee != null && priority != null) {
+        computedMaxFee = (baseFee * headroomMultiplierScaled) / SCALE + priority;
+      }
+
+      if (priority == null || computedMaxFee == null) {
+        throw new Error('EIP-1559 detected but missing required fee fields');
+      }
+
+      return {
+        maxFeePerGas: computedMaxFee.toString(),
+        maxPriorityFeePerGas: priority.toString(),
+        estimatedGas: estimatedGasWithBuffer.toString(),
+      };
+    }
+
+    // Legacy transaction path
+    if (gasPrice == null) {
+      throw new Error('Legacy transaction detected but gasPrice is missing in feeData');
+    }
+
+    return {
+      gasPrice: gasPrice.toString(),
+      estimatedGas: estimatedGasWithBuffer.toString(),
+    };
+  } finally {
+    // Clean up provider to prevent open handles
+    provider.destroy();
   }
-  // Final fallback to a nominal value if still null
-  if (baseFeePerGas == null) {
-    baseFeePerGas = ethers.utils.parseUnits('1', 'gwei');
-  }
-
-  // Determine the maxPriorityFeePerGas, using a dynamic value if available; otherwise, fallback
-  const maxPriorityFeePerGas =
-    feeData && feeData.maxPriorityFeePerGas
-      ? feeData.maxPriorityFeePerGas
-      : ethers.utils.parseUnits('1.5', 'gwei');
-
-  // Calculate maxFeePerGas as the sum of baseFee and priority fee
-  const maxFeePerGas = baseFeePerGas.add(maxPriorityFeePerGas);
-
-  // Add a 50% buffer to the estimated gas limit for complex swaps
-  const estimatedGasWithBuffer = estimatedGas.mul(150).div(100);
-
-  return {
-    estimatedGas: estimatedGasWithBuffer,
-    maxFeePerGas,
-    maxPriorityFeePerGas,
-  };
 };

--- a/packages/apps/ability-uniswap-swap/src/lib/ability-helpers/send-uniswap-tx.ts
+++ b/packages/apps/ability-uniswap-swap/src/lib/ability-helpers/send-uniswap-tx.ts
@@ -80,10 +80,9 @@ export const sendUniswapTx = async ({
 
         // Use getGasParams helper which handles block/feeData fetching and applies 50% buffer
         const gasParams = await getGasParams({
+          ...transactionOptions,
           rpcUrl,
           estimatedGas: uniswapTxData.estimatedGasUsed,
-          gasLimitBuffer: transactionOptions?.gasLimitBuffer,
-          headroomMultiplier: transactionOptions?.headroomMultiplier,
         });
 
         const partialSwapTx: PartialSwapTx = {

--- a/packages/apps/ability-uniswap-swap/src/lib/schemas.ts
+++ b/packages/apps/ability-uniswap-swap/src/lib/schemas.ts
@@ -29,6 +29,23 @@ export const abilityParamsSchema = z.object({
       signature: z.string().describe('The signature of the Uniswap quote'),
     })
     .describe('Signed Uniswap quote from Prepare Lit Action'),
+  transactionOptions: z
+    .object({
+      gasLimitBuffer: z
+        .number()
+        .optional()
+        .describe(
+          'Extra percentage added to the estimated gas limit to reduce risk of out-of-gas errors. Defaults to 50 (i.e. 50%).',
+        ),
+      headroomMultiplier: z
+        .number()
+        .optional()
+        .describe(
+          'Multiplier applied to the base fee when computing maxFeePerGas, ensuring the tx remains valid if base fees rise before inclusion. Defaults to 2.',
+        ),
+    })
+    .optional()
+    .describe('Optional overrides for gasLimit and maxFeePerGas calculation behavior'),
 });
 
 export const precheckFailSchema = z.object({

--- a/packages/apps/ability-uniswap-swap/src/lib/schemas.ts
+++ b/packages/apps/ability-uniswap-swap/src/lib/schemas.ts
@@ -37,7 +37,7 @@ export const abilityParamsSchema = z.object({
         .describe(
           'Extra percentage added to the estimated gas limit to reduce risk of out-of-gas errors. Defaults to 50 (i.e. 50%).',
         ),
-      headroomMultiplier: z
+      baseFeePerGasMultiplier: z
         .number()
         .optional()
         .describe(

--- a/packages/apps/ability-uniswap-swap/src/lib/vincent-ability.ts
+++ b/packages/apps/ability-uniswap-swap/src/lib/vincent-ability.ts
@@ -103,7 +103,7 @@ export const vincentAbility = createVincentAbility({
   execute: async ({ abilityParams }, { succeed, fail, delegation: { delegatorPkpInfo } }) => {
     console.log('Executing UniswapSwapAbility', JSON.stringify(abilityParams, bigintReplacer, 2));
 
-    const { rpcUrlForUniswap, signedUniswapQuote } = abilityParams;
+    const { rpcUrlForUniswap, signedUniswapQuote, transactionOptions } = abilityParams;
     const { quote } = signedUniswapQuote;
 
     try {
@@ -128,6 +128,7 @@ export const vincentAbility = createVincentAbility({
         calldata: quote.calldata,
         estimatedGasUsed: quote.estimatedGasUsed,
       },
+      transactionOptions,
     });
 
     return succeed({ swapTxHash });

--- a/packages/apps/ability-uniswap-swap/test/integration/get-gas-params.spec.ts
+++ b/packages/apps/ability-uniswap-swap/test/integration/get-gas-params.spec.ts
@@ -1,0 +1,323 @@
+import { Block, FeeData, JsonRpcProvider, formatUnits } from 'ethers-v6';
+
+import { getGasParams } from '../../src/lib/ability-helpers';
+import { BASE_RPC_URL } from '../helpers/test-variables';
+
+// Extend Jest timeout to 30 seconds for live RPC
+jest.setTimeout(30000);
+
+describe('getGasParams (live and mocked)', () => {
+  describe('live: Base network', () => {
+    it('should fetch real EIP-1559 gas params from Base network and apply buffer', async () => {
+      const estimatedGas = '100000'; // gas units
+      const result = await getGasParams({ rpcUrl: BASE_RPC_URL, estimatedGas });
+
+      // Basic structure checks
+      expect(result).toBeDefined();
+      expect(typeof result.estimatedGas).toBe('string');
+
+      // Buffer check: default is 50% => estimated * 1.5
+      const expectedBuffered = (BigInt(estimatedGas) * 150n) / 100n;
+      expect(BigInt(result.estimatedGas)).toBe(expectedBuffered);
+
+      if ('gasPrice' in result) {
+        // Legacy path (unlikely on Base, but assert if it happens)
+        expect(typeof result.gasPrice).toBe('string');
+        expect(BigInt(result.gasPrice) > 0n).toBe(true);
+
+        // Logging (human-readable)
+        console.log('[live: Base network] Gas Params (legacy):', {
+          estimatedGas: result.estimatedGas,
+          gasPriceGwei: formatUnits(result.gasPrice, 'gwei') + ' gwei',
+        });
+      } else {
+        // EIP-1559 path (expected on Base)
+        expect(typeof result.maxFeePerGas).toBe('string');
+        expect(typeof result.maxPriorityFeePerGas).toBe('string');
+        expect(BigInt(result.maxFeePerGas) > 0n).toBe(true);
+        expect(BigInt(result.maxPriorityFeePerGas) > 0n).toBe(true);
+
+        // Sanity: cap >= tip
+        expect(BigInt(result.maxFeePerGas) >= BigInt(result.maxPriorityFeePerGas)).toBe(true);
+
+        // Logging (human-readable)
+        console.log('[live: Base network] Gas Params (eip1559):', {
+          estimatedGas: result.estimatedGas,
+          maxFeePerGasGwei: formatUnits(result.maxFeePerGas, 'gwei') + ' gwei',
+          maxPriorityFeePerGasGwei: formatUnits(result.maxPriorityFeePerGas, 'gwei') + ' gwei',
+        });
+      }
+    });
+  });
+
+  describe('mocked: deterministic behavior', () => {
+    let feeDataSpy: jest.SpyInstance<Promise<FeeData>>;
+    let blockSpy: jest.SpyInstance;
+
+    beforeEach(() => {
+      feeDataSpy = jest.spyOn(JsonRpcProvider.prototype, 'getFeeData');
+      blockSpy = jest.spyOn(JsonRpcProvider.prototype, 'getBlock');
+    });
+
+    afterEach(() => {
+      jest.clearAllMocks();
+      jest.restoreAllMocks();
+    });
+
+    it('EIP-1559: computes cap as base * headroom + tip when provider maxFeePerGas is null', async () => {
+      const baseFee = 1_000_000_000n; // 1 gwei
+      const priority = 1_000_000n; // 0.001 gwei
+
+      feeDataSpy.mockResolvedValue({
+        gasPrice: null,
+        maxFeePerGas: null,
+        maxPriorityFeePerGas: priority,
+        toJSON: () => ({}),
+      } as FeeData);
+
+      blockSpy.mockResolvedValue({
+        baseFeePerGas: baseFee,
+        number: 123456,
+        hash: '0x123',
+      } as Block);
+
+      const estimatedGas = '21000';
+      const result = await getGasParams({
+        rpcUrl: 'http://mock.rpc',
+        estimatedGas,
+      });
+
+      // Assert buffer: 21000 * 1.5 = 31500
+      expect(result.estimatedGas).toBe('31500');
+
+      // EIP-1559 branch
+      expect('maxFeePerGas' in result).toBe(true);
+      if ('maxFeePerGas' in result) {
+        const expectedCap = baseFee * 2n + priority; // default headroom is 2x
+        expect(result.maxFeePerGas).toBe(expectedCap.toString());
+        expect(result.maxPriorityFeePerGas).toBe(priority.toString());
+        expect(BigInt(result.maxFeePerGas) >= BigInt(result.maxPriorityFeePerGas)).toBe(true);
+      }
+    });
+
+    it('EIP-1559: uses provider maxFeePerGas when available', async () => {
+      const maxFee = 5_000_000_000n; // 5 gwei
+      const priority = 1_500_000_000n; // 1.5 gwei
+
+      feeDataSpy.mockResolvedValue({
+        gasPrice: null,
+        maxFeePerGas: maxFee,
+        maxPriorityFeePerGas: priority,
+        toJSON: () => ({}),
+      } as FeeData);
+
+      blockSpy.mockResolvedValue({
+        baseFeePerGas: 2_000_000_000n, // 2 gwei (ignored when maxFee is provided)
+        number: 123456,
+        hash: '0x123',
+      } as Block);
+
+      const estimatedGas = '42000';
+      const result = await getGasParams({
+        rpcUrl: 'http://mock.rpc',
+        estimatedGas,
+      });
+
+      // Assert buffer: 42000 * 1.5 = 63000
+      expect(result.estimatedGas).toBe('63000');
+
+      // Should use provider's maxFeePerGas directly
+      if ('maxFeePerGas' in result) {
+        expect(result.maxFeePerGas).toBe(maxFee.toString());
+        expect(result.maxPriorityFeePerGas).toBe(priority.toString());
+      }
+    });
+
+    it('EIP-1559: applies custom headroom multiplier', async () => {
+      const baseFee = 2_000_000_000n; // 2 gwei
+      const priority = 500_000_000n; // 0.5 gwei
+      const headroomMultiplier = 1.5; // 1.5x instead of default 2x
+
+      feeDataSpy.mockResolvedValue({
+        gasPrice: null,
+        maxFeePerGas: null,
+        maxPriorityFeePerGas: priority,
+        toJSON: () => ({}),
+      } as FeeData);
+
+      blockSpy.mockResolvedValue({
+        baseFeePerGas: baseFee,
+        number: 123456,
+        hash: '0x123',
+      } as Block);
+
+      const estimatedGas = '30000';
+      const result = await getGasParams({
+        rpcUrl: 'http://mock.rpc',
+        estimatedGas,
+        headroomMultiplier,
+      });
+
+      // Assert buffer: 30000 * 1.5 = 45000
+      expect(result.estimatedGas).toBe('45000');
+
+      if ('maxFeePerGas' in result) {
+        // baseFee * 1.5 + priority = 2 gwei * 1.5 + 0.5 gwei = 3.5 gwei
+        const expectedCap = 3_000_000_000n + priority;
+        expect(result.maxFeePerGas).toBe(expectedCap.toString());
+        expect(result.maxPriorityFeePerGas).toBe(priority.toString());
+      }
+    });
+
+    it('Legacy: returns gasPrice when EIP-1559 fields are unavailable', async () => {
+      const gasPrice = 20_000_000_000n; // 20 gwei
+
+      feeDataSpy.mockResolvedValue({
+        gasPrice,
+        maxFeePerGas: null,
+        maxPriorityFeePerGas: null,
+        toJSON: () => ({}),
+      } as FeeData);
+
+      blockSpy.mockResolvedValue(null);
+
+      const estimatedGas = '100000';
+      const result = await getGasParams({
+        rpcUrl: 'http://mock.rpc',
+        estimatedGas,
+        gasLimitBuffer: 25, // 25% buffer
+      });
+
+      // Buffer: 100000 * 1.25 = 125000
+      expect(result.estimatedGas).toBe('125000');
+
+      // Legacy branch
+      expect('gasPrice' in result).toBe(true);
+      if ('gasPrice' in result) {
+        expect(result.gasPrice).toBe(gasPrice.toString());
+        expect(BigInt(result.gasPrice) > 0n).toBe(true);
+      }
+    });
+
+    it('Legacy: throws error when gasPrice is null', async () => {
+      feeDataSpy.mockResolvedValue({
+        gasPrice: null,
+        maxFeePerGas: null,
+        maxPriorityFeePerGas: null,
+        toJSON: () => ({}),
+      } as FeeData);
+
+      blockSpy.mockResolvedValue(null);
+
+      const estimatedGas = '50000';
+
+      // Should throw an error when gas price cannot be determined
+      await expect(
+        getGasParams({
+          rpcUrl: 'http://mock.rpc',
+          estimatedGas,
+        }),
+      ).rejects.toThrow('Legacy transaction detected but gasPrice is missing in feeData');
+    });
+
+    it('throws error when EIP-1559 is detected but fields are missing', async () => {
+      // Has baseFee but missing priority fee
+      feeDataSpy.mockResolvedValue({
+        gasPrice: null,
+        maxFeePerGas: null,
+        maxPriorityFeePerGas: null, // missing
+        toJSON: () => ({}),
+      } as FeeData);
+
+      blockSpy.mockResolvedValue({
+        baseFeePerGas: 1_000_000_000n,
+        number: 123456,
+        hash: '0x123',
+      } as Block);
+
+      await expect(
+        getGasParams({
+          rpcUrl: 'http://mock.rpc',
+          estimatedGas: '21000',
+        }),
+      ).rejects.toThrow('EIP-1559 detected but missing required fee fields');
+    });
+  });
+
+  describe('edge cases', () => {
+    let feeDataSpy: jest.SpyInstance<Promise<FeeData>>;
+    let blockSpy: jest.SpyInstance;
+
+    beforeEach(() => {
+      feeDataSpy = jest.spyOn(JsonRpcProvider.prototype, 'getFeeData');
+      blockSpy = jest.spyOn(JsonRpcProvider.prototype, 'getBlock');
+    });
+
+    afterEach(() => {
+      jest.restoreAllMocks();
+    });
+
+    it('handles fractional buffer values correctly', async () => {
+      feeDataSpy.mockResolvedValue({
+        gasPrice: 10_000_000_000n,
+        maxFeePerGas: null,
+        maxPriorityFeePerGas: null,
+        toJSON: () => ({}),
+      } as FeeData);
+
+      blockSpy.mockResolvedValue(null);
+
+      const estimatedGas = '10000';
+      const gasLimitBuffer = 37.5; // 37.5% buffer
+
+      const result = await getGasParams({
+        rpcUrl: 'http://mock.rpc',
+        estimatedGas,
+        gasLimitBuffer,
+      });
+
+      // 10000 * 1.375 = 13750
+      expect(result.estimatedGas).toBe('13750');
+    });
+
+    it('handles very small gas estimates', async () => {
+      feeDataSpy.mockResolvedValue({
+        gasPrice: 1_000_000_000n,
+        maxFeePerGas: null,
+        maxPriorityFeePerGas: null,
+        toJSON: () => ({}),
+      } as FeeData);
+
+      blockSpy.mockResolvedValue(null);
+
+      const estimatedGas = '1';
+      const result = await getGasParams({
+        rpcUrl: 'http://mock.rpc',
+        estimatedGas,
+      });
+
+      // 1 * 1.5 = 1.5, rounded down to 1
+      expect(result.estimatedGas).toBe('1');
+    });
+
+    it('handles very large gas estimates', async () => {
+      feeDataSpy.mockResolvedValue({
+        gasPrice: 1_000_000_000n,
+        maxFeePerGas: null,
+        maxPriorityFeePerGas: null,
+        toJSON: () => ({}),
+      } as FeeData);
+
+      blockSpy.mockResolvedValue(null);
+
+      const estimatedGas = '10000000'; // 10 million
+      const result = await getGasParams({
+        rpcUrl: 'http://mock.rpc',
+        estimatedGas,
+      });
+
+      // 10000000 * 1.5 = 15000000
+      expect(result.estimatedGas).toBe('15000000');
+    });
+  });
+});

--- a/packages/apps/ability-uniswap-swap/test/integration/get-gas-params.spec.ts
+++ b/packages/apps/ability-uniswap-swap/test/integration/get-gas-params.spec.ts
@@ -64,7 +64,7 @@ describe('getGasParams (live and mocked)', () => {
       jest.restoreAllMocks();
     });
 
-    it('EIP-1559: computes cap as base * headroom + tip when provider maxFeePerGas is null', async () => {
+    it('EIP-1559: computes cap as base * baseFeePerGasMultiplier + tip when provider maxFeePerGas is null', async () => {
       const baseFee = 1_000_000_000n; // 1 gwei
       const priority = 1_000_000n; // 0.001 gwei
 
@@ -93,7 +93,7 @@ describe('getGasParams (live and mocked)', () => {
       // EIP-1559 branch
       expect('maxFeePerGas' in result).toBe(true);
       if ('maxFeePerGas' in result) {
-        const expectedCap = baseFee * 2n + priority; // default headroom is 2x
+        const expectedCap = baseFee * 2n + priority; // default baseFeePerGasMultiplier is 2x
         expect(result.maxFeePerGas).toBe(expectedCap.toString());
         expect(result.maxPriorityFeePerGas).toBe(priority.toString());
         expect(BigInt(result.maxFeePerGas) >= BigInt(result.maxPriorityFeePerGas)).toBe(true);
@@ -133,10 +133,10 @@ describe('getGasParams (live and mocked)', () => {
       }
     });
 
-    it('EIP-1559: applies custom headroom multiplier', async () => {
+    it('EIP-1559: applies custom baseFeePerGasMultiplier', async () => {
       const baseFee = 2_000_000_000n; // 2 gwei
       const priority = 500_000_000n; // 0.5 gwei
-      const headroomMultiplier = 1.5; // 1.5x instead of default 2x
+      const baseFeePerGasMultiplier = 1.5; // 1.5x instead of default 2x
 
       feeDataSpy.mockResolvedValue({
         gasPrice: null,
@@ -155,7 +155,7 @@ describe('getGasParams (live and mocked)', () => {
       const result = await getGasParams({
         rpcUrl: 'http://mock.rpc',
         estimatedGas,
-        headroomMultiplier,
+        baseFeePerGasMultiplier,
       });
 
       // Assert buffer: 30000 * 1.5 = 45000

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -466,6 +466,9 @@ importers:
       ethers:
         specifier: ^5.8.0
         version: 5.8.0(bufferutil@4.0.9)(utf-8-validate@5.0.10)
+      ethers-v6:
+        specifier: npm:ethers@^6
+        version: ethers@6.15.0(bufferutil@4.0.9)(utf-8-validate@5.0.10)
       json-stable-stringify:
         specifier: ^1.3.0
         version: 1.3.0
@@ -583,7 +586,7 @@ importers:
         version: 1.8.4(@types/react@19.1.12)(bufferutil@4.0.9)(react@19.1.1)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.64)
       '@reown/appkit-adapter-wagmi':
         specifier: ^1.7.18
-        version: 1.8.4(@types/react@19.1.12)(@wagmi/core@2.20.3(@tanstack/query-core@5.87.1)(@types/react@19.1.12)(immer@10.1.3)(react@19.1.1)(typescript@5.8.3)(use-sync-external-store@1.4.0(react@19.1.1))(viem@2.37.5(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.64)))(bufferutil@4.0.9)(immer@10.1.3)(react@19.1.1)(typescript@5.8.3)(use-sync-external-store@1.5.0(react@19.1.1))(utf-8-validate@5.0.10)(viem@2.37.5(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.64))(wagmi@2.16.9(@tanstack/query-core@5.87.1)(@tanstack/react-query@5.87.1(react@19.1.1))(@types/react@19.1.12)(bufferutil@4.0.9)(immer@10.1.3)(react@19.1.1)(typescript@5.8.3)(utf-8-validate@5.0.10)(viem@2.37.5(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.64))(zod@3.25.64))(zod@3.25.64)
+        version: 1.8.4(@types/react@19.1.12)(@wagmi/core@2.20.3(@tanstack/query-core@5.87.1)(@types/react@19.1.12)(immer@10.1.3)(react@19.1.1)(typescript@5.8.3)(use-sync-external-store@1.4.0(react@19.1.1))(viem@2.37.5(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.64)))(bufferutil@4.0.9)(immer@10.1.3)(react@19.1.1)(typescript@5.8.3)(use-sync-external-store@1.4.0(react@19.1.1))(utf-8-validate@5.0.10)(viem@2.37.5(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.64))(wagmi@2.16.9(@tanstack/query-core@5.87.1)(@tanstack/react-query@5.87.1(react@19.1.1))(@types/react@19.1.12)(bufferutil@4.0.9)(immer@10.1.3)(react@19.1.1)(typescript@5.8.3)(utf-8-validate@5.0.10)(viem@2.37.5(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.64))(zod@3.25.64))(zod@3.25.64)
       '@reown/walletkit':
         specifier: 1.2.10
         version: 1.2.10(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.64)
@@ -773,7 +776,7 @@ importers:
         version: 3.25.64
       zustand:
         specifier: ^5.0.4
-        version: 5.0.8(@types/react@19.1.12)(immer@10.1.3)(react@19.1.1)(use-sync-external-store@1.5.0(react@19.1.1))
+        version: 5.0.8(@types/react@19.1.12)(immer@10.1.3)(react@19.1.1)(use-sync-external-store@1.4.0(react@19.1.1))
 
   packages/apps/mcp:
     dependencies:
@@ -1003,7 +1006,7 @@ importers:
         version: 1.2.21
       jest:
         specifier: ^29.5.0
-        version: 29.7.0(@types/node@20.19.13)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.5.29(@swc/helpers@0.5.17))(@types/node@20.19.13)(typescript@5.8.3))
+        version: 29.7.0(@types/node@20.19.13)(babel-plugin-macros@3.1.0)(ts-node@10.9.1(@swc/core@1.5.29(@swc/helpers@0.5.17))(@types/node@20.19.13)(typescript@5.8.3))
       jest-process-manager:
         specifier: ^0.2.9
         version: 0.2.9(debug@4.4.1)
@@ -1012,7 +1015,7 @@ importers:
         version: 10.2.0
       ts-jest:
         specifier: ^29.1.0
-        version: 29.4.1(@babel/core@7.28.4)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.4))(esbuild@0.19.12)(jest-util@29.7.0)(jest@29.7.0(@types/node@20.19.13)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.5.29(@swc/helpers@0.5.17))(@types/node@20.19.13)(typescript@5.8.3)))(typescript@5.8.3)
+        version: 29.4.1(@babel/core@7.28.4)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.4))(esbuild@0.19.12)(jest-util@29.7.0)(jest@29.7.0(@types/node@20.19.13)(babel-plugin-macros@3.1.0)(ts-node@10.9.1(@swc/core@1.5.29(@swc/helpers@0.5.17))(@types/node@20.19.13)(typescript@5.8.3)))(typescript@5.8.3)
       unbuild:
         specifier: ^3.5.0
         version: 3.6.1(typescript@5.8.3)
@@ -1162,13 +1165,13 @@ importers:
         version: 29.5.14
       jest:
         specifier: ^29.5.0
-        version: 29.7.0(@types/node@22.7.5)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.5.29(@swc/helpers@0.5.17))(@types/node@22.7.5)(typescript@5.8.3))
+        version: 29.7.0(@types/node@20.19.13)(babel-plugin-macros@3.1.0)(ts-node@10.9.1(@swc/core@1.5.29(@swc/helpers@0.5.17))(@types/node@20.19.13)(typescript@5.8.3))
       pino-pretty:
         specifier: ^13.0.0
         version: 13.1.1
       ts-jest:
         specifier: ^29.1.0
-        version: 29.4.1(@babel/core@7.28.4)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.4))(esbuild@0.19.12)(jest-util@29.7.0)(jest@29.7.0(@types/node@22.7.5)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.5.29(@swc/helpers@0.5.17))(@types/node@22.7.5)(typescript@5.8.3)))(typescript@5.8.3)
+        version: 29.4.1(@babel/core@7.28.4)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.4))(esbuild@0.19.12)(jest-util@29.7.0)(jest@29.7.0(@types/node@20.19.13)(babel-plugin-macros@3.1.0)(ts-node@10.9.1(@swc/core@1.5.29(@swc/helpers@0.5.17))(@types/node@20.19.13)(typescript@5.8.3)))(typescript@5.8.3)
       viem:
         specifier: ^2.34.0
         version: 2.37.5(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.64)
@@ -5859,6 +5862,7 @@ packages:
 
   bun@1.2.21:
     resolution: {integrity: sha512-y0lJ02dS90U3PJm+7KAKY8Se95AQvP5Xm77LouUwrpNOHpv59kBG4SK1+9iE1cAhpUaFipq+0EJ56S6MmE3row==}
+    cpu: [arm64, x64, aarch64]
     os: [darwin, linux, win32]
     hasBin: true
 
@@ -13362,27 +13366,6 @@ snapshots:
       - utf-8-validate
       - zod
 
-  '@base-org/account@1.1.1(@types/react@19.1.12)(bufferutil@4.0.9)(immer@10.1.3)(react@19.1.1)(typescript@5.8.3)(use-sync-external-store@1.5.0(react@19.1.1))(utf-8-validate@5.0.10)(zod@3.25.64)':
-    dependencies:
-      '@noble/hashes': 1.4.0
-      clsx: 1.2.1
-      eventemitter3: 5.0.1
-      idb-keyval: 6.2.1
-      ox: 0.6.9(typescript@5.8.3)(zod@3.25.64)
-      preact: 10.24.2
-      viem: 2.37.5(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.64)
-      zustand: 5.0.3(@types/react@19.1.12)(immer@10.1.3)(react@19.1.1)(use-sync-external-store@1.5.0(react@19.1.1))
-    transitivePeerDependencies:
-      - '@types/react'
-      - bufferutil
-      - immer
-      - react
-      - typescript
-      - use-sync-external-store
-      - utf-8-validate
-      - zod
-    optional: true
-
   '@bcoe/v8-coverage@0.2.3': {}
 
   '@bgd-labs/aave-address-book@4.29.1(viem@2.37.5(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.64))':
@@ -13422,27 +13405,6 @@ snapshots:
       - use-sync-external-store
       - utf-8-validate
       - zod
-
-  '@coinbase/wallet-sdk@4.3.6(@types/react@19.1.12)(bufferutil@4.0.9)(immer@10.1.3)(react@19.1.1)(typescript@5.8.3)(use-sync-external-store@1.5.0(react@19.1.1))(utf-8-validate@5.0.10)(zod@3.25.64)':
-    dependencies:
-      '@noble/hashes': 1.4.0
-      clsx: 1.2.1
-      eventemitter3: 5.0.1
-      idb-keyval: 6.2.1
-      ox: 0.6.9(typescript@5.8.3)(zod@3.25.64)
-      preact: 10.24.2
-      viem: 2.37.5(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.64)
-      zustand: 5.0.3(@types/react@19.1.12)(immer@10.1.3)(react@19.1.1)(use-sync-external-store@1.5.0(react@19.1.1))
-    transitivePeerDependencies:
-      - '@types/react'
-      - bufferutil
-      - immer
-      - react
-      - typescript
-      - use-sync-external-store
-      - utf-8-validate
-      - zod
-    optional: true
 
   '@cspotcode/source-map-support@0.8.1':
     dependencies:
@@ -14423,76 +14385,6 @@ snapshots:
       - supports-color
       - ts-node
 
-  '@jest/core@29.7.0(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.5.29(@swc/helpers@0.5.17))(@types/node@20.19.13)(typescript@5.8.3))':
-    dependencies:
-      '@jest/console': 29.7.0
-      '@jest/reporters': 29.7.0
-      '@jest/test-result': 29.7.0
-      '@jest/transform': 29.7.0
-      '@jest/types': 29.6.3
-      '@types/node': 20.19.13
-      ansi-escapes: 4.3.2
-      chalk: 4.1.2
-      ci-info: 3.9.0
-      exit: 0.1.2
-      graceful-fs: 4.2.11
-      jest-changed-files: 29.7.0
-      jest-config: 29.7.0(@types/node@20.19.13)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.5.29(@swc/helpers@0.5.17))(@types/node@20.19.13)(typescript@5.8.3))
-      jest-haste-map: 29.7.0
-      jest-message-util: 29.7.0
-      jest-regex-util: 29.6.3
-      jest-resolve: 29.7.0
-      jest-resolve-dependencies: 29.7.0
-      jest-runner: 29.7.0
-      jest-runtime: 29.7.0
-      jest-snapshot: 29.7.0
-      jest-util: 29.7.0
-      jest-validate: 29.7.0
-      jest-watcher: 29.7.0
-      micromatch: 4.0.8
-      pretty-format: 29.7.0
-      slash: 3.0.0
-      strip-ansi: 6.0.1
-    transitivePeerDependencies:
-      - babel-plugin-macros
-      - supports-color
-      - ts-node
-
-  '@jest/core@29.7.0(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.5.29(@swc/helpers@0.5.17))(@types/node@22.7.5)(typescript@5.8.3))':
-    dependencies:
-      '@jest/console': 29.7.0
-      '@jest/reporters': 29.7.0
-      '@jest/test-result': 29.7.0
-      '@jest/transform': 29.7.0
-      '@jest/types': 29.6.3
-      '@types/node': 20.19.13
-      ansi-escapes: 4.3.2
-      chalk: 4.1.2
-      ci-info: 3.9.0
-      exit: 0.1.2
-      graceful-fs: 4.2.11
-      jest-changed-files: 29.7.0
-      jest-config: 29.7.0(@types/node@20.19.13)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.5.29(@swc/helpers@0.5.17))(@types/node@22.7.5)(typescript@5.8.3))
-      jest-haste-map: 29.7.0
-      jest-message-util: 29.7.0
-      jest-regex-util: 29.6.3
-      jest-resolve: 29.7.0
-      jest-resolve-dependencies: 29.7.0
-      jest-runner: 29.7.0
-      jest-runtime: 29.7.0
-      jest-snapshot: 29.7.0
-      jest-util: 29.7.0
-      jest-validate: 29.7.0
-      jest-watcher: 29.7.0
-      micromatch: 4.0.8
-      pretty-format: 29.7.0
-      slash: 3.0.0
-      strip-ansi: 6.0.1
-    transitivePeerDependencies:
-      - babel-plugin-macros
-      - supports-color
-      - ts-node
-
   '@jest/environment@29.7.0':
     dependencies:
       '@jest/fake-timers': 29.7.0
@@ -15379,7 +15271,7 @@ snapshots:
       '@lit-protocol/contracts-sdk': 7.3.0(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)
       '@lit-protocol/vincent-app-sdk': link:packages/libs/app-sdk
       '@lit-protocol/vincent-tool-sdk': 1.0.2(bufferutil@4.0.9)(utf-8-validate@5.0.10)
-      '@wagmi/core': 2.20.3(@tanstack/query-core@5.87.1)(@types/react@19.1.12)(immer@10.1.3)(react@19.1.1)(typescript@5.8.3)(use-sync-external-store@1.4.0(react@19.1.1))(viem@2.37.5(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.64))
+      '@wagmi/core': 2.20.3(@tanstack/query-core@5.87.1)(@types/react@19.1.12)(immer@10.1.3)(react@19.1.1)(typescript@5.8.3)(use-sync-external-store@1.5.0(react@19.1.1))(viem@2.37.5(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.64))
       chalk: 4.1.2
       dotenv: 16.6.1
       esbuild: 0.19.12
@@ -16548,7 +16440,7 @@ snapshots:
       react: 19.1.1
       react-redux: 9.2.0(@types/react@19.1.12)(react@19.1.1)(redux@5.0.1)
 
-  '@reown/appkit-adapter-wagmi@1.8.4(@types/react@19.1.12)(@wagmi/core@2.20.3(@tanstack/query-core@5.87.1)(@types/react@19.1.12)(immer@10.1.3)(react@19.1.1)(typescript@5.8.3)(use-sync-external-store@1.4.0(react@19.1.1))(viem@2.37.5(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.64)))(bufferutil@4.0.9)(immer@10.1.3)(react@19.1.1)(typescript@5.8.3)(use-sync-external-store@1.5.0(react@19.1.1))(utf-8-validate@5.0.10)(viem@2.37.5(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.64))(wagmi@2.16.9(@tanstack/query-core@5.87.1)(@tanstack/react-query@5.87.1(react@19.1.1))(@types/react@19.1.12)(bufferutil@4.0.9)(immer@10.1.3)(react@19.1.1)(typescript@5.8.3)(utf-8-validate@5.0.10)(viem@2.37.5(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.64))(zod@3.25.64))(zod@3.25.64)':
+  '@reown/appkit-adapter-wagmi@1.8.4(@types/react@19.1.12)(@wagmi/core@2.20.3(@tanstack/query-core@5.87.1)(@types/react@19.1.12)(immer@10.1.3)(react@19.1.1)(typescript@5.8.3)(use-sync-external-store@1.4.0(react@19.1.1))(viem@2.37.5(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.64)))(bufferutil@4.0.9)(immer@10.1.3)(react@19.1.1)(typescript@5.8.3)(use-sync-external-store@1.4.0(react@19.1.1))(utf-8-validate@5.0.10)(viem@2.37.5(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.64))(wagmi@2.16.9(@tanstack/query-core@5.87.1)(@tanstack/react-query@5.87.1(react@19.1.1))(@types/react@19.1.12)(bufferutil@4.0.9)(immer@10.1.3)(react@19.1.1)(typescript@5.8.3)(utf-8-validate@5.0.10)(viem@2.37.5(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.64))(zod@3.25.64))(zod@3.25.64)':
     dependencies:
       '@reown/appkit': 1.8.4(@types/react@19.1.12)(bufferutil@4.0.9)(react@19.1.1)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.64)
       '@reown/appkit-common': 1.8.4(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.64)
@@ -16563,7 +16455,7 @@ snapshots:
       viem: 2.37.5(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.64)
       wagmi: 2.16.9(@tanstack/query-core@5.87.1)(@tanstack/react-query@5.87.1(react@19.1.1))(@types/react@19.1.12)(bufferutil@4.0.9)(immer@10.1.3)(react@19.1.1)(typescript@5.8.3)(utf-8-validate@5.0.10)(viem@2.37.5(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.64))(zod@3.25.64)
     optionalDependencies:
-      '@wagmi/connectors': 5.9.9(@types/react@19.1.12)(@wagmi/core@2.20.3(@tanstack/query-core@5.87.1)(@types/react@19.1.12)(immer@10.1.3)(react@19.1.1)(typescript@5.8.3)(use-sync-external-store@1.4.0(react@19.1.1))(viem@2.37.5(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.64)))(bufferutil@4.0.9)(immer@10.1.3)(react@19.1.1)(typescript@5.8.3)(use-sync-external-store@1.5.0(react@19.1.1))(utf-8-validate@5.0.10)(viem@2.37.5(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.64))(zod@3.25.64)
+      '@wagmi/connectors': 5.9.9(@types/react@19.1.12)(@wagmi/core@2.20.3(@tanstack/query-core@5.87.1)(@types/react@19.1.12)(immer@10.1.3)(react@19.1.1)(typescript@5.8.3)(use-sync-external-store@1.4.0(react@19.1.1))(viem@2.37.5(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.64)))(bufferutil@4.0.9)(immer@10.1.3)(react@19.1.1)(typescript@5.8.3)(use-sync-external-store@1.4.0(react@19.1.1))(utf-8-validate@5.0.10)(viem@2.37.5(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.64))(zod@3.25.64)
     transitivePeerDependencies:
       - '@azure/app-configuration'
       - '@azure/cosmos'
@@ -18729,52 +18621,22 @@ snapshots:
       - utf-8-validate
       - zod
 
-  '@wagmi/connectors@5.9.9(@types/react@19.1.12)(@wagmi/core@2.20.3(@tanstack/query-core@5.87.1)(@types/react@19.1.12)(immer@10.1.3)(react@19.1.1)(typescript@5.8.3)(use-sync-external-store@1.4.0(react@19.1.1))(viem@2.37.5(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.64)))(bufferutil@4.0.9)(immer@10.1.3)(react@19.1.1)(typescript@5.8.3)(use-sync-external-store@1.5.0(react@19.1.1))(utf-8-validate@5.0.10)(viem@2.37.5(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.64))(zod@3.25.64)':
+  '@wagmi/core@2.20.3(@tanstack/query-core@5.87.1)(@types/react@19.1.12)(immer@10.1.3)(react@19.1.1)(typescript@5.8.3)(use-sync-external-store@1.4.0(react@19.1.1))(viem@2.37.5(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.64))':
     dependencies:
-      '@base-org/account': 1.1.1(@types/react@19.1.12)(bufferutil@4.0.9)(immer@10.1.3)(react@19.1.1)(typescript@5.8.3)(use-sync-external-store@1.5.0(react@19.1.1))(utf-8-validate@5.0.10)(zod@3.25.64)
-      '@coinbase/wallet-sdk': 4.3.6(@types/react@19.1.12)(bufferutil@4.0.9)(immer@10.1.3)(react@19.1.1)(typescript@5.8.3)(use-sync-external-store@1.5.0(react@19.1.1))(utf-8-validate@5.0.10)(zod@3.25.64)
-      '@gemini-wallet/core': 0.2.0(viem@2.37.5(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.64))
-      '@metamask/sdk': 0.32.0(bufferutil@4.0.9)(utf-8-validate@5.0.10)
-      '@safe-global/safe-apps-provider': 0.18.6(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.64)
-      '@safe-global/safe-apps-sdk': 9.1.0(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.64)
-      '@wagmi/core': 2.20.3(@tanstack/query-core@5.87.1)(@types/react@19.1.12)(immer@10.1.3)(react@19.1.1)(typescript@5.8.3)(use-sync-external-store@1.4.0(react@19.1.1))(viem@2.37.5(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.64))
-      '@walletconnect/ethereum-provider': 2.21.1(@types/react@19.1.12)(bufferutil@4.0.9)(react@19.1.1)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.64)
-      cbw-sdk: '@coinbase/wallet-sdk@3.9.3'
+      eventemitter3: 5.0.1
+      mipd: 0.0.7(typescript@5.8.3)
       viem: 2.37.5(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.64)
+      zustand: 5.0.0(@types/react@19.1.12)(immer@10.1.3)(react@19.1.1)(use-sync-external-store@1.4.0(react@19.1.1))
     optionalDependencies:
+      '@tanstack/query-core': 5.87.1
       typescript: 5.8.3
     transitivePeerDependencies:
-      - '@azure/app-configuration'
-      - '@azure/cosmos'
-      - '@azure/data-tables'
-      - '@azure/identity'
-      - '@azure/keyvault-secrets'
-      - '@azure/storage-blob'
-      - '@capacitor/preferences'
-      - '@deno/kv'
-      - '@netlify/blobs'
-      - '@planetscale/database'
-      - '@react-native-async-storage/async-storage'
       - '@types/react'
-      - '@upstash/redis'
-      - '@vercel/blob'
-      - '@vercel/functions'
-      - '@vercel/kv'
-      - aws4fetch
-      - bufferutil
-      - db0
-      - encoding
       - immer
-      - ioredis
       - react
-      - supports-color
-      - uploadthing
       - use-sync-external-store
-      - utf-8-validate
-      - zod
-    optional: true
 
-  '@wagmi/core@2.20.3(@tanstack/query-core@5.87.1)(@types/react@19.1.12)(immer@10.1.3)(react@19.1.1)(typescript@5.8.3)(use-sync-external-store@1.4.0(react@19.1.1))(viem@2.37.5(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.64))':
+  '@wagmi/core@2.20.3(@tanstack/query-core@5.87.1)(@types/react@19.1.12)(immer@10.1.3)(react@19.1.1)(typescript@5.8.3)(use-sync-external-store@1.5.0(react@19.1.1))(viem@2.37.5(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.64))':
     dependencies:
       eventemitter3: 5.0.1
       mipd: 0.0.7(typescript@5.8.3)
@@ -20998,36 +20860,6 @@ snapshots:
       exit: 0.1.2
       graceful-fs: 4.2.11
       jest-config: 29.7.0(@types/node@20.19.13)(babel-plugin-macros@3.1.0)(ts-node@10.9.1(@swc/core@1.5.29(@swc/helpers@0.5.17))(@types/node@20.19.13)(typescript@5.8.3))
-      jest-util: 29.7.0
-      prompts: 2.4.2
-    transitivePeerDependencies:
-      - '@types/node'
-      - babel-plugin-macros
-      - supports-color
-      - ts-node
-
-  create-jest@29.7.0(@types/node@20.19.13)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.5.29(@swc/helpers@0.5.17))(@types/node@20.19.13)(typescript@5.8.3)):
-    dependencies:
-      '@jest/types': 29.6.3
-      chalk: 4.1.2
-      exit: 0.1.2
-      graceful-fs: 4.2.11
-      jest-config: 29.7.0(@types/node@20.19.13)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.5.29(@swc/helpers@0.5.17))(@types/node@20.19.13)(typescript@5.8.3))
-      jest-util: 29.7.0
-      prompts: 2.4.2
-    transitivePeerDependencies:
-      - '@types/node'
-      - babel-plugin-macros
-      - supports-color
-      - ts-node
-
-  create-jest@29.7.0(@types/node@22.7.5)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.5.29(@swc/helpers@0.5.17))(@types/node@22.7.5)(typescript@5.8.3)):
-    dependencies:
-      '@jest/types': 29.6.3
-      chalk: 4.1.2
-      exit: 0.1.2
-      graceful-fs: 4.2.11
-      jest-config: 29.7.0(@types/node@22.7.5)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.5.29(@swc/helpers@0.5.17))(@types/node@22.7.5)(typescript@5.8.3))
       jest-util: 29.7.0
       prompts: 2.4.2
     transitivePeerDependencies:
@@ -23648,44 +23480,6 @@ snapshots:
       - supports-color
       - ts-node
 
-  jest-cli@29.7.0(@types/node@20.19.13)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.5.29(@swc/helpers@0.5.17))(@types/node@20.19.13)(typescript@5.8.3)):
-    dependencies:
-      '@jest/core': 29.7.0(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.5.29(@swc/helpers@0.5.17))(@types/node@20.19.13)(typescript@5.8.3))
-      '@jest/test-result': 29.7.0
-      '@jest/types': 29.6.3
-      chalk: 4.1.2
-      create-jest: 29.7.0(@types/node@20.19.13)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.5.29(@swc/helpers@0.5.17))(@types/node@20.19.13)(typescript@5.8.3))
-      exit: 0.1.2
-      import-local: 3.2.0
-      jest-config: 29.7.0(@types/node@20.19.13)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.5.29(@swc/helpers@0.5.17))(@types/node@20.19.13)(typescript@5.8.3))
-      jest-util: 29.7.0
-      jest-validate: 29.7.0
-      yargs: 17.7.2
-    transitivePeerDependencies:
-      - '@types/node'
-      - babel-plugin-macros
-      - supports-color
-      - ts-node
-
-  jest-cli@29.7.0(@types/node@22.7.5)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.5.29(@swc/helpers@0.5.17))(@types/node@22.7.5)(typescript@5.8.3)):
-    dependencies:
-      '@jest/core': 29.7.0(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.5.29(@swc/helpers@0.5.17))(@types/node@22.7.5)(typescript@5.8.3))
-      '@jest/test-result': 29.7.0
-      '@jest/types': 29.6.3
-      chalk: 4.1.2
-      create-jest: 29.7.0(@types/node@22.7.5)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.5.29(@swc/helpers@0.5.17))(@types/node@22.7.5)(typescript@5.8.3))
-      exit: 0.1.2
-      import-local: 3.2.0
-      jest-config: 29.7.0(@types/node@22.7.5)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.5.29(@swc/helpers@0.5.17))(@types/node@22.7.5)(typescript@5.8.3))
-      jest-util: 29.7.0
-      jest-validate: 29.7.0
-      yargs: 17.7.2
-    transitivePeerDependencies:
-      - '@types/node'
-      - babel-plugin-macros
-      - supports-color
-      - ts-node
-
   jest-config@29.7.0(@types/node@20.19.13)(babel-plugin-macros@3.1.0)(ts-node@10.9.1(@swc/core@1.5.29(@swc/helpers@0.5.17))(@types/node@20.19.13)(typescript@5.8.3)):
     dependencies:
       '@babel/core': 7.28.4
@@ -23713,99 +23507,6 @@ snapshots:
     optionalDependencies:
       '@types/node': 20.19.13
       ts-node: 10.9.1(@swc/core@1.5.29(@swc/helpers@0.5.17))(@types/node@20.19.13)(typescript@5.8.3)
-    transitivePeerDependencies:
-      - babel-plugin-macros
-      - supports-color
-
-  jest-config@29.7.0(@types/node@20.19.13)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.5.29(@swc/helpers@0.5.17))(@types/node@20.19.13)(typescript@5.8.3)):
-    dependencies:
-      '@babel/core': 7.28.4
-      '@jest/test-sequencer': 29.7.0
-      '@jest/types': 29.6.3
-      babel-jest: 29.7.0(@babel/core@7.28.4)
-      chalk: 4.1.2
-      ci-info: 3.9.0
-      deepmerge: 4.3.1
-      glob: 7.2.3
-      graceful-fs: 4.2.11
-      jest-circus: 29.7.0(babel-plugin-macros@3.1.0)
-      jest-environment-node: 29.7.0
-      jest-get-type: 29.6.3
-      jest-regex-util: 29.6.3
-      jest-resolve: 29.7.0
-      jest-runner: 29.7.0
-      jest-util: 29.7.0
-      jest-validate: 29.7.0
-      micromatch: 4.0.8
-      parse-json: 5.2.0
-      pretty-format: 29.7.0
-      slash: 3.0.0
-      strip-json-comments: 3.1.1
-    optionalDependencies:
-      '@types/node': 20.19.13
-      ts-node: 10.9.2(@swc/core@1.5.29(@swc/helpers@0.5.17))(@types/node@20.19.13)(typescript@5.8.3)
-    transitivePeerDependencies:
-      - babel-plugin-macros
-      - supports-color
-
-  jest-config@29.7.0(@types/node@20.19.13)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.5.29(@swc/helpers@0.5.17))(@types/node@22.7.5)(typescript@5.8.3)):
-    dependencies:
-      '@babel/core': 7.28.4
-      '@jest/test-sequencer': 29.7.0
-      '@jest/types': 29.6.3
-      babel-jest: 29.7.0(@babel/core@7.28.4)
-      chalk: 4.1.2
-      ci-info: 3.9.0
-      deepmerge: 4.3.1
-      glob: 7.2.3
-      graceful-fs: 4.2.11
-      jest-circus: 29.7.0(babel-plugin-macros@3.1.0)
-      jest-environment-node: 29.7.0
-      jest-get-type: 29.6.3
-      jest-regex-util: 29.6.3
-      jest-resolve: 29.7.0
-      jest-runner: 29.7.0
-      jest-util: 29.7.0
-      jest-validate: 29.7.0
-      micromatch: 4.0.8
-      parse-json: 5.2.0
-      pretty-format: 29.7.0
-      slash: 3.0.0
-      strip-json-comments: 3.1.1
-    optionalDependencies:
-      '@types/node': 20.19.13
-      ts-node: 10.9.2(@swc/core@1.5.29(@swc/helpers@0.5.17))(@types/node@22.7.5)(typescript@5.8.3)
-    transitivePeerDependencies:
-      - babel-plugin-macros
-      - supports-color
-
-  jest-config@29.7.0(@types/node@22.7.5)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.5.29(@swc/helpers@0.5.17))(@types/node@22.7.5)(typescript@5.8.3)):
-    dependencies:
-      '@babel/core': 7.28.4
-      '@jest/test-sequencer': 29.7.0
-      '@jest/types': 29.6.3
-      babel-jest: 29.7.0(@babel/core@7.28.4)
-      chalk: 4.1.2
-      ci-info: 3.9.0
-      deepmerge: 4.3.1
-      glob: 7.2.3
-      graceful-fs: 4.2.11
-      jest-circus: 29.7.0(babel-plugin-macros@3.1.0)
-      jest-environment-node: 29.7.0
-      jest-get-type: 29.6.3
-      jest-regex-util: 29.6.3
-      jest-resolve: 29.7.0
-      jest-runner: 29.7.0
-      jest-util: 29.7.0
-      jest-validate: 29.7.0
-      micromatch: 4.0.8
-      parse-json: 5.2.0
-      pretty-format: 29.7.0
-      slash: 3.0.0
-      strip-json-comments: 3.1.1
-    optionalDependencies:
-      '@types/node': 22.7.5
-      ts-node: 10.9.2(@swc/core@1.5.29(@swc/helpers@0.5.17))(@types/node@22.7.5)(typescript@5.8.3)
     transitivePeerDependencies:
       - babel-plugin-macros
       - supports-color
@@ -24062,30 +23763,6 @@ snapshots:
       '@jest/types': 29.6.3
       import-local: 3.2.0
       jest-cli: 29.7.0(@types/node@20.19.13)(babel-plugin-macros@3.1.0)(ts-node@10.9.1(@swc/core@1.5.29(@swc/helpers@0.5.17))(@types/node@20.19.13)(typescript@5.8.3))
-    transitivePeerDependencies:
-      - '@types/node'
-      - babel-plugin-macros
-      - supports-color
-      - ts-node
-
-  jest@29.7.0(@types/node@20.19.13)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.5.29(@swc/helpers@0.5.17))(@types/node@20.19.13)(typescript@5.8.3)):
-    dependencies:
-      '@jest/core': 29.7.0(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.5.29(@swc/helpers@0.5.17))(@types/node@20.19.13)(typescript@5.8.3))
-      '@jest/types': 29.6.3
-      import-local: 3.2.0
-      jest-cli: 29.7.0(@types/node@20.19.13)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.5.29(@swc/helpers@0.5.17))(@types/node@20.19.13)(typescript@5.8.3))
-    transitivePeerDependencies:
-      - '@types/node'
-      - babel-plugin-macros
-      - supports-color
-      - ts-node
-
-  jest@29.7.0(@types/node@22.7.5)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.5.29(@swc/helpers@0.5.17))(@types/node@22.7.5)(typescript@5.8.3)):
-    dependencies:
-      '@jest/core': 29.7.0(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.5.29(@swc/helpers@0.5.17))(@types/node@22.7.5)(typescript@5.8.3))
-      '@jest/types': 29.6.3
-      import-local: 3.2.0
-      jest-cli: 29.7.0(@types/node@22.7.5)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.5.29(@swc/helpers@0.5.17))(@types/node@22.7.5)(typescript@5.8.3))
     transitivePeerDependencies:
       - '@types/node'
       - babel-plugin-macros
@@ -27219,48 +26896,6 @@ snapshots:
       esbuild: 0.19.12
       jest-util: 29.7.0
 
-  ts-jest@29.4.1(@babel/core@7.28.4)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.4))(esbuild@0.19.12)(jest-util@29.7.0)(jest@29.7.0(@types/node@20.19.13)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.5.29(@swc/helpers@0.5.17))(@types/node@20.19.13)(typescript@5.8.3)))(typescript@5.8.3):
-    dependencies:
-      bs-logger: 0.2.6
-      fast-json-stable-stringify: 2.1.0
-      handlebars: 4.7.8
-      jest: 29.7.0(@types/node@20.19.13)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.5.29(@swc/helpers@0.5.17))(@types/node@20.19.13)(typescript@5.8.3))
-      json5: 2.2.3
-      lodash.memoize: 4.1.2
-      make-error: 1.3.6
-      semver: 7.7.2
-      type-fest: 4.41.0
-      typescript: 5.8.3
-      yargs-parser: 21.1.1
-    optionalDependencies:
-      '@babel/core': 7.28.4
-      '@jest/transform': 29.7.0
-      '@jest/types': 29.6.3
-      babel-jest: 29.7.0(@babel/core@7.28.4)
-      esbuild: 0.19.12
-      jest-util: 29.7.0
-
-  ts-jest@29.4.1(@babel/core@7.28.4)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.4))(esbuild@0.19.12)(jest-util@29.7.0)(jest@29.7.0(@types/node@22.7.5)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.5.29(@swc/helpers@0.5.17))(@types/node@22.7.5)(typescript@5.8.3)))(typescript@5.8.3):
-    dependencies:
-      bs-logger: 0.2.6
-      fast-json-stable-stringify: 2.1.0
-      handlebars: 4.7.8
-      jest: 29.7.0(@types/node@22.7.5)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.5.29(@swc/helpers@0.5.17))(@types/node@22.7.5)(typescript@5.8.3))
-      json5: 2.2.3
-      lodash.memoize: 4.1.2
-      make-error: 1.3.6
-      semver: 7.7.2
-      type-fest: 4.41.0
-      typescript: 5.8.3
-      yargs-parser: 21.1.1
-    optionalDependencies:
-      '@babel/core': 7.28.4
-      '@jest/transform': 29.7.0
-      '@jest/types': 29.6.3
-      babel-jest: 29.7.0(@babel/core@7.28.4)
-      esbuild: 0.19.12
-      jest-util: 29.7.0
-
   ts-morph@12.0.0:
     dependencies:
       '@ts-morph/common': 0.11.1
@@ -28354,6 +27989,13 @@ snapshots:
 
   zod@3.25.64: {}
 
+  zustand@5.0.0(@types/react@19.1.12)(immer@10.1.3)(react@19.1.1)(use-sync-external-store@1.4.0(react@19.1.1)):
+    optionalDependencies:
+      '@types/react': 19.1.12
+      immer: 10.1.3
+      react: 19.1.1
+      use-sync-external-store: 1.4.0(react@19.1.1)
+
   zustand@5.0.0(@types/react@19.1.12)(immer@10.1.3)(react@19.1.1)(use-sync-external-store@1.5.0(react@19.1.1)):
     optionalDependencies:
       '@types/react': 19.1.12
@@ -28368,17 +28010,9 @@ snapshots:
       react: 19.1.1
       use-sync-external-store: 1.4.0(react@19.1.1)
 
-  zustand@5.0.3(@types/react@19.1.12)(immer@10.1.3)(react@19.1.1)(use-sync-external-store@1.5.0(react@19.1.1)):
+  zustand@5.0.8(@types/react@19.1.12)(immer@10.1.3)(react@19.1.1)(use-sync-external-store@1.4.0(react@19.1.1)):
     optionalDependencies:
       '@types/react': 19.1.12
       immer: 10.1.3
       react: 19.1.1
-      use-sync-external-store: 1.5.0(react@19.1.1)
-    optional: true
-
-  zustand@5.0.8(@types/react@19.1.12)(immer@10.1.3)(react@19.1.1)(use-sync-external-store@1.5.0(react@19.1.1)):
-    optionalDependencies:
-      '@types/react': 19.1.12
-      immer: 10.1.3
-      react: 19.1.1
-      use-sync-external-store: 1.5.0(react@19.1.1)
+      use-sync-external-store: 1.4.0(react@19.1.1)


### PR DESCRIPTION
# Description

It was [previously discovered](https://litprotocol.slack.com/archives/C06PBN0CW93/p1749768356451169) that ethers v5 is unable to fetch EIP-1559 gas fee data for L2s such as Base, and would default to ETH mainnet default pricing - This was patched in ethers v6.

This PR refactors gas estimation to use ethers v6 and introduces optional overrides:
- `gasLimitBuffer`: percentage added to the estimated gas limit
- `baseFeePerGasMultiplier`: multiplier applied to the block’s base fee when computing `maxFeePerGas` (used if the provider does not return `maxFeePerGas`)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- Successful run of the E2E Uniswap Swap test (that actually swaps on Base mainnet)
- New E2E tests specifically for `getGasParams` helper method

# Checklist:

- [x] I created a [release plan](https://nx.dev/recipes/nx-release/file-based-versioning-version-plans) (`nx release plan`) describing my changes and the version bump
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
