### PR TITLE
Remove `ApproveAndSwap` option from Uniswap Ability

### DIFF
--- a/.nx/version-plans/version-plan-1759906570919.md
+++ b/.nx/version-plans/version-plan-1759906570919.md
@@ -2,4 +2,4 @@
 ability-uniswap-swap: major
 ---
 
-Remove the ApproveAndSwap Ability Action from the Uniswap Swap Ability
+Remove the ApproveAndSwap Ability Action from the Uniswap Swap Ability, and format returned tokenIn allowances and balances as decimal strings

--- a/.nx/version-plans/version-plan-1759906570919.md
+++ b/.nx/version-plans/version-plan-1759906570919.md
@@ -1,0 +1,5 @@
+---
+ability-uniswap-swap: major
+---
+
+Remove the ApproveAndSwap Ability Action from the Uniswap Swap Ability

--- a/packages/apps/abilities-e2e/test-e2e/swap-no-native.spec.ts
+++ b/packages/apps/abilities-e2e/test-e2e/swap-no-native.spec.ts
@@ -344,7 +344,7 @@ describe('Uniswap Swap Ability E2E Tests', () => {
       // Try to precheck with the malicious quote
       const precheckResult = await uniswapSwapAbilityClient.precheck(
         {
-          action: AbilityAction.ApproveAndSwap,
+          action: AbilityAction.Approve,
           rpcUrlForUniswap: RPC_URL,
           signedUniswapQuote: {
             quote: signedUniswapQuote.quote,
@@ -486,8 +486,17 @@ describe('Uniswap Swap Ability E2E Tests', () => {
       expect(precheckResult.result!.nativeTokenBalance).toBeUndefined();
       expect(precheckResult.result!.tokenInAddress).toBe(SWAP_TOKEN_IN_ADDRESS);
       expect(precheckResult.result!.tokenInBalance).toBeDefined();
-      expect(BigInt(precheckResult.result!.tokenInBalance as string)).toBeGreaterThan(0n);
-      expect(BigInt(precheckResult.result!.currentTokenInAllowanceForSpender)).toBeGreaterThan(0n);
+      expect(
+        ethers.utils
+          .parseUnits(precheckResult.result!.tokenInBalance as string, SWAP_TOKEN_IN_DECIMALS)
+          .toBigInt(),
+      ).toBeGreaterThan(0n);
+      expect(precheckResult.result!.currentTokenInAllowanceForSpender as string).toBe(
+        ethers.utils.formatUnits(
+          ethers.utils.parseUnits(SWAP_AMOUNT.toString(), SWAP_TOKEN_IN_DECIMALS),
+          SWAP_TOKEN_IN_DECIMALS,
+        ),
+      );
       expect(precheckResult.result!.spenderAddress).toBe(signedUniswapQuote.quote.to);
     });
 

--- a/packages/apps/abilities-e2e/test-e2e/swap-no-native.spec.ts
+++ b/packages/apps/abilities-e2e/test-e2e/swap-no-native.spec.ts
@@ -46,24 +46,24 @@ import {
 const ALCHEMY_GAS_SPONSOR_API_KEY = getEnv('ALCHEMY_GAS_SPONSOR_API_KEY');
 const ALCHEMY_GAS_SPONSOR_POLICY_ID = getEnv('ALCHEMY_GAS_SPONSOR_POLICY_ID');
 
-// const SWAP_AMOUNT = 80;
-// const SWAP_TOKEN_IN_ADDRESS = '0x4ed4E862860beD51a9570b96d89aF5E1B0Efefed'; // DEGEN
-// const SWAP_TOKEN_IN_DECIMALS = 18;
-
-const SWAP_AMOUNT = 0.0003;
-const SWAP_TOKEN_IN_ADDRESS = '0x4200000000000000000000000000000000000006'; // WETH
+const SWAP_AMOUNT = 80;
+const SWAP_TOKEN_IN_ADDRESS = '0x4ed4E862860beD51a9570b96d89aF5E1B0Efefed'; // DEGEN
 const SWAP_TOKEN_IN_DECIMALS = 18;
+
+// const SWAP_AMOUNT = 0.0003;
+// const SWAP_TOKEN_IN_ADDRESS = '0x4200000000000000000000000000000000000006'; // WETH
+// const SWAP_TOKEN_IN_DECIMALS = 18;
 
 // const SWAP_AMOUNT = 0.1;
 // const SWAP_TOKEN_IN_ADDRESS = '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913'; // USDC
 // const SWAP_TOKEN_IN_DECIMALS = 6;
 
-// const SWAP_TOKEN_OUT_ADDRESS = '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913'; // USDC
-// const SWAP_TOKEN_OUT_DECIMALS = 6;
+const SWAP_TOKEN_OUT_ADDRESS = '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913'; // USDC
+const SWAP_TOKEN_OUT_DECIMALS = 6;
 // const SWAP_TOKEN_OUT_ADDRESS = '0x4200000000000000000000000000000000000006'; // WETH
 // const SWAP_TOKEN_OUT_DECIMALS = 18;
-const SWAP_TOKEN_OUT_ADDRESS = '0x4ed4E862860beD51a9570b96d89aF5E1B0Efefed'; // DEGEN
-const SWAP_TOKEN_OUT_DECIMALS = 18;
+// const SWAP_TOKEN_OUT_ADDRESS = '0x4ed4E862860beD51a9570b96d89aF5E1B0Efefed'; // DEGEN
+// const SWAP_TOKEN_OUT_DECIMALS = 18;
 
 const RPC_URL = BASE_RPC_URL;
 const CHAIN_ID = 8453;
@@ -491,7 +491,7 @@ describe('Uniswap Swap Ability E2E Tests', () => {
       expect(precheckResult.result!.spenderAddress).toBe(signedUniswapQuote.quote.to);
     });
 
-    it('should execute the Uniswap Swap Ability with the Agent Wallet PKP', async () => {
+    it('should execute the Uniswap Swap Ability with the Agent Wallet PKP using Swap', async () => {
       const signedUniswapQuote = await validateSignedUniswapQuoteIsDefined(SIGNED_UNISWAP_QUOTE);
       const uniswapSwapAbilityClient = getUniswapSwapAbilityClient();
 

--- a/packages/apps/ability-uniswap-swap/src/generated/vincent-ability-metadata.json
+++ b/packages/apps/ability-uniswap-swap/src/generated/vincent-ability-metadata.json
@@ -1,3 +1,3 @@
 {
-  "ipfsCid": "QmNzpmybreenCN3TPQRp8VEKXAwV5LGNsTms5FcmPHZb4h"
+  "ipfsCid": "QmbF1E3QZiP2pHqbDMsrp167cx8JSa8Zz5CsWPWGQKeKah"
 }

--- a/packages/apps/ability-uniswap-swap/src/generated/vincent-ability-metadata.json
+++ b/packages/apps/ability-uniswap-swap/src/generated/vincent-ability-metadata.json
@@ -1,3 +1,3 @@
 {
-  "ipfsCid": "QmNhA92xLMq31iPfpK67Zdko9AMaHRs4JQShFdzGQ2fLUz"
+  "ipfsCid": "QmNzpmybreenCN3TPQRp8VEKXAwV5LGNsTms5FcmPHZb4h"
 }

--- a/packages/apps/ability-uniswap-swap/src/generated/vincent-ability-metadata.json
+++ b/packages/apps/ability-uniswap-swap/src/generated/vincent-ability-metadata.json
@@ -1,3 +1,3 @@
 {
-  "ipfsCid": "QmRy1kzA8c1fQpSrudVA3FNEkZuKWhnZcPLhwKz421A3U2"
+  "ipfsCid": "QmNhA92xLMq31iPfpK67Zdko9AMaHRs4JQShFdzGQ2fLUz"
 }

--- a/packages/apps/ability-uniswap-swap/src/lib/schemas.ts
+++ b/packages/apps/ability-uniswap-swap/src/lib/schemas.ts
@@ -72,6 +72,10 @@ export const precheckSuccessSchema = z.object({
     .string()
     .describe('The current allowance of the input token used for the swap'),
   spenderAddress: z.string().describe('The Uniswap router address that will be used for the swap'),
+  requiredTokenInAllowance: z
+    .string()
+    .describe('The required allowance of the input token for the swap for the ERC20 spender')
+    .optional(),
 });
 
 export const precheckFailSchema = z.object({
@@ -119,5 +123,9 @@ export const executeSuccessSchema = z.object({
   currentAllowance: z
     .string()
     .describe('The current allowance of the input token used for the swap for the ERC20 spender')
+    .optional(),
+  requiredAllowance: z
+    .string()
+    .describe('The required allowance of the input token used for the swap for the ERC20 spender')
     .optional(),
 });

--- a/packages/apps/ability-uniswap-swap/src/lib/schemas.ts
+++ b/packages/apps/ability-uniswap-swap/src/lib/schemas.ts
@@ -2,7 +2,7 @@ import { z } from 'zod';
 
 export const abilityParamsSchema = z.object({
   action: z
-    .enum(['approve', 'swap', 'approveAndSwap'])
+    .enum(['approve', 'swap'])
     .describe(
       'Dictates whether to perform an ERC20 approval, a swap, or both using the signed Uniswap quote',
     ),

--- a/packages/apps/ability-uniswap-swap/src/lib/schemas.ts
+++ b/packages/apps/ability-uniswap-swap/src/lib/schemas.ts
@@ -4,7 +4,7 @@ export const abilityParamsSchema = z.object({
   action: z
     .enum(['approve', 'swap'])
     .describe(
-      'Dictates whether to perform an ERC20 approval, a swap, or both using the signed Uniswap quote',
+      'Dictates whether to perform an ERC20 approval or a swap using the signed Uniswap quote',
     ),
   rpcUrlForUniswap: z
     .string()

--- a/packages/apps/ability-uniswap-swap/src/lib/vincent-ability.ts
+++ b/packages/apps/ability-uniswap-swap/src/lib/vincent-ability.ts
@@ -91,7 +91,14 @@ export const vincentAbility = createVincentAbility({
     if (action === AbilityAction.Approve) {
       return succeed({
         nativeTokenBalance: checkNativeTokenBalanceResultSuccess?.ethBalance.toString(),
-        currentTokenInAllowanceForSpender: checkErc20AllowanceResult.currentAllowance.toString(),
+        currentTokenInAllowanceForSpender: ethers.utils.formatUnits(
+          checkErc20AllowanceResult.currentAllowance,
+          quote.tokenInDecimals,
+        ),
+        requiredTokenInAllowance: ethers.utils.formatUnits(
+          checkErc20AllowanceResult.requiredAllowance,
+          quote.tokenInDecimals,
+        ),
         spenderAddress: checkErc20AllowanceResult.spenderAddress,
       });
     }
@@ -103,8 +110,14 @@ export const vincentAbility = createVincentAbility({
         reason: checkErc20AllowanceResult.reason,
         spenderAddress: checkErc20AllowanceResult.spenderAddress,
         tokenAddress: checkErc20AllowanceResult.tokenAddress,
-        requiredAllowance: checkErc20AllowanceResult.requiredAllowance.toString(),
-        currentAllowance: checkErc20AllowanceResult.currentAllowance.toString(),
+        requiredAllowance: ethers.utils.formatUnits(
+          checkErc20AllowanceResult.requiredAllowance,
+          quote.tokenInDecimals,
+        ),
+        currentAllowance: ethers.utils.formatUnits(
+          checkErc20AllowanceResult.currentAllowance,
+          quote.tokenInDecimals,
+        ),
       });
     }
 
@@ -120,8 +133,14 @@ export const vincentAbility = createVincentAbility({
       return fail({
         reason: checkErc20BalanceResult.reason,
         tokenAddress: checkErc20BalanceResult.tokenAddress,
-        requiredTokenAmount: checkErc20BalanceResult.requiredTokenAmount.toString(),
-        tokenBalance: checkErc20BalanceResult.tokenBalance.toString(),
+        requiredTokenAmount: ethers.utils.formatUnits(
+          checkErc20BalanceResult.requiredTokenAmount,
+          quote.tokenInDecimals,
+        ),
+        tokenBalance: ethers.utils.formatUnits(
+          checkErc20BalanceResult.tokenBalance,
+          quote.tokenInDecimals,
+        ),
       });
     }
 
@@ -130,8 +149,18 @@ export const vincentAbility = createVincentAbility({
     return succeed({
       nativeTokenBalance: checkNativeTokenBalanceResultSuccess?.ethBalance.toString(),
       tokenInAddress: checkErc20BalanceResult.tokenAddress,
-      tokenInBalance: checkErc20BalanceResult.tokenBalance.toString(),
-      currentTokenInAllowanceForSpender: checkErc20AllowanceResult.currentAllowance.toString(),
+      tokenInBalance: ethers.utils.formatUnits(
+        checkErc20BalanceResult.tokenBalance,
+        quote.tokenInDecimals,
+      ),
+      currentTokenInAllowanceForSpender: ethers.utils.formatUnits(
+        checkErc20AllowanceResult.currentAllowance,
+        quote.tokenInDecimals,
+      ),
+      requiredTokenInAllowance: ethers.utils.formatUnits(
+        checkErc20AllowanceResult.requiredAllowance,
+        quote.tokenInDecimals,
+      ),
       spenderAddress: checkErc20AllowanceResult.spenderAddress,
     });
   },
@@ -186,7 +215,14 @@ export const vincentAbility = createVincentAbility({
         // 1.1 Because the ability action is approve, we return success since the current allowance is sufficient,
         // and a new approval transaction is not needed.
         return succeed({
-          currentAllowance: checkErc20AllowanceResult.currentAllowance.toString(),
+          currentAllowance: ethers.utils.formatUnits(
+            checkErc20AllowanceResult.currentAllowance,
+            quote.tokenInDecimals,
+          ),
+          requiredAllowance: ethers.utils.formatUnits(
+            checkErc20AllowanceResult.requiredAllowance,
+            quote.tokenInDecimals,
+          ),
         });
       } else {
         if (checkErc20AllowanceResult.reason.includes('insufficient ERC20 allowance for spender')) {


### PR DESCRIPTION
# Description

User operations can take several seconds to be batched and included in a block, therefore we cannot reliably send an Approval and Swap transaction without risking a Lit Action timeout. This PR simply removes the option to `ApproveAndSwap`, meaning Delegatee must first call the Ability with the `Approve` action, and then call with the `Swap` Action

In the future we could explore batching user operation and performing a multicall to be able to approve and swap within the same tx

- This PR also formats the `tokenIn` allowances and balances using the tokenIn decimals that are returned to the user for success and fail responses

## Type of change

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# How Has This Been Tested?

Existing tests pass, and updated the test cases to validate the returned values are formatted

# Checklist:

- [x] I created a [release plan](https://nx.dev/recipes/nx-release/file-based-versioning-version-plans) (`nx release plan`) describing my changes and the version bump
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
