### PR TITLE
fix: remove sponsorDelegateesPayment endpoint

### DIFF
--- a/packages/apps/app-dashboard/src/components/developer-dashboard/app/wrappers/CreateAppWrapper.tsx
+++ b/packages/apps/app-dashboard/src/components/developer-dashboard/app/wrappers/CreateAppWrapper.tsx
@@ -4,6 +4,7 @@ import { reactClient as vincentApiClient } from '@lit-protocol/vincent-registry-
 import { StatusMessage } from '@/components/shared/ui/statusMessage';
 import { CreateAppForm, type CreateAppFormData } from '../forms/CreateAppForm';
 import { getErrorMessage, navigateWithDelay } from '@/utils/developer-dashboard/app-forms';
+import { addPayee } from '@/utils/user-dashboard/addPayee';
 
 export function CreateAppWrapper() {
   // Mutation

--- a/packages/apps/app-dashboard/src/components/developer-dashboard/app/wrappers/PublishAppVersionWrapper.tsx
+++ b/packages/apps/app-dashboard/src/components/developer-dashboard/app/wrappers/PublishAppVersionWrapper.tsx
@@ -36,8 +36,6 @@ export function PublishAppVersionWrapper({ isAppPublished }: { isAppPublished: b
     version: Number(versionId),
   });
 
-  const [sponsorDelegateesPayment] = vincentApiClient.useSponsorDelegateesPaymentMutation();
-
   // Lazy queries for fetching ability and policy versions
   const [
     triggerGetAbilityVersion,
@@ -256,9 +254,6 @@ export function PublishAppVersionWrapper({ isAppPublished }: { isAppPublished: b
           }
         }
       }
-
-      // Add the delegatee addresses to the Payment DB contract on the backend, with our master address as the payer
-      await sponsorDelegateesPayment({ appId: Number(appId) });
 
       if (!isAppPublished) {
         // App not registered - use registerApp (first-time registration)

--- a/packages/apps/registry-backend/src/lib/express/app/routes.ts
+++ b/packages/apps/registry-backend/src/lib/express/app/routes.ts
@@ -131,6 +131,26 @@ export function registerRoutes(app: Express) {
           return;
         }
 
+        // Register delegatee addresses in the payment DB contract via the relayer
+        // so that the app dev doesn't have to think about RLI NFTs
+        const response = await fetch('https://datil-relayer.getlit.dev/add-users', {
+          method: 'POST',
+          headers: {
+            'api-key': LIT_RELAYER_API_KEY,
+            'payer-secret-key': LIT_PAYER_SECRET_KEY,
+            'Content-Type': 'application/json',
+          },
+          body: JSON.stringify(delegateeAddresses),
+        });
+
+        if (!response.ok) {
+          const text = await response.text();
+          res.status(500).json({
+            error: `Failed to add delegatees as payees -- status: ${response.status} - ${text}`,
+          });
+          return;
+        }
+
         res.status(201).json(appDef);
         return;
       });
@@ -600,40 +620,6 @@ export function registerRoutes(app: Express) {
         );
 
         res.json({ message: 'App activeVersion updated successfully' });
-        return;
-      }),
-    ),
-  );
-
-  // Register delegatee addresses in the payment DB contract via the relayer
-  // so that the app dev doesn't have to think about RLI NFTs
-  app.post(
-    '/app/:appId/sponsorDelegateesPayment',
-    requireVincentAuth,
-    requireApp(),
-    requireUserManagesApp(),
-    withVincentAuth(
-      withApp(async (req, res) => {
-        const { delegateeAddresses } = req.vincentApp;
-
-        const response = await fetch('https://datil-relayer.getlit.dev/add-users', {
-          method: 'POST',
-          headers: {
-            'api-key': LIT_RELAYER_API_KEY,
-            'payer-secret-key': LIT_PAYER_SECRET_KEY,
-            'Content-Type': 'application/json',
-          },
-          body: JSON.stringify(delegateeAddresses),
-        });
-
-        if (!response.ok) {
-          const text = await response.text();
-          throw new Error(
-            `Failed to add delegatees as payees -- status: ${response.status} - ${text}`,
-          );
-        }
-
-        res.json({ message: 'Delegatees are sponsored for LIT chain usage costs' });
         return;
       }),
     ),

--- a/packages/apps/registry-backend/test/integration/app.spec.ts
+++ b/packages/apps/registry-backend/test/integration/app.spec.ts
@@ -444,57 +444,6 @@ describe('App API Integration Tests', () => {
     });
   });
 
-  describe('POST /app/:appId/sponsorDelegateesPayment', () => {
-    it('should sponsor delegatees for payment', async () => {
-      const delegateeAddresses = generateRandomEthAddresses(2);
-
-      verboseLog(`POST /app/:appId/sponsorDelegateesPayment: ${delegateeAddresses.join(',')}`);
-
-      // Create a new app for this test
-      const newAppData = {
-        name: 'Payment Test App',
-        description: 'Test app for payment sponsorship',
-        contactEmail: 'payment@example.com',
-        appUserUrl: 'https://example.com/payment-app',
-        logo: 'https://example.com/payment-logo.png',
-        redirectUris: ['https://example.com/payment-callback'],
-        delegateeAddresses,
-      };
-
-      // Create the app
-      const createResult = await store.dispatch(
-        api.endpoints.createApp.initiate({
-          appCreate: newAppData,
-        }),
-      );
-
-      verboseLog(createResult);
-      expect(createResult).not.toHaveProperty('error');
-
-      const { data: appData } = createResult;
-      expectAssertObject(appData);
-
-      const paymentAppId = appData.appId;
-
-      // Call the sponsorDelegateesPayment endpoint
-      const result = await store.dispatch(
-        api.endpoints.sponsorDelegateesPayment.initiate({ appId: paymentAppId }),
-      );
-
-      verboseLog(result);
-      expect(result).not.toHaveProperty('error');
-
-      const { data } = result;
-      expectAssertObject(data);
-
-      expect(data).toHaveProperty('message');
-      expect(data.message).toContain('sponsored for LIT chain usage costs');
-
-      // Clean up - delete the app
-      await store.dispatch(api.endpoints.deleteApp.initiate({ appId: paymentAppId }));
-    });
-  });
-
   describe('DELETE /app/:appId', () => {
     it('should delete an app and its versions', async () => {
       {

--- a/packages/libs/registry-sdk/src/generated/openapi.json
+++ b/packages/libs/registry-sdk/src/generated/openapi.json
@@ -2575,51 +2575,6 @@
         }
       }
     },
-    "/app/{appId}/sponsorDelegateesPayment": {
-      "post": {
-        "summary": "Sponsor LIT chain usage costs for app delegatee addresses ",
-        "operationId": "sponsorDelegateesPayment",
-        "security": [
-          {
-            "bearerAuth": []
-          }
-        ],
-        "parameters": [
-          {
-            "schema": {
-              "type": "number"
-            },
-            "required": true,
-            "description": "ID of the target application",
-            "example": 132,
-            "name": "appId",
-            "in": "path"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK - Current app delegatee addresses are sponsored for LIT chain usage costs",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/GenericResultMessage"
-                }
-              }
-            }
-          },
-          "default": {
-            "description": "Unexpected error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
     "/abilities": {
       "get": {
         "tags": [

--- a/packages/libs/registry-sdk/src/generated/vincentApiClientNode.ts
+++ b/packages/libs/registry-sdk/src/generated/vincentApiClientNode.ts
@@ -166,15 +166,6 @@ const injectedRtkApi = api
         }),
         invalidatesTags: ['App'],
       }),
-      sponsorDelegateesPayment: build.mutation<
-        SponsorDelegateesPaymentApiResponse,
-        SponsorDelegateesPaymentApiArg
-      >({
-        query: (queryArg) => ({
-          url: `/app/${encodeURIComponent(String(queryArg.appId))}/sponsorDelegateesPayment`,
-          method: 'POST',
-        }),
-      }),
       listAllAbilities: build.query<ListAllAbilitiesApiResponse, ListAllAbilitiesApiArg>({
         query: () => ({ url: `/abilities` }),
         providesTags: ['Ability'],
@@ -525,12 +516,6 @@ export type SetAppActiveVersionApiArg = {
   appId: number;
   /** The version to set as active */
   appSetActiveVersion: AppSetActiveVersion;
-};
-export type SponsorDelegateesPaymentApiResponse =
-  /** status 200 OK - Current app delegatee addresses are sponsored for LIT chain usage costs */ GenericResultMessage;
-export type SponsorDelegateesPaymentApiArg = {
-  /** ID of the target application */
-  appId: number;
 };
 export type ListAllAbilitiesApiResponse = /** status 200 Successful operation */ AbilityListRead;
 export type ListAllAbilitiesApiArg = void;

--- a/packages/libs/registry-sdk/src/generated/vincentApiClientReact.ts
+++ b/packages/libs/registry-sdk/src/generated/vincentApiClientReact.ts
@@ -166,15 +166,6 @@ const injectedRtkApi = api
         }),
         invalidatesTags: ['App'],
       }),
-      sponsorDelegateesPayment: build.mutation<
-        SponsorDelegateesPaymentApiResponse,
-        SponsorDelegateesPaymentApiArg
-      >({
-        query: (queryArg) => ({
-          url: `/app/${encodeURIComponent(String(queryArg.appId))}/sponsorDelegateesPayment`,
-          method: 'POST',
-        }),
-      }),
       listAllAbilities: build.query<ListAllAbilitiesApiResponse, ListAllAbilitiesApiArg>({
         query: () => ({ url: `/abilities` }),
         providesTags: ['Ability'],
@@ -525,12 +516,6 @@ export type SetAppActiveVersionApiArg = {
   appId: number;
   /** The version to set as active */
   appSetActiveVersion: AppSetActiveVersion;
-};
-export type SponsorDelegateesPaymentApiResponse =
-  /** status 200 OK - Current app delegatee addresses are sponsored for LIT chain usage costs */ GenericResultMessage;
-export type SponsorDelegateesPaymentApiArg = {
-  /** ID of the target application */
-  appId: number;
 };
 export type ListAllAbilitiesApiResponse = /** status 200 Successful operation */ AbilityListRead;
 export type ListAllAbilitiesApiArg = void;
@@ -1284,7 +1269,6 @@ export const {
   useUndeleteAppVersionMutation,
   useUndeleteAppVersionAbilityMutation,
   useSetAppActiveVersionMutation,
-  useSponsorDelegateesPaymentMutation,
   useListAllAbilitiesQuery,
   useLazyListAllAbilitiesQuery,
   useCreateAbilityMutation,

--- a/packages/libs/registry-sdk/src/lib/openApi/app.ts
+++ b/packages/libs/registry-sdk/src/lib/openApi/app.ts
@@ -881,34 +881,4 @@ export function addToRegistry(registry: OpenAPIRegistry) {
       },
     },
   });
-
-  // POST /app/:appId/sponsorDelegateesPayment - Add delegatee addresses to the payment DB contract via the relayer
-  registry.registerPath({
-    method: 'post',
-    path: '/app/{appId}/sponsorDelegateesPayment',
-    summary: 'Sponsor LIT chain usage costs for app delegatee addresses ',
-    operationId: 'sponsorDelegateesPayment',
-    security: [{ [jwtAuth.name]: [] }],
-    request: {
-      params: z.object({ appId: appIdParam }),
-    },
-    responses: {
-      200: {
-        description: 'OK - Current app delegatee addresses are sponsored for LIT chain usage costs',
-        content: {
-          'application/json': {
-            schema: GenericResult,
-          },
-        },
-      },
-      default: {
-        description: 'Unexpected error',
-        content: {
-          'application/json': {
-            schema: ErrorResponse,
-          },
-        },
-      },
-    },
-  });
 }


### PR DESCRIPTION
the sponsorDelagateePayment endpoint is not being called, and does not work.  Instead of having a separate endpoint for this, just do it on app creation, since it's simpler

this PR removes this endpoint and moves it into the app creation endpoint.