### PR TITLE
Return deleted Apps for get Apps contract methods

### DIFF
--- a/.nx/version-plans/version-plan-1759560325219.md
+++ b/.nx/version-plans/version-plan-1759560325219.md
@@ -2,4 +2,4 @@
 contracts-sdk: major
 ---
 
-getPermittedAppsForPkps and getUnpermittedAppsForPkps now return deleted Apps. A new isDeleted property has been added to the return value of these methods to indicated if each returned App is currently marked as deleted
+getPermittedAppsForPkps and getUnpermittedAppsForPkps now return deleted Apps. A new isDeleted property has been added to the return value of these methods to indicate if each returned App is currently marked as deleted

--- a/.nx/version-plans/version-plan-1759560325219.md
+++ b/.nx/version-plans/version-plan-1759560325219.md
@@ -1,0 +1,5 @@
+---
+contracts-sdk: major
+---
+
+getPermittedAppsForPkps and getUnpermittedAppsForPkps now return deleted Apps. A new isDeleted property has been added to the return value of these methods to indicated if each returned App is currently marked as deleted

--- a/packages/libs/contracts-sdk/abis/VincentUserViewFacet.abi.json
+++ b/packages/libs/contracts-sdk/abis/VincentUserViewFacet.abi.json
@@ -206,6 +206,11 @@
                 "name": "versionEnabled",
                 "type": "bool",
                 "internalType": "bool"
+              },
+              {
+                "name": "isDeleted",
+                "type": "bool",
+                "internalType": "bool"
               }
             ]
           }
@@ -257,6 +262,11 @@
               },
               {
                 "name": "versionEnabled",
+                "type": "bool",
+                "internalType": "bool"
+              },
+              {
+                "name": "isDeleted",
                 "type": "bool",
                 "internalType": "bool"
               }

--- a/packages/libs/contracts-sdk/src/internal/user/UserView.ts
+++ b/packages/libs/contracts-sdk/src/internal/user/UserView.ts
@@ -129,6 +129,7 @@ export async function getPermittedAppsForPkps(
         appId: app.appId,
         version: app.version,
         versionEnabled: app.versionEnabled,
+        isDeleted: app.isDeleted,
       })),
     }));
   } catch (error: unknown) {
@@ -247,6 +248,7 @@ export async function getUnpermittedAppsForPkps(
         appId: app.appId,
         previousPermittedVersion: app.previousPermittedVersion,
         versionEnabled: app.versionEnabled,
+        isDeleted: app.isDeleted,
       })),
     }));
   } catch (error: unknown) {

--- a/packages/libs/contracts-sdk/src/internal/user/types.ts
+++ b/packages/libs/contracts-sdk/src/internal/user/types.ts
@@ -149,6 +149,7 @@ export interface ContractPkpPermittedApps {
     appId: number;
     version: number;
     versionEnabled: boolean;
+    isDeleted: boolean;
   }[];
 }
 
@@ -163,5 +164,6 @@ export interface ContractPkpUnpermittedApps {
     appId: number;
     previousPermittedVersion: number;
     versionEnabled: boolean;
+    isDeleted: boolean;
   }[];
 }

--- a/packages/libs/contracts-sdk/src/types.ts
+++ b/packages/libs/contracts-sdk/src/types.ts
@@ -299,6 +299,7 @@ export interface PermittedApp {
   appId: number;
   version: number;
   versionEnabled: boolean;
+  isDeleted: boolean;
 }
 
 /**
@@ -359,6 +360,7 @@ export interface UnpermittedApp {
   appId: number;
   previousPermittedVersion: number;
   versionEnabled: boolean;
+  isDeleted: boolean;
 }
 
 /**
@@ -514,7 +516,7 @@ export interface ContractClient {
     params: GetAllRegisteredAgentPkpsParams,
   ): ReturnType<typeof _getAllRegisteredAgentPkpEthAddresses>;
 
-  /** Get the permitted app version for a specific PKP token and app
+  /** Get the permitted app version for a specific PKP token and app, even if the app has been deleted
    *
    * @returns The permitted app version for the PKP token and app
    */
@@ -522,10 +524,10 @@ export interface ContractClient {
     params: GetPermittedAppVersionForPkpParams,
   ): ReturnType<typeof _getPermittedAppVersionForPkp>;
 
-  /** Get all app IDs that have permissions for a specific PKP token, excluding deleted apps
+  /** Get all app IDs that have permissions for a specific PKP token, including deleted apps
    *
    * @deprecated Use getPermittedAppsForPkps instead
-   * @returns Array of app IDs that have permissions for the PKP token and haven't been deleted
+   * @returns Array of app IDs that have permissions for the PKP token (including deleted apps)
    */
   getAllPermittedAppIdsForPkp(
     params: GetAllPermittedAppIdsForPkpParams,

--- a/packages/libs/contracts-sdk/test/facets/VincentAppFacet.t.sol
+++ b/packages/libs/contracts-sdk/test/facets/VincentAppFacet.t.sol
@@ -671,11 +671,17 @@ contract VincentAppFacetTest is Test {
 
         assertEq(vincentAppViewFacet.getAppById(newAppId).isDeleted, true);
 
-        // Verify deleted app is filtered out from getPermittedAppsForPkps
+        // Verify deleted app is still returned but with isDeleted flag set to true
         permittedAppsResults = vincentUserViewFacet.getPermittedAppsForPkps(pkpTokenIds, 0, 10);
         assertEq(permittedAppsResults.length, 1);
         assertEq(permittedAppsResults[0].pkpTokenId, PKP_TOKEN_ID_1);
-        assertEq(permittedAppsResults[0].permittedApps.length, 0); // Deleted app should not appear
+        assertEq(permittedAppsResults[0].permittedApps.length, 1); // Deleted app should still appear
+        assertEq(permittedAppsResults[0].permittedApps[0].appId, newAppId);
+        assertTrue(permittedAppsResults[0].permittedApps[0].isDeleted); // isDeleted flag should be true
+
+        // Verify permitted app version is still returned even if the app has been deleted
+        uint24 permittedAppVersion = vincentUserViewFacet.getPermittedAppVersionForPkp(PKP_TOKEN_ID_1, newAppId);
+        assertEq(permittedAppVersion, newAppVersion);
     }
 
     function test_fetchDelegatedAgentPkpTokenIds() public {

--- a/packages/libs/contracts-sdk/test/sdk.spec.ts
+++ b/packages/libs/contracts-sdk/test/sdk.spec.ts
@@ -245,6 +245,7 @@ describe('Vincent Contracts SDK E2E', () => {
       expect(testApp).toBeDefined();
       expect(testApp!.version).toBe(TEST_CONFIG.appVersion);
       expect(testApp!.versionEnabled).toBe(true);
+      expect(testApp!.isDeleted).toBe(false);
     });
 
     it('should get all registered agent PKPs', async () => {
@@ -382,6 +383,7 @@ describe('Vincent Contracts SDK E2E', () => {
       expect(testApp).toBeDefined();
       expect(testApp!.previousPermittedVersion).toBe(TEST_CONFIG.appVersion);
       expect(testApp!.versionEnabled).toBe(true);
+      expect(testApp!.isDeleted).toBe(false);
     });
 
     it('should get last permitted app version', async () => {


### PR DESCRIPTION
# Description

- `getPermittedAppVersionForPkp` no longer reverts if the requested App is deleted (i.e. it will return the permitted version for a deleted App)
- `getAllPermittedAppIdsForPkp` includes the App IDs for deleted Apps (Note: this method is deprecated, but I don't think it makes sense to not update it along with the other getters)
- `getPermittedAppsForPkps` includes deleted Apps in return value with `isDeleted: true` (`false` for non-deleted Apps)
- `getUnpermittedAppsForPkps` includes deleted Apps in return value with `isDeleted: true` (`false` for non-deleted Apps)
- Adds `isDeleted` to return value for Contract SDK wrapper functions

## Type of change

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# How Has This Been Tested?

- Added assertions to `packages/libs/contracts-sdk/test/facets/VincentAppFacet.t.sol` to validate new `isDeleted` property
- Added assertions to `packages/libs/contracts-sdk/test/sdk.spec.ts` to validate new `isDeleted` property

# Checklist:

- [x] I created a [release plan](https://nx.dev/recipes/nx-release/file-based-versioning-version-plans) (`nx release plan`) describing my changes and the version bump
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
